### PR TITLE
Use upper dynamical matrix in Numpy diagonalisation. Fixes #47

### DIFF
--- a/euphonic/data/interpolation.py
+++ b/euphonic/data/interpolation.py
@@ -510,7 +510,7 @@ class InterpolationData(PhononData):
             dyn_mat_corr *= dyn_mat_weighting
 
             try:
-                evals, evecs = np.linalg.eigh(dyn_mat_corr)
+                evals, evecs = np.linalg.eigh(dyn_mat_corr, UPLO='U')
             # Fall back to zheev if eigh fails (eigh calls zheevd)
             except np.linalg.LinAlgError:
                 evals, evecs, info = zheev(dyn_mat_corr)
@@ -1075,7 +1075,7 @@ class InterpolationData(PhononData):
         n_branches = dyn_mat.shape[0]
         n_ions = int(n_branches/3)
 
-        evals, evecs = np.linalg.eigh(dyn_mat)
+        evals, evecs = np.linalg.eigh(dyn_mat, UPLO='U')
         evec_reshape = np.reshape(
             np.transpose(evecs), (n_branches, n_ions, 3))
         # Sum displacements for all ions in each branch

--- a/tests_and_analysis/test/test_dw_factor.py
+++ b/tests_and_analysis/test/test_dw_factor.py
@@ -47,14 +47,14 @@ class TestDWFactorQuartz(unittest.TestCase):
         expected_dw = np.reshape(
             np.loadtxt(os.path.join(self.dw_path, 'dw_T5.txt')),
             (self.data.n_ions, 3, 3))
-        npt.assert_allclose(dw, expected_dw, atol=2e-14)
+        npt.assert_allclose(dw, expected_dw, atol=2e-8)
 
     def test_dw_T100(self):
         dw = self.data._dw_coeff(100)
         expected_dw = np.reshape(
             np.loadtxt(os.path.join(self.dw_path, 'dw_T100.txt')),
             (self.data.n_ions, 3, 3))
-        npt.assert_allclose(dw, expected_dw, atol=5e-10)
+        npt.assert_allclose(dw, expected_dw, atol=6e-8)
 
     def test_empty_idata_raises_exception(self):
         empty_data = InterpolationData.from_castep(self.seedname, self.path)

--- a/tests_and_analysis/test/test_interpolation_data.py
+++ b/tests_and_analysis/test/test_interpolation_data.py
@@ -1013,7 +1013,7 @@ class TestInterpolatePhononsQuartz(unittest.TestCase):
         npt.assert_allclose(
             self.data.freqs.to('hartree').magnitude,
             self.expctd_freqs_no_asr.to('hartree').magnitude,
-            atol=1e-8)
+            atol=8e-8)
 
     def test_calculate_fine_phonons_dipole_recip_asr(self):
         self.data.calculate_fine_phonons(
@@ -1021,7 +1021,7 @@ class TestInterpolatePhononsQuartz(unittest.TestCase):
         npt.assert_allclose(
             self.data.freqs.to('hartree').magnitude,
             self.expctd_freqs_asr.to('hartree').magnitude,
-            atol=1e-8)
+            atol=2e-6)
 
     def test_calculate_fine_phonons_dipole_recip_asr_c(self):
         self.data.calculate_fine_phonons(
@@ -1030,7 +1030,7 @@ class TestInterpolatePhononsQuartz(unittest.TestCase):
         npt.assert_allclose(
             self.data.freqs.to('hartree').magnitude,
             self.expctd_freqs_asr.to('hartree').magnitude,
-            atol=1e-8)
+            atol=2e-6)
 
     def test_calculate_fine_phonons_dipole_recip_asr_c_2threads(self):
         self.data.calculate_fine_phonons(
@@ -1039,7 +1039,7 @@ class TestInterpolatePhononsQuartz(unittest.TestCase):
         npt.assert_allclose(
             self.data.freqs.to('hartree').magnitude,
             self.expctd_freqs_asr.to('hartree').magnitude,
-            atol=1e-8)
+            atol=2e-6)
 
     def test_calculate_fine_phonons_dipole_recip_asr_split(self):
         self.data.calculate_fine_phonons(
@@ -1048,11 +1048,11 @@ class TestInterpolatePhononsQuartz(unittest.TestCase):
         npt.assert_allclose(
             self.data.freqs.to('hartree').magnitude,
             self.expctd_freqs_asr_splitting.to('hartree').magnitude,
-            atol=1e-8)
+            atol=2e-6)
         npt.assert_allclose(
             self.data.split_freqs.to('hartree').magnitude,
             self.expctd_split_freqs.to('hartree').magnitude,
-            atol=1e-8)
+            atol=2e-6)
 
     def test_calculate_fine_phonons_dipole_recip_asr_split_c(self):
         self.data.calculate_fine_phonons(
@@ -1062,11 +1062,11 @@ class TestInterpolatePhononsQuartz(unittest.TestCase):
         npt.assert_allclose(
             self.data.freqs.to('hartree').magnitude,
             self.expctd_freqs_asr_splitting.to('hartree').magnitude,
-            atol=1e-8)
+            atol=2e-6)
         npt.assert_allclose(
             self.data.split_freqs.to('hartree').magnitude,
             self.expctd_split_freqs.to('hartree').magnitude,
-            atol=1e-8)
+            atol=2e-6)
 
     def test_calculate_fine_phonons_dipole_recip_asr_split_c_2threads(self):
         self.data.calculate_fine_phonons(
@@ -1076,8 +1076,8 @@ class TestInterpolatePhononsQuartz(unittest.TestCase):
         npt.assert_allclose(
             self.data.freqs.to('hartree').magnitude,
             self.expctd_freqs_asr_splitting.to('hartree').magnitude,
-            atol=1e-8)
+            atol=2e-6)
         npt.assert_allclose(
             self.data.split_freqs.to('hartree').magnitude,
             self.expctd_split_freqs.to('hartree').magnitude,
-            atol=1e-8)
+            atol=2e-6)

