### PR TITLE
Spectrum2D: rework plotting, provide a new user script

### DIFF
--- a/euphonic/plot.py
+++ b/euphonic/plot.py
@@ -1,4 +1,4 @@
-from typing import Optional, Union
+from typing import List, Optional, Tuple, Union
 import warnings
 
 try:
@@ -9,7 +9,6 @@ try:
     from matplotlib.colors import Normalize
     from matplotlib.image import NonUniformImage
 
-
 except ImportError:
     warnings.warn((
         'Cannot import Matplotliib for plotting (maybe Matplotlib is '
@@ -17,6 +16,7 @@ except ImportError:
         'dependency, try:\n\npip install euphonic[matplotlib]\n'))
     raise
 
+from pint import Quantity
 import numpy as np
 
 from euphonic import ureg
@@ -187,41 +187,35 @@ def _plot_2d_core(spectrum: Spectrum2D, ax: Axes,
     return image
 
 
-def plot_2d(spectrum, vmin=None, vmax=None, ratio=None,
-            cmap='viridis', title='', x_label='', y_label='') -> Figure:
+def plot_2d(spectrum: Spectrum2D,
+            vmin: Optional[float] = None,
+            vmax: Optional[float] = None,
+            cmap: Union[str, mpl.colors.Colormap] = 'viridis',
+            title: str = '', x_label: str = '', y_label: str = '') -> Figure:
     """
     Creates a Matplotlib figure for a Spectrum2D object
 
     Parameters
     ----------
-    spectrum : Spectrum2D
+    spectrum
         Containing the 2D data to plot
-    vmin : float, optional
+    vmin
         Minimum of data range for colormap. See Matplotlib imshow docs
-        Default: None
-    vmax : float, optional
+    vmax
         Maximum of data range for colormap. See Matplotlib imshow docs
-        Default: None
-    ratio : float, optional
-        Ratio of the size of the y and x axes. e.g. if ratio is 2, the
-        y-axis will be twice as long as the x-axis
-        Default: None
-    cmap : string, optional
+    cmap
         Which colormap to use, see Matplotlib docs
-    title : string, optional
-        The figure title. Default: ''
-    x_label : string, optional
+    title
+        Set a title for the Figure.
+    x_label
         X-axis label
-    y_label : string, optional
+    y_label
         Y-axis label
 
     Returns
     -------
     fig : matplotlib.figure.Figure
-        The figure
-    ims : (n_qpts,) 'matplotlib.image.AxesImage' ndarray
-        A Numpy.ndarray of AxesImage objects, one for each x-bin, for
-        easier access to some attributes/functions
+        The Figure instance
     """
 
     fig, ax = plt.subplots(1, 1)
@@ -237,10 +231,13 @@ def plot_2d(spectrum, vmin=None, vmax=None, ratio=None,
     return fig
 
 
-def _set_x_tick_labels(ax, x_tick_labels, x_data):
+def _set_x_tick_labels(ax: Axes,
+                       x_tick_labels: List[Tuple[int, str]],
+                       x_data: Quantity) -> None:
     if x_tick_labels is not None:
         locs, labels = [list(x) for x in zip(*x_tick_labels)]
-        ax.set_xticks(x_data.magnitude[locs])
+        x_values = x_data.magnitude  # type: np.ndarray
+        ax.set_xticks(x_values[locs])
         ax.xaxis.grid(True, which='major')
         # Rotate long tick labels
         if len(max(labels, key=len)) >= 11:

--- a/euphonic/plot.py
+++ b/euphonic/plot.py
@@ -163,12 +163,12 @@ def _plot_2d_core(spectrum: Spectrum2D, ax: Axes,
         plots are on the same colour scale.
 
     """
-    x_bins = spectrum._get_bin_edges('x').magnitude
-    y_bins = spectrum._get_bin_edges('y').magnitude
-    z_data = spectrum.z_data.magnitude.T
+    x_unit = spectrum.x_data_unit
+    y_unit = spectrum.y_data_unit
+    z_unit = spectrum.z_data_unit
 
-    x_pts = (x_bins[:-1] + x_bins[1:]) / 2
-    y_pts = (y_bins[:-1] + y_bins[1:]) / 2
+    x_bins = spectrum._get_bin_edges('x').to(x_unit).magnitude
+    y_bins = spectrum._get_bin_edges('y').to(y_unit).magnitude
 
     image = NonUniformImage(ax, interpolation=interpolation,
                             extent=(min(x_bins), max(x_bins),
@@ -177,7 +177,9 @@ def _plot_2d_core(spectrum: Spectrum2D, ax: Axes,
     if norm is not None:
         image.set_norm(norm)
 
-    image.set_data(x_pts, y_pts, z_data)
+    image.set_data(spectrum._get_bin_centres('x').to(x_unit).magnitude,
+                   spectrum._get_bin_centres('y').to(y_unit).magnitude,
+                   spectrum.z_data.to(z_unit).magnitude.T)
     ax.images.append(image)
     ax.set_xlim(min(x_bins), max(x_bins))
     ax.set_ylim(min(y_bins), max(y_bins))

--- a/scripts/neutron-band-structure.py
+++ b/scripts/neutron-band-structure.py
@@ -1,0 +1,83 @@
+#! /usr/bin/env python3
+import argparse
+import os
+
+import ase
+import euphonic
+from euphonic import ureg
+import euphonic.plot
+import matplotlib.pyplot as plt
+import numpy as np
+
+
+def get_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser()
+    parser.add_argument('file', type=str)
+    parser.add_argument('--qpoints', type=int, default=200)
+    parser.add_argument('--ebins', type=int, default=200)
+    parser.add_argument('--ase-labels', action='store_true', dest='ase_labels',
+                        help="Get high-symmetry labels from ASE bandpath. "
+                             "Otherwise these are detected by Euphonic.")
+    return parser
+
+
+def get_special_point_indices(bandpath):
+    all_x, special_x, labels = bandpath.get_linear_kpoint_axis()
+
+    initial_list = all_x.searchsorted(special_x).tolist()
+    results = []
+    left_label = None
+    for (x_index, label) in zip(initial_list, labels):
+        if initial_list.count(x_index) == 1:
+            results.append((x_index, label))
+        elif initial_list.count(x_index) == 2:
+            # Index is repeated at jumps between BS segments
+            if left_label is None:
+                left_label = label
+            else:
+                right_label = label
+                results.append((x_index, f"{left_label}|{right_label}"))
+                left_label = None
+        else:
+            raise Exception()
+
+    return results
+
+def main():
+    args = get_parser().parse_args()
+    filename = args.file
+    summary_name = os.path.basename(filename)
+    path = os.path.dirname(filename)
+
+    print(f"Reading force constants from {filename}")
+    force_constants = euphonic.ForceConstants.from_phonopy(
+        path=path, summary_name=summary_name)
+
+    print(f"Getting band path with {args.qpoints} q-points")
+    atoms = ase.Atoms(force_constants.crystal.atom_type,
+                      cell=force_constants.crystal.cell_vectors.to('angstrom').magnitude,
+                      scaled_positions=force_constants.crystal.atom_r)
+    bandpath = atoms.cell.bandpath(npoints=args.qpoints)
+
+    print(f"Computing phonon modes")
+    modes = force_constants.calculate_qpoint_phonon_modes(bandpath.kpts, reduce_qpts=False)
+    emin = np.min(modes.frequencies.magnitude) * modes.frequencies.units
+    emax = np.max(modes.frequencies.magnitude) * modes.frequencies.units
+    ebins = np.linspace(emin.to('meV').magnitude, emax.to('meV').magnitude,
+                        args.ebins) * ureg['meV']
+
+    print(f"Computing structure factor")
+    structure_factor = modes.calculate_structure_factor()
+
+    print(f"Compiling structure factor to 2D map")
+    sqw = structure_factor.calculate_sqw_map(ebins)
+    if args.ase_labels:
+        sqw.x_tick_labels = get_special_point_indices(bandpath)
+
+    print(f"Plotting figure")    
+    euphonic.plot.plot_2d(sqw)
+
+    plt.show()
+
+if __name__ == '__main__':
+    main()

--- a/scripts/neutron-band-structure.py
+++ b/scripts/neutron-band-structure.py
@@ -46,13 +46,12 @@ def get_seekpath_structure(crystal: euphonic.Crystal) -> Tuple[np.ndarray,
                                                                List[int]]:
     # Seekpath needs a set of integer identities, while Crystal stores strings
     # so we need to convert e.g. ['H', 'C', 'Cl', 'C'] -> [0, 1, 2, 1]
-    all_atom_types = list(set(crystal.atom_type.tolist()))
-    atom_id_list = [all_atom_types.index(symbol)
-                    for symbol in crystal.atom_type]
+    _, unique_inverse = np.unique(crystal.atom_type,
+                                  return_inverse=True)
 
     return (crystal.cell_vectors.to('angstrom').magnitude,
             crystal.atom_r,
-            atom_id_list)
+            unique_inverse.tolist())
 
 
 def _get_break_points(bandpath: dict) -> Tuple[List[Tuple[int, int]],

--- a/scripts/neutron-band-structure.py
+++ b/scripts/neutron-band-structure.py
@@ -173,10 +173,8 @@ def main():
         spectra.append(sqw)
 
     print(f"Plotting figure")
-    energy_units = str(spectra[0].y_data.units)
-
     if args.y_label is None:
-        y_label = f"Energy / {energy_units}"
+        y_label = f"Energy / {spectra[0].y_data.units:~P}"
     else:
         y_label = args.y_label
 

--- a/scripts/neutron-band-structure.py
+++ b/scripts/neutron-band-structure.py
@@ -183,7 +183,9 @@ def main():
         start_point = break_point + 1
     regions.append((start_point, len(bandpath["explicit_kpoints_rel"])))
 
-    print("Computing phonon modes")
+    print("Computing phonon modes: {n_modes} modes across {n_qpts} q-points"
+          .format(n_modes=(force_constants.crystal.n_atoms * 3),
+                  n_qpts=len(bandpath["explicit_kpoints_rel"])))
     region_modes = []
     for (start, end) in regions:
         qpts = bandpath["explicit_kpoints_rel"][start:end]

--- a/scripts/neutron-band-structure.py
+++ b/scripts/neutron-band-structure.py
@@ -23,6 +23,13 @@ def get_parser() -> argparse.ArgumentParser:
     parser.add_argument('--q-distance', type=float, default=0.025,
                         dest='q_distance',
                         help='Target distance between q-point samples')
+    parser.add_argument('--x-label', type=str, default=None,
+                        dest='x_label')
+    parser.add_argument('--y-label', type=str, default=None,
+                        dest='y_label')
+    parser.add_argument('--title', type=str, default=None)
+    parser.add_argument('--cmap', type=str, default='viridis',
+                        help='Matplotlib colormap')
     return parser
 
 
@@ -140,6 +147,7 @@ def main():
                         args.ebins) * ureg['meV']
 
     print("Computing structure factors and generating 2D maps")
+    spectra = []
     for region, modes in zip(regions, region_modes):
 
         structure_factor = modes.calculate_structure_factor()
@@ -148,11 +156,23 @@ def main():
         if args.seekpath_labels:
             sqw.x_tick_labels = _get_tick_labels(region, bandpath,
                                                  special_point_indices)
+        spectra.append(sqw)
 
-        print(f"Plotting figure")
-        euphonic.plot.plot_2d(sqw)
+    print(f"Plotting figure")
+    energy_units = str(spectra[0].y_data.units)
 
-        plt.show()
+    if args.y_label is None:
+        y_label = f"Energy / {energy_units}"
+    else:
+        y_label = args.y_label
+
+    euphonic.plot.plot_2d(spectra,
+                          cmap=args.cmap,
+                          x_label=args.x_label,
+                          y_label=y_label,
+                          title=args.title)
+
+    plt.show()
 
 
 if __name__ == '__main__':

--- a/scripts/neutron-band-structure.py
+++ b/scripts/neutron-band-structure.py
@@ -1,6 +1,7 @@
 #! /usr/bin/env python3
 import argparse
 import os
+from typing import List, Tuple
 
 import euphonic
 from euphonic import ureg
@@ -25,6 +26,77 @@ def get_parser() -> argparse.ArgumentParser:
     return parser
 
 
+def get_seekpath_structure(crystal: euphonic.Crystal) -> Tuple[np.ndarray,
+                                                               np.ndarray,
+                                                               List[int]]:
+    # Seekpath needs a set of integer identities, while Crystal stores strings
+    # so we need to convert e.g. ['H', 'C', 'Cl', 'C'] -> [0, 1, 2, 1]
+    all_atom_types = list(set(crystal.atom_type.tolist()))
+    atom_id_list = [all_atom_types.index(symbol)
+                    for symbol in crystal.atom_type]
+
+    return (crystal.cell_vectors.to('angstrom').magnitude,
+            crystal.atom_r,
+            atom_id_list)
+
+
+def _get_break_points(bandpath: dict) -> Tuple[List[Tuple[int, int]],
+                                               List[int]]:
+    """Get information about band path labels and break points
+
+    Parameters
+    ----------
+    bandpath
+        Bandpath dictionary from Seekpath
+
+    Returns
+    -------
+    (break_points, special_point_indices)
+
+    ``break_points`` is a list of tuples identifying the boundaries of regions
+    with discontinuities between them, e.g.::
+
+      [(0, end1), (start2, end2), (start3, end3)]
+
+    for a band path with three segments. end3 should equal the index of the
+    last k-point in the full path.
+
+    ``special_point_indices`` is a list of locations for labelled points in the
+    full set of labels from Seekpath.
+
+    """
+    # Find break points between continuous spectra: wherever there are two
+    # adjacent labels
+    special_point_bools = np.fromiter(
+        map(bool, bandpath["explicit_kpoints_labels"]), dtype=bool)
+    special_point_indices = special_point_bools.nonzero()[0]
+
+    # [T F F T T F T] -> [F F T T F T] AND [T F F T T F] = [F F F T F F] -> 3,
+    break_points = (np.logical_and(special_point_bools[:-1],
+                                   special_point_bools[1:])
+                    .nonzero()[0].tolist())
+
+    return break_points, special_point_indices
+
+
+def _get_tick_labels(region: Tuple[int, int],
+                     bandpath: dict,
+                     special_point_indices) -> List[Tuple[int, str]]:
+    start, end = region
+    label_indices = special_point_indices[
+        np.logical_and(special_point_indices >= start,
+                       special_point_indices < end)]
+
+    labels = [bandpath["explicit_kpoints_labels"][i]
+              for i in label_indices]
+    for i, label in enumerate(labels):
+        if label == 'GAMMA':
+            labels[i] = r'$\Gamma$'
+
+    label_indices_shifted = [i - start for i in label_indices]
+    return list(zip(label_indices_shifted, labels))
+
+
 def main():
     args = get_parser().parse_args()
     filename = args.file
@@ -36,30 +108,11 @@ def main():
         path=path, summary_name=summary_name)
 
     print(f"Getting band path")
-    # Seekpath needs a set of integer identities, while Crystal stores strings
-    # so we need to convert e.g. ['H', 'C', 'Cl', 'C'] -> [0, 1, 2, 1]
-    all_atom_types = list(set(force_constants.crystal.atom_type.tolist()))
-    atom_id_list = [all_atom_types.index(symbol)
-                    for symbol in force_constants.crystal.atom_type]
-
-    structure = (force_constants.crystal.cell_vectors.to('angstrom').magnitude,
-                 force_constants.crystal.atom_r,
-                 atom_id_list)
-
+    structure = get_seekpath_structure(force_constants.crystal)
     bandpath = seekpath.get_explicit_k_path(structure,
                                             reference_distance=args.q_distance)
 
-    # Find break points between continuous spectra: wherever there are two
-    # adjacent labels
-    special_point_bools = np.fromiter(
-        map(bool, bandpath["explicit_kpoints_labels"]), dtype=bool)
-    # End points are always special even if unlabeled
-    special_point_bools[0] = special_point_bools[-1] = True
-
-    # [T F F T T F T] -> [F F T T F T] AND [T F F T T F] = [F F F T F F] -> 3,
-    break_points = (np.logical_and(special_point_bools[:-1],
-                                   special_point_bools[1:])
-                    .nonzero()[0].tolist())
+    break_points, special_point_indices = _get_break_points(bandpath)
     if break_points:
         print(f"Found {len(break_points)} regions in q-point path")
 
@@ -68,7 +121,7 @@ def main():
     for break_point in break_points:
         regions.append((start_point, break_point + 1))
         start_point = break_point + 1
-    regions.append((start_point, len(special_point_bools)))
+    regions.append((start_point, len(bandpath["explicit_kpoints_rel"])))
 
     print("Computing phonon modes")
     region_modes = []
@@ -86,30 +139,15 @@ def main():
     ebins = np.linspace(emin.to('meV').magnitude, emax.to('meV').magnitude,
                         args.ebins) * ureg['meV']
 
-    print(f"Computing structure factor")
-    structure_factors = []
-    for modes in region_modes:
-        structure_factors.append(modes.calculate_structure_factor())
+    print("Computing structure factors and generating 2D maps")
+    for region, modes in zip(regions, region_modes):
 
-    print(f"Compiling structure factor to 2D map")
-    special_point_indices = special_point_bools.nonzero()[0]
-
-    for (region_start, region_end), structure_factor in zip(regions,
-                                                            structure_factors):
+        structure_factor = modes.calculate_structure_factor()
         sqw = structure_factor.calculate_sqw_map(ebins)
+
         if args.seekpath_labels:
-            label_indices = special_point_indices[
-                np.logical_and(special_point_indices >= region_start,
-                               special_point_indices < region_end)]
-
-            labels = [bandpath["explicit_kpoints_labels"][i]
-                      for i in label_indices]
-            for i, label in enumerate(labels):
-                if label == 'GAMMA':
-                    labels[i] = r'$\Gamma$'
-
-            label_indices_shifted = [i - region_start for i in label_indices]
-            sqw.x_tick_labels = list(zip(label_indices_shifted, labels))
+            sqw.x_tick_labels = _get_tick_labels(region, bandpath,
+                                                 special_point_indices)
 
         print(f"Plotting figure")
         euphonic.plot.plot_2d(sqw)

--- a/scripts/neutron-band-structure.py
+++ b/scripts/neutron-band-structure.py
@@ -30,6 +30,14 @@ def get_parser() -> argparse.ArgumentParser:
     parser.add_argument('--title', type=str, default=None)
     parser.add_argument('--cmap', type=str, default='viridis',
                         help='Matplotlib colormap')
+    parser.add_argument('--q-broadening', type=float, default=None,
+                        dest='gaussian_x',
+                        help='Width of Gaussian broadening on q axis in recip '
+                             'angstrom. (No broadening if unspecified.)')
+    parser.add_argument('--energy-broadening', type=float, default=None,
+                        dest='gaussian_y',
+                        help='Width of Gaussian broadening on energy axis in '
+                        'meV. (No broadening if unspecified.)')
     return parser
 
 
@@ -156,6 +164,12 @@ def main():
         if args.seekpath_labels:
             sqw.x_tick_labels = _get_tick_labels(region, bandpath,
                                                  special_point_indices)
+        if args.gaussian_x or args.gaussian_y:
+            sqw = sqw.broaden(x_width=(args.gaussian_x * ureg['1 / angstrom']
+                                       if args.gaussian_x else None),
+                              y_width=(args.gaussian_y * ureg['meV']
+                                       if args.gaussian_y else None))
+
         spectra.append(sqw)
 
     print(f"Plotting figure")

--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,8 @@ def run_setup(build_c=True):
 
     scripts = ['scripts/dispersion.py',
                'scripts/dos.py',
-               'scripts/optimise_eta.py']
+               'scripts/optimise_eta.py',
+               'scripts/neutron-band-structure.py']
 
     cmdclass = versioneer.get_cmdclass()
     cmdclass['install'] = InstallCommand


### PR DESCRIPTION
Addressing Issue #84

- Refactor plot_2d to use NonUniformImage. This cleans up a lot of the plotting logic, taking care of the irregular spacing for us.
- Break actual axis plotting into separate function that can be re-used for custom/complex layouts, while plot_2d remains a "fire and forget" tool returning a Figure
- Allow Normalize object to be passed, in preparation for implementation of multi-part plot with common colour scale
- Dump script used for testing/prototyping into scripts directory; with a bit more work this should become a good tool for users.

Setting the plot aspect ratio is no longer a technical requirement as NonUniformImage manages this well. For now I will remove the feature; user-facing scripts would be able to set dimensions by manipulating the figure directly.

## To do
- [x] Agree decent names for everything
- [x] Accept a sequence of Spectrum2D in `plot_2d()`, to subplot into a nice band structure
- [x] Improve script to use band structure path and deliver data to `plot_2d()` in segments
- [x] Improve script to work with multiple input file types
- [x] Use Seekpath instead of ASE

## Future wishlist
- Allow `plot_2d` to use heuristics and break up a Spectrum2D automatically. (This should be optional, or at least bypassable.)
- Revisit name/structure/conventions of 1D plotting tools, get things consistent