### PR TITLE
11 read from methods

### DIFF
--- a/euphonic/data/bands.py
+++ b/euphonic/data/bands.py
@@ -40,7 +40,7 @@ class BandsData(Data):
         Default units eV
     """
 
-    def __init__(self, seedname, model='CASTEP', path=''):
+    def __init__(self, data, **kwargs):
         """"
         Calls functions to read the correct file(s) and sets BandsData
         attributes
@@ -56,8 +56,15 @@ class BandsData(Data):
             Path to dir containing the file(s), if in another directory
         """
 
-        self.seedname = seedname
-        self.model = model
+        self._set_data(data)
+
+        if 'seedname' in kwargs.keys():
+            self.seedname = kwargs['seedname']
+
+        if 'model' in kwargs.keys():
+            self.model = kwargs['model']
+        else:
+            self.model = 'CASTEP'
 
         self._l_units = 'angstrom'
         self._e_units = 'eV'
@@ -83,15 +90,9 @@ class BandsData(Data):
         return self._fermi*ureg('hartree').to(self._e_units, 'spectroscopy')
 
     @classmethod
-    def from_castep(**kwargs):
-        if 'seedname' not in kwargs.keys():
-            raise TypeError("Argument 'seedname' required to load CASTEP data.")
-
-        seedname = kwargs['seedname']
-        path = kwargs['path']
-
+    def from_castep(seedname, path=''):
         data = _castep._read_bands_data(seedname, path)
-        return self(seedname, model='castep')._set_data(data)
+        return self(data, seedname=seedname, model='castep')
 
     def _set_data(self, data):
         self.n_qpts = data['n_qpts']

--- a/euphonic/data/bands.py
+++ b/euphonic/data/bands.py
@@ -55,7 +55,7 @@ class BandsData(Data):
         path : str, optional
             Path to dir containing the file(s), if in another directory
         """
-        self._get_data(seedname, model, path)
+
         self.seedname = seedname
         self.model = model
 
@@ -81,6 +81,37 @@ class BandsData(Data):
     @property
     def fermi(self):
         return self._fermi*ureg('hartree').to(self._e_units, 'spectroscopy')
+
+    @classmethod
+    def from_castep(**kwargs):
+        if 'seedname' not in kwargs.keys():
+            raise TypeError("Argument 'seedname' required to load CASTEP data.")
+
+        seedname = kwargs['seedname']
+        path = kwargs['path']
+
+        data = _castep._read_bands_data(seedname, path)
+        return self(seedname, model='castep')._set_data(data)
+
+    def _set_data(self, data):
+        self.n_qpts = data['n_qpts']
+        self.n_spins = data['n_spins']
+        self.n_branches = data['n_branches']
+        self._fermi = data['fermi']
+        self._cell_vec = data['cell_vec']
+        self._recip_vec = data['recip_vec']
+        self.qpts = data['qpts']
+        self.weights = data['weights']
+        self._freqs = data['freqs']
+        self._freq_down = data['freq_down']
+
+        try:
+            self.n_ions = data['n_ions']
+            self.ion_r = data['ion_r']
+            self.ion_type = data['ion_type']
+        except KeyError:
+            pass
+
 
     def _get_data(self, seedname, model, path):
         """"

--- a/euphonic/data/bands.py
+++ b/euphonic/data/bands.py
@@ -63,8 +63,6 @@ class BandsData(Data):
 
         if 'model' in kwargs.keys():
             self.model = kwargs['model']
-        else:
-            self.model = 'CASTEP'
 
         self._l_units = 'angstrom'
         self._e_units = 'eV'

--- a/euphonic/data/bands.py
+++ b/euphonic/data/bands.py
@@ -89,6 +89,16 @@ class BandsData(Data):
 
     @classmethod
     def from_castep(seedname, path=''):
+        """
+        Calls the CASTEP bands data reader and sets the BandsData attributes
+
+        Parameters
+        ----------
+        seedname : str
+            Seedname of file(s) to read
+        path : str
+            Path to dir containing the file(s), if in another directory
+        """
         data = _castep._read_bands_data(seedname, path)
         return self(data, seedname=seedname, model='castep')
 
@@ -111,46 +121,6 @@ class BandsData(Data):
         except KeyError:
             pass
 
-
-    def _get_data(self, seedname, model, path):
-        """"
-        Calls the correct reader to get the required data, and sets the
-        BandsData attributes
-
-        Parameters
-        ----------
-        seedname : str
-            Seedname of file(s) to read
-        model : {'CASTEP'}, optional, default 'CASTEP'
-            Which model has been used. e.g. if seedname = 'Fe' and
-            model='CASTEP', the 'Fe.bands' file will be read
-        path : str
-            Path to dir containing the file(s), if in another directory
-        """
-        if model.lower() == 'castep':
-            data = _castep._read_bands_data(seedname, path)
-        else:
-            raise ValueError(
-                "{:s} is not a valid model, please use one of {{'CASTEP'}}"
-                .format(model))
-
-        self.n_qpts = data['n_qpts']
-        self.n_spins = data['n_spins']
-        self.n_branches = data['n_branches']
-        self._fermi = data['fermi']
-        self._cell_vec = data['cell_vec']
-        self._recip_vec = data['recip_vec']
-        self.qpts = data['qpts']
-        self.weights = data['weights']
-        self._freqs = data['freqs']
-        self._freq_down = data['freq_down']
-
-        try:
-            self.n_ions = data['n_ions']
-            self.ion_r = data['ion_r']
-            self.ion_type = data['ion_type']
-        except KeyError:
-            pass
 
     def calculate_dos(self, dos_bins, gwidth, lorentz=False,
                       weights=None):

--- a/euphonic/data/bands.py
+++ b/euphonic/data/bands.py
@@ -41,19 +41,21 @@ class BandsData(Data):
     """
 
     def __init__(self, data, **kwargs):