--- a/tests_and_analysis/test/test_structure_factor.py
+++ b/tests_and_analysis/test/test_structure_factor.py
@@ -89,7 +89,7 @@ class TestStructureFactorInterpolationDataLZOSerial(unittest.TestCase):
         sf_sum = np.zeros(sf.shape)
         expected_sf_sum = np.zeros(sf.shape)
         for q in range(self.data.n_qpts):
-            TOL = 1e-8
+            TOL = 1e-4
             diff = np.append(TOL + 1, np.diff(self.data.freqs[q].magnitude))
             unique_index = np.where(diff > TOL)[0]
             x = np.zeros(self.data.n_branches, dtype=np.int32)
@@ -114,7 +114,7 @@ class TestStructureFactorInterpolationDataLZOSerial(unittest.TestCase):
         sf_sum = np.zeros(sf.shape)
         expected_sf_sum = np.zeros(sf.shape)
         for q in range(self.data.n_qpts):
-            TOL = 1e-8
+            TOL = 1e-4
             diff = np.append(TOL + 1, np.diff(self.data.freqs[q].magnitude))
             unique_index = np.where(diff > TOL)[0]
             x = np.zeros(self.data.n_branches, dtype=np.int32)
@@ -137,7 +137,7 @@ class TestStructureFactorInterpolationDataLZOSerial(unittest.TestCase):
         sf_sum = np.zeros(sf.shape)
         expected_sf_sum = np.zeros(sf.shape)
         for q in range(self.data.n_qpts):
-            TOL = 1e-8
+            TOL = 1e-4
             diff = np.append(TOL + 1, np.diff(self.data.freqs[q].magnitude))
             unique_index = np.where(diff > TOL)[0]
             x = np.zeros(self.data.n_branches, dtype=np.int32)
@@ -160,7 +160,7 @@ class TestStructureFactorInterpolationDataLZOSerial(unittest.TestCase):
         sf_sum = np.zeros(sf.shape)
         expected_sf_sum = np.zeros(sf.shape)
         for q in range(self.data.n_qpts):
-            TOL = 1e-8
+            TOL = 1e-4
             diff = np.append(TOL + 1, np.diff(self.data.freqs[q].magnitude))
             unique_index = np.where(diff > TOL)[0]
             x = np.zeros(self.data.n_branches, dtype=np.int32)
@@ -183,7 +183,7 @@ class TestStructureFactorInterpolationDataLZOSerial(unittest.TestCase):
         sf_sum = np.zeros(sf.shape)
         expected_sf_sum = np.zeros(sf.shape)
         for q in range(self.data.n_qpts):
-            TOL = 1e-8
+            TOL = 1e-4
             diff = np.append(TOL + 1, np.diff(self.data.freqs[q].magnitude))
             unique_index = np.where(diff > TOL)[0]
             x = np.zeros(self.data.n_branches, dtype=np.int32)
@@ -206,7 +206,7 @@ class TestStructureFactorInterpolationDataLZOSerial(unittest.TestCase):
         sf_sum = np.zeros(sf.shape)
         expected_sf_sum = np.zeros(sf.shape)
         for q in range(self.data.n_qpts):
-            TOL = 1e-8
+            TOL = 1e-4
             diff = np.append(TOL + 1, np.diff(self.data.freqs[q].magnitude))
             unique_index = np.where(diff > TOL)[0]
             x = np.zeros(self.data.n_branches, dtype=np.int32)
@@ -324,7 +324,7 @@ class TestStructureFactorInterpolationDataQuartzSerial(unittest.TestCase):
         sf_sum = np.zeros(sf.shape)
         expected_sf_sum = np.zeros(sf.shape)
         for q in range(self.data.n_qpts):
-            TOL = 1e-8
+            TOL = 5e-4
             diff = np.append(TOL + 1, np.diff(self.data.freqs[q].magnitude))
             unique_index = np.where(diff > TOL)[0]
             x = np.zeros(self.data.n_branches, dtype=np.int32)
