### PR TITLE
Removed fixed number of line skips

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,5 +1,8 @@
 `Unreleased <https://github.com/pace-neutrons/Euphonic/compare/v0.2.2...HEAD>`_
 ----------
+- Bug fixes:
+
+  - On reading CASTEP phonon file header information, switch from a fixed number of lines skipped to a search for a specific line, fixing issue `#23 <https://github.com/pace-neutrons/Euphonic/issues/23>`_
 
 `v0.2.2 <https://github.com/pace-neutrons/Euphonic/compare/v0.2.1...v0.2.2>`_
 ------

--- a/euphonic/_readers/_castep.py
+++ b/euphonic/_readers/_castep.py
@@ -157,7 +157,8 @@ def _read_phonon_header(f):
     n_ions = int(f.readline().split()[3])
     n_branches = int(f.readline().split()[3])
     n_qpts = int(f.readline().split()[3])
-    [f.readline() for x in range(4)]  # Skip units and label lines
+    while not 'Unit cell vectors' in f.readline():
+        pass # skip lines up to and including one which starts 'Unit cell vectors'
     cell_vec = np.array([[float(x) for x in f.readline().split()[0:3]]
                          for i in range(3)])
     f.readline()  # Skip fractional co-ordinates label


### PR DESCRIPTION
Replace fixed number of line skips with a search for the line beginning 'Unit cell vectors'
This resolves #23