-        """"
+        """
         Calls functions to read the correct file(s) and sets BandsData
         attributes
 
         Parameters
         ----------
+        data : dict
+            A dict containing the following keys: n_qpts, n_spins,
+            n_branches, fermi, cell_vec, recip_vec, qpts, weights,
+            freqs, freq_down, and optional: n_ions, ion_r, ion_type.
         seedname : str
             Seedname of file(s) to read
-        model : {'CASTEP'}, optional, default 'CASTEP'
+        model : {'CASTEP', 'PHONOPY'}, optional, default None
             Which model has been used. e.g. if seedname = 'Fe' and
             model='CASTEP', the 'Fe.bands' file will be read
-        path : str, optional
-            Path to dir containing the file(s), if in another directory
         """
 
         self._set_data(data)

--- a/euphonic/data/interpolation.py
+++ b/euphonic/data/interpolation.py
@@ -111,7 +111,6 @@ class InterpolationData(PhononData):
             If qpts has been specified, kwargs may be used to pass keyword
             arguments to calculate_fine_phonons
         """
-        self._get_data(seedname, model, path)
 
         self.seedname = seedname
         self.model = model
@@ -153,6 +152,38 @@ class InterpolationData(PhononData):
     @property
     def born(self):
         return self._born*ureg('e')
+
+
+    @classmethod
+    def from_castep(**kwargs):
+        if 'seedname' not in kwargs.keys():
+            raise TypeError("Argument 'seedname' required to load CASTEP data.")
+
+        seedname = kwargs['seedname']
+        path = kwargs['path']
+
+        data = _castep._read_interpolation_data(seedname, path)
+        return self(seedname, model='castep')._set_data(data)
+
+
+    def _set_data(self, data):
+        self.n_ions = data['n_ions']
+        self.n_branches = data['n_branches']
+        self._cell_vec = data['cell_vec']
+        self._recip_vec = data['recip_vec']
+        self.ion_r = data['ion_r']
+        self.ion_type = data['ion_type']
+        self._ion_mass = data['ion_mass']
+        self._force_constants = data['force_constants']
+        self.sc_matrix = data['sc_matrix']
+        self.n_cells_in_sc = data['n_cells_in_sc']
+        self.cell_origins = data['cell_origins']
+
+        try:
+            self._born = data['born']
+            self.dielectric = data['dielectric']
+        except KeyError:
+            pass
 
     def _get_data(self, seedname, model, path):
         """"

--- a/euphonic/data/interpolation.py
+++ b/euphonic/data/interpolation.py
@@ -89,8 +89,7 @@ class InterpolationData(PhononData):
 
     """
 
-    def __init__(self, seedname, model='CASTEP', path='', qpts=np.array([]),
-                 **kwargs):
+    def __init__(self, data, **kwargs):
         """
         Calls functions to read the correct file(s) and sets InterpolationData
         attributes, additionally can calculate frequencies/eigenvectors at
@@ -112,8 +111,16 @@ class InterpolationData(PhononData):
             arguments to calculate_fine_phonons
         """
 