@@ -338,10 +338,10 @@ class TestStructureFactorInterpolationDataQuartzSerial(unittest.TestCase):
         gamma_qpts = [16]  # Index of gamma pts in qpts array
         npt.assert_allclose(np.delete(sf_sum, gamma_qpts, axis=0),
                             np.delete(expected_sf_sum, gamma_qpts, axis=0),
-                            rtol=7e-4, atol=3e-16)
+                            rtol=7e-4, atol=2e-13)
         npt.assert_allclose(sf_sum[gamma_qpts, 3:],
                             expected_sf_sum[gamma_qpts, 3:],
-                            rtol=8e-6, atol=3e-14)
+                            rtol=4e-3, atol=1.1e-11)
 
     def test_sf_T0_dw_grid(self):
         sf = self.data.calculate_structure_factor(
@@ -351,7 +351,7 @@ class TestStructureFactorInterpolationDataQuartzSerial(unittest.TestCase):
         sf_sum = np.zeros(sf.shape)
         expected_sf_sum = np.zeros(sf.shape)
         for q in range(self.data.n_qpts):
-            TOL = 1e-8
+            TOL = 5e-4
             diff = np.append(TOL + 1, np.diff(self.data.freqs[q].magnitude))
             unique_index = np.where(diff > TOL)[0]
             x = np.zeros(self.data.n_branches, dtype=np.int32)
@@ -363,10 +363,10 @@ class TestStructureFactorInterpolationDataQuartzSerial(unittest.TestCase):
         gamma_qpts = [16]
         npt.assert_allclose(np.delete(sf_sum, gamma_qpts, axis=0),
                             np.delete(expected_sf_sum, gamma_qpts, axis=0),
-                            rtol=2e-3, atol=3e-16)
+                            rtol=2e-3, atol=2e-13)
         npt.assert_allclose(sf_sum[gamma_qpts, 3:],
                             expected_sf_sum[gamma_qpts, 3:],
-                            rtol=8e-6, atol=3e-14)
+                            rtol=4e-3, atol=1.1e-11)
 
     def test_sf_T100(self):
         sf = self.data.calculate_structure_factor(
@@ -376,7 +376,7 @@ class TestStructureFactorInterpolationDataQuartzSerial(unittest.TestCase):
         sf_sum = np.zeros(sf.shape)
         expected_sf_sum = np.zeros(sf.shape)
         for q in range(self.data.n_qpts):
-            TOL = 1e-8
+            TOL = 5e-4
             diff = np.append(TOL + 1, np.diff(self.data.freqs[q].magnitude))
             unique_index = np.where(diff > TOL)[0]
             x = np.zeros(self.data.n_branches, dtype=np.int32)
@@ -388,10 +388,10 @@ class TestStructureFactorInterpolationDataQuartzSerial(unittest.TestCase):
         gamma_qpts = [16]
         npt.assert_allclose(np.delete(sf_sum, gamma_qpts, axis=0),
                             np.delete(expected_sf_sum, gamma_qpts, axis=0),
-                            rtol=7e-4, atol=3e-16)
+                            rtol=7e-4, atol=2e-13)
         npt.assert_allclose(sf_sum[gamma_qpts, 3:],
                             expected_sf_sum[gamma_qpts, 3:],
-                            rtol=8e-6, atol=3e-14)
+                            rtol=4e-3, atol=1.1e-11)
 
     def test_sf_T100_dw_grid(self):
         sf = self.data.calculate_structure_factor(
@@ -402,7 +402,7 @@ class TestStructureFactorInterpolationDataQuartzSerial(unittest.TestCase):
         sf_sum = np.zeros(sf.shape)
         expected_sf_sum = np.zeros(sf.shape)
         for q in range(self.data.n_qpts):
-            TOL = 1e-8
+            TOL = 5e-4
             diff = np.append(TOL + 1, np.diff(self.data.freqs[q].magnitude))
             unique_index = np.where(diff > TOL)[0]
             x = np.zeros(self.data.n_branches, dtype=np.int32)
@@ -414,10 +414,10 @@ class TestStructureFactorInterpolationDataQuartzSerial(unittest.TestCase):
         gamma_qpts = [16]
         npt.assert_allclose(np.delete(sf_sum, gamma_qpts, axis=0),
                             np.delete(expected_sf_sum, gamma_qpts, axis=0),
-                            rtol=7e-4, atol=3e-16)
+                            rtol=7e-4, atol=2e-13)
         npt.assert_allclose(sf_sum[gamma_qpts, 3:],
                             expected_sf_sum[gamma_qpts, 3:],
-                            rtol=8e-6, atol=3e-14)
+                            rtol=4e-3, atol=1.1e-11)
 
 
 class TestStructureFactorInterpolationDataQuartzSerialC(TestStructureFactorInterpolationDataQuartzSerial):


### PR DESCRIPTION
- This has a small effect on the structure factor (eigenvectors are very
  sensitive to changes in the dynamical matrix) so also update test tolerances