### PR TITLE
Add append free channel to use python with conda

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -26,6 +26,7 @@ pipeline {
                     if (isUnix()) {
                         sh """
                             module load conda/3 &&
+                            conda config --append channels free &&
                             module load gcc &&
                             conda create --name py python=3.6.0 -y &&
                             conda activate py &&
@@ -44,6 +45,7 @@ pipeline {
                     if (isUnix()) {
                         sh """
                             module load conda/3 &&
+                            conda config --append channels free
                             conda activate py &&
                             python -m tox
                         """


### PR DESCRIPTION
We use the free package for conda to install python 3.6

Anvil removed this from being loaded as default, this fix loads that package so we can run python 3.6