-        self.seedname = seedname
-        self.model = model
+        self._set_data(data)
+
+        if 'seedname' in kwargs.keys():
+            self.seedname = kwargs['seedname']
+
+        if 'model' in kwargs.keys():
+            self.model = kwargs['model']
+        else:
+            self.model = 'CASTEP'
+
         self.n_qpts = 0
         self.qpts = np.array([])
         self._reduced_freqs = np.empty((0, 3*self.n_ions))
@@ -128,8 +135,8 @@ class InterpolationData(PhononData):
         self._l_units = 'angstrom'
         self._e_units = 'meV'
 
-        if len(qpts) > 0:
-            self.calculate_fine_phonons(qpts, **kwargs)
+        #if len(qpts) > 0:
+            #self.calculate_fine_phonons(qpts, **kwargs)
 
     @property
     def _freqs(self):
@@ -155,16 +162,9 @@ class InterpolationData(PhononData):
 
 
     @classmethod
-    def from_castep(**kwargs):
-        if 'seedname' not in kwargs.keys():
-            raise TypeError("Argument 'seedname' required to load CASTEP data.")
-
-        seedname = kwargs['seedname']
-        path = kwargs['path']
-
+    def from_castep(seedname, path=''):
         data = _castep._read_interpolation_data(seedname, path)
-        return self(seedname, model='castep')._set_data(data)
-
+        return self(data, seedname=seedname, model='castep')
 
     def _set_data(self, data):
         self.n_ions = data['n_ions']

--- a/euphonic/data/interpolation.py
+++ b/euphonic/data/interpolation.py
@@ -158,9 +158,18 @@ class InterpolationData(PhononData):
     def born(self):
         return self._born*ureg('e')
 
-
     @classmethod
     def from_castep(seedname, path=''):
+        """
+        Calls the CASTEP interpolation data reader and sets the InerpolationData attributes.
+
+        Parameters
+        ----------
+        seedname : str
+            Seedname of file(s) to read
+        path : str, optional
+            Path to dir containing the file(s), if in another directory
+        """
         data = _castep._read_interpolation_data(seedname, path)
         return self(data, seedname=seedname, model='castep')
 
@@ -183,45 +192,6 @@ class InterpolationData(PhononData):
         except KeyError:
             pass
 
-    def _get_data(self, seedname, model, path):
-        """"
-        Calls the correct reader to get the required data, and sets the
-        PhononData attributes
-
-        Parameters
-        ----------
-        seedname : str
-            Seedname of file(s) to read
-        model : {'CASTEP'}, optional, default 'CASTEP'
-            Which model has been used. e.g. if seedname = 'quartz' and
-            model='CASTEP', the 'quartz.castep_bin' file will be read
-        path : str, optional
-            Path to dir containing the file(s), if in another directory
-        """
-        if model.lower() == 'castep':
-            data = _castep._read_interpolation_data(seedname, path)
-        else:
-            raise ValueError(
-                "{:s} is not a valid model, please use one of {{'CASTEP'}}"
-                .format(model))
-
-        self.n_ions = data['n_ions']
-        self.n_branches = data['n_branches']
-        self._cell_vec = data['cell_vec']
-        self._recip_vec = data['recip_vec']
-        self.ion_r = data['ion_r']
-        self.ion_type = data['ion_type']
-        self._ion_mass = data['ion_mass']
-        self._force_constants = data['force_constants']
-        self.sc_matrix = data['sc_matrix']
-        self.n_cells_in_sc = data['n_cells_in_sc']
-        self.cell_origins = data['cell_origins']
-
-        try:
-            self._born = data['born']
-            self.dielectric = data['dielectric']
-        except KeyError:
-            pass
 
     def calculate_fine_phonons(
         self, qpts, asr=None, precondition=False, dipole=True,

--- a/euphonic/data/interpolation.py
+++ b/euphonic/data/interpolation.py
@@ -118,8 +118,6 @@ class InterpolationData(PhononData):
 
         if 'model' in kwargs.keys():
             self.model = kwargs['model']
-        else:
-            self.model = 'CASTEP'
 
         self.n_qpts = 0
         self.qpts = np.array([])

--- a/euphonic/data/interpolation.py
+++ b/euphonic/data/interpolation.py
@@ -97,18 +97,15 @@ class InterpolationData(PhononData):
 
         Parameters
         ----------
+        data : dict
+            A dict containing the following keys: n_ions, n_branches, cell_vec,
+            ion_r, ion_type, ion_mass, force_constants, sc_matrix, n_cells_in_sc,
+            cell_origins, and optional: born, dielectric.
         seedname : str
             Seedname of file(s) to read
-        model : {'CASTEP'}, optional, default 'CASTEP'
+        model : {'CASTEP', 'PHONOPY'}, optional, default None
             Which model has been used. e.g. if seedname = 'quartz' and
             model='CASTEP', the 'quartz.castep_bin' file will be read
-        path : str, optional
-            Path to dir containing the file(s), if in another directory
-        qpts : (n_qpts, 3) float ndarray, optional
-            Q-point coordinates to use for an initial interpolation calculation
-        **kwargs
-            If qpts has been specified, kwargs may be used to pass keyword
-            arguments to calculate_fine_phonons
         """
 
         self._set_data(data)
@@ -133,8 +130,6 @@ class InterpolationData(PhononData):
         self._l_units = 'angstrom'
         self._e_units = 'meV'
 
-        #if len(qpts) > 0:
-            #self.calculate_fine_phonons(qpts, **kwargs)
 
     @property
     def _freqs(self):

--- a/euphonic/data/phonon.py
+++ b/euphonic/data/phonon.py
@@ -54,7 +54,7 @@ class PhononData(Data):
         q-points specified in split_i. Empty if no LO-TO splitting
     """
 
-    def __init__(self, seedname, model='CASTEP', path=''):
+    def __init__(self, data, **kwargs):
         """
         Calls functions to read the correct file(s) and sets PhononData
         attributes
@@ -70,8 +70,15 @@ class PhononData(Data):
             Path to dir containing the file(s), if in another directory
         """
 
-        self.seedname = seedname
-        self.model = model
+        self._set_data(data)
+
+        if 'seedname' in kwargs.keys():
+            self.seedname = kwargs['seedname']
+
+        if 'model' in kwargs.keys():
+            self.model = kwargs['model']
+        else:
+            self.model = 'CASTEP'
 
         self._l_units = 'angstrom'
         self._e_units = 'meV'
@@ -102,15 +109,9 @@ class PhononData(Data):
         return self._sqw_ebins*ureg('E_h').to(self._e_units, 'spectroscopy')
 
     @classmethod
-    def from_castep(**kwargs):
-        if 'seedname' not in kwargs.keys():
-            raise TypeError("Argument 'seedname' required to load CASTEP data.")
-
-        seedname = kwargs['seedname']
-        path = kwargs['path']
-
+    def from_castep(seedname, path=''):
         data = _castep._read_phonon_data(seedname, path)
-        return self(seedname, model='castep')._set_data(data)
+        return self(data, seedname=seedname, model='castep')
 
     def _set_data(self, data):
         self.n_ions = data['n_ions']

--- a/euphonic/data/phonon.py
+++ b/euphonic/data/phonon.py
@@ -108,6 +108,16 @@ class PhononData(Data):
 
     @classmethod
     def from_castep(seedname, path=''):
+        """
+        Calls the CASTEP phonon data reader and sets the PhononData attributes.
+
+        Parameters
+        ----------
+        seedname : str
+            Seedname of file(s) to read
+        path : str
+            Path to dir containing the file(s), if in another directory
+        """
         data = _castep._read_phonon_data(seedname, path)
         return self(data, seedname=seedname, model='castep')
 
@@ -128,43 +138,6 @@ class PhononData(Data):
         self._split_freqs = data['split_freqs']
         self.split_eigenvecs = data['split_eigenvecs']
 
-    def _get_data(self, seedname, model, path):
-        """"
-        Calls the correct reader to get the required data, and sets the
-        PhononData attributes
-
-        Parameters
-        ----------
-        seedname : str
-            Seedname of file(s) to read
-        model : {'CASTEP'}, optional, default 'CASTEP'
-            Which model has been used. e.g. if seedname = 'quartz' and
-            model='CASTEP', the 'quartz.phonon' file will be read
-        path : str
-            Path to dir containing the file(s), if in another directory
-        """
-        if model.lower() == 'castep':
-            data = _castep._read_phonon_data(seedname, path)
-        else:
-            raise ValueError(
-                "{:s} is not a valid model, please use one of {{'CASTEP'}}"
-                .format(model))
-
-        self.n_ions = data['n_ions']
-        self.n_branches = data['n_branches']
-        self.n_qpts = data['n_qpts']
-        self._cell_vec = data['cell_vec']
-        self._recip_vec = data['recip_vec']
-        self.ion_r = data['ion_r']
-        self.ion_type = data['ion_type']
-        self._ion_mass = data['ion_mass']
-        self.qpts = data['qpts']
-        self.weights = data['weights']
-        self._freqs = data['freqs']
-        self.eigenvecs = data['eigenvecs']
-        self.split_i = data['split_i']
-        self._split_freqs = data['split_freqs']
-        self.split_eigenvecs = data['split_eigenvecs']
 
     def reorder_freqs(self, reorder_gamma=True):
         """

--- a/euphonic/data/phonon.py
+++ b/euphonic/data/phonon.py
@@ -77,8 +77,6 @@ class PhononData(Data):
 
         if 'model' in kwargs.keys():
             self.model = kwargs['model']
-        else:
-            self.model = 'CASTEP'
 
         self._l_units = 'angstrom'
         self._e_units = 'meV'

--- a/euphonic/data/phonon.py
+++ b/euphonic/data/phonon.py
@@ -69,12 +69,13 @@ class PhononData(Data):
         path : str, optional
             Path to dir containing the file(s), if in another directory
         """
-        self._get_data(seedname, model, path)
+
         self.seedname = seedname
         self.model = model
 
         self._l_units = 'angstrom'
         self._e_units = 'meV'
+
 
     @property
     def cell_vec(self):
@@ -99,6 +100,34 @@ class PhononData(Data):
     @property
     def sqw_ebins(self):
         return self._sqw_ebins*ureg('E_h').to(self._e_units, 'spectroscopy')
+
+    @classmethod
+    def from_castep(**kwargs):
+        if 'seedname' not in kwargs.keys():
+            raise TypeError("Argument 'seedname' required to load CASTEP data.")
+
+        seedname = kwargs['seedname']
+        path = kwargs['path']
+
+        data = _castep._read_phonon_data(seedname, path)
+        return self(seedname, model='castep')._set_data(data)
+
+    def _set_data(self, data):
+        self.n_ions = data['n_ions']
+        self.n_branches = data['n_branches']
+        self.n_qpts = data['n_qpts']
+        self._cell_vec = data['cell_vec']
+        self._recip_vec = data['recip_vec']
+        self.ion_r = data['ion_r']
+        self.ion_type = data['ion_type']
+        self._ion_mass = data['ion_mass']
+        self.qpts = data['qpts']
+        self.weights = data['weights']
+        self._freqs = data['freqs']
+        self.eigenvecs = data['eigenvecs']
+        self.split_i = data['split_i']
+        self._split_freqs = data['split_freqs']
+        self.split_eigenvecs = data['split_eigenvecs']
 
     def _get_data(self, seedname, model, path):
         """"

--- a/euphonic/data/phonon.py
+++ b/euphonic/data/phonon.py
@@ -61,13 +61,15 @@ class PhononData(Data):
 
         Parameters
         ----------
+        data : dict
+            A dict containing the following keys: n_ions, n_branches, n_qpts,
+            cell_vec, recip_vec, ion_r, ion_type, ion_mass, qpts, weights,
+            freqs, eigenvecs, split_i, split_freqs, split_eigenvecs.
         seedname : str
             Seedname of file(s) to read
-        model : {'CASTEP'}, optional, default 'CASTEP'
+        model : {'CASTEP', 'PHONOPY'}, optional, default None
             Which model has been used. e.g. if seedname = 'quartz' and
             model='CASTEP', the 'quartz.phonon' file will be read
-        path : str, optional
-            Path to dir containing the file(s), if in another directory
         """
 
         self._set_data(data)


### PR DESCRIPTION
The interfaces to BandsData, PhononData, InterpolationData, are updated to allow reading from CASTEP using class method `from_castep()` as a wrapper for standard class instantiation. This means cleaner instantiation and autocomplete options.  Mandatory `__init__` parameters, `model` and `seedname` are made optional, `path` is removed, and a new `data` input is made mandatory (contents depending on data class.) The wrapper takes on mandatory parameter `seedname` and optional `path`.