### PR TITLE
Add metadata to .json outputs and associated tests

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,8 +3,6 @@
 
 - Changes:
 
-  - ``yaml.CSafeLoader`` is now used instead of ``yaml.SafeLoader`` by
-    default, so Phonopy ``.yaml`` files should load faster
   - Some of Euphonic's dependency version requirements have been changed - but
     can now be relied on with more certainty due to better CI testing. This
     includes:
@@ -14,6 +12,13 @@
     - pint requirement decreased from ``0.10.1`` to ``0.9``
     - h5py requirement decreased from ``2.9.0`` to ``2.7.0``
     - pyyaml requirement decreased from ``5.1.2`` to ``3.13``
+
+- Improvements:
+
+  - ``yaml.CSafeLoader`` is now used instead of ``yaml.SafeLoader`` by
+    default, so Phonopy ``.yaml`` files should load faster
+  - Metadata ``__euphonic_version__`` and ``__euphonic_class__`` have been
+    added to .json file output for better provenance
 
 - Bug fixes:
 

--- a/euphonic/io.py
+++ b/euphonic/io.py
@@ -4,7 +4,7 @@ import os
 
 import numpy as np
 
-from euphonic import ureg, Quantity
+from euphonic import ureg, Quantity, __version__
 
 
 def _to_json_dict(dictionary):
@@ -91,6 +91,8 @@ def _obj_to_json_file(obj, filename):
     Generic function for writing to a JSON file from a Euphonic object
     """
     dout = _to_json_dict(obj.to_dict())
+    dout['__euphonic_class__'] = obj.__class__.__name__
+    dout['__euphonic_version__'] = __version__
     with open(filename, 'w') as f:
         json.dump(dout, f, indent=4, sort_keys=True)
     print(f'Written to {os.path.realpath(f.name)}')

--- a/tests_and_analysis/test/euphonic_test/test_crystal.py
+++ b/tests_and_analysis/test/euphonic_test/test_crystal.py
@@ -7,7 +7,8 @@ import pytest
 from pint import DimensionalityError
 
 from euphonic import ureg, Quantity, Crystal
-from tests_and_analysis.test.utils import get_data_path, check_unit_conversion
+from tests_and_analysis.test.utils import (
+    get_data_path, check_unit_conversion, check_json_metadata)
 
 
 class ExpectedCrystal:
@@ -191,19 +192,18 @@ class TestCrystalCreation:
 @pytest.mark.unit
 class TestCrystalSerialisation:
 
-    @pytest.fixture(params=[get_crystal('quartz'), get_crystal('LZO')])
-    def serialise_to_json_file(self, request, tmpdir):
-        crystal = request.param
+    @pytest.mark.parametrize('crystal', [
+        get_crystal('quartz'),
+        get_crystal('LZO')])
+    def test_serialise_to_json_file(self, crystal, tmpdir):
         # Serialise
         output_file = str(tmpdir.join('tmp.test'))
         crystal.to_json_file(output_file)
+        # Test file metadata
+        check_json_metadata(output_file, 'Crystal')
         # Deserialise
         deserialised_crystal = Crystal.from_json_file(output_file)
-        return crystal, deserialised_crystal
-
-    def test_serialise_to_file(self, serialise_to_json_file):
-        crystal, deserialised_crystal = serialise_to_json_file
-        check_crystal(crystal, deserialised_crystal)
+        return check_crystal(crystal, deserialised_crystal)
 
     @pytest.fixture(params=[
         (get_crystal('quartz'), get_expected_crystal('quartz')),

--- a/tests_and_analysis/test/euphonic_test/test_debye_waller.py
+++ b/tests_and_analysis/test/euphonic_test/test_debye_waller.py
@@ -9,7 +9,8 @@ import pytest
 from euphonic import ureg, Crystal, DebyeWaller
 from tests_and_analysis.test.euphonic_test.test_crystal import (
     ExpectedCrystal, get_crystal, check_crystal)
-from tests_and_analysis.test.utils import get_data_path, check_unit_conversion
+from tests_and_analysis.test.utils import (
+    get_data_path, check_unit_conversion, check_json_metadata)
 
 
 class ExpectedDebyeWaller:
@@ -169,21 +170,15 @@ class TestDebyeWallerCreation:
 @pytest.mark.unit
 class TestDebyeWallerSerialisation:
 
-    @pytest.fixture(params=[
+    @pytest.mark.parametrize('dw', [
         get_dw('quartz', 'quartz_666_0K_debye_waller.json'),
         get_dw('Si2-sc-skew', 'Si2-sc-skew_666_300K_debye_waller.json'),
         get_dw('CaHgO2', 'CaHgO2_666_300K_debye_waller.json')])
-    def serialise_to_json_file(self, request, tmpdir):
-        dw = request.param
-        # Serialise
+    def test_serialise_to_json_file(self, dw, tmpdir):
         output_file = str(tmpdir.join('tmp.test'))
         dw.to_json_file(output_file)
-        # Deserialise
+        check_json_metadata(output_file, 'DebyeWaller')
         deserialised_dw = DebyeWaller.from_json_file(output_file)
-        return dw, deserialised_dw
-
-    def test_serialise_to_file(self, serialise_to_json_file):
-        dw, deserialised_dw = serialise_to_json_file
         check_debye_waller(dw, deserialised_dw)
 
     @pytest.fixture(params=[

--- a/tests_and_analysis/test/euphonic_test/test_force_constants.py
+++ b/tests_and_analysis/test/euphonic_test/test_force_constants.py
@@ -9,7 +9,8 @@ from euphonic import ForceConstants, Crystal, ureg
 from euphonic.readers.phonopy import ImportPhonopyReaderError
 from tests_and_analysis.test.euphonic_test.test_crystal import (
     get_crystal, ExpectedCrystal, check_crystal)
-from tests_and_analysis.test.utils import get_data_path, check_unit_conversion
+from tests_and_analysis.test.utils import (
+    get_data_path, check_unit_conversion, check_json_metadata)
 
 
 class ExpectedForceConstants:
@@ -358,17 +359,15 @@ class TestForceConstantsCreation:
 @pytest.mark.unit
 class TestForceConstantsSerialisation:
 
-    @pytest.fixture(params=[get_fc('quartz'), get_fc('LZO'), get_fc('NaCl')])
-    def serialise_to_json_file(self, request, tmpdir):
-        fc = request.param
-        # Write to file then read back to test
+    @pytest.mark.parametrize('fc', [
+        get_fc('quartz'),
+        get_fc('LZO'),
+        get_fc('NaCl')])
+    def test_serialise_to_json_file(self, fc, tmpdir):
         output_file = str(tmpdir.join('tmp.test'))
         fc.to_json_file(output_file)
+        check_json_metadata(output_file, 'ForceConstants')
         deserialised_fc = ForceConstants.from_json_file(output_file)
-        return fc, deserialised_fc
-
-    def test_serialise_to_file(self, serialise_to_json_file):
-        fc, deserialised_fc = serialise_to_json_file
         check_force_constants(fc, deserialised_fc)
 
     @pytest.fixture(params=[

--- a/tests_and_analysis/test/euphonic_test/test_qpoint_phonon_modes.py
+++ b/tests_and_analysis/test/euphonic_test/test_qpoint_phonon_modes.py
@@ -15,7 +15,8 @@ from tests_and_analysis.test.euphonic_test.test_debye_waller import (
 from tests_and_analysis.test.euphonic_test.test_spectrum1d import (
     get_expected_spectrum1d, check_spectrum1d)
 from tests_and_analysis.test.utils import (
-    get_data_path, check_mode_values_at_qpts, check_unit_conversion)
+    get_data_path, check_mode_values_at_qpts, check_unit_conversion,
+    check_json_metadata)
 
 
 class ExpectedQpointPhononModes:
@@ -361,18 +362,16 @@ class TestQpointPhononModesCreation:
 @pytest.mark.unit
 class TestQpointPhononModesSerialisation:
 
-    @pytest.fixture(params=['quartz', 'Si2-sc-skew', 'NaCl'])
-    def serialise_to_json_file(self, request, tmpdir):
-        qpt_ph_modes = get_qpt_ph_modes(request.param)
-        # Write to file then read back to test
+    @pytest.mark.parametrize('qpt_ph_modes', [
+        get_qpt_ph_modes('quartz'),
+        get_qpt_ph_modes('Si2-sc-skew'),
+        get_qpt_ph_modes('NaCl')])
+    def test_serialise_to_json_file(self, qpt_ph_modes, tmpdir):
         output_file = str(tmpdir.join('tmp.test'))
         qpt_ph_modes.to_json_file(output_file)
+        check_json_metadata(output_file, 'QpointPhononModes')
         deserialised_qpt_ph_modes = QpointPhononModes.from_json_file(
             output_file)
-        return qpt_ph_modes, deserialised_qpt_ph_modes
-
-    def test_serialise_to_file(self, serialise_to_json_file):
-        qpt_ph_modes, deserialised_qpt_ph_modes = serialise_to_json_file
         check_qpt_ph_modes(qpt_ph_modes, deserialised_qpt_ph_modes,
                            check_evecs=True)
 

--- a/tests_and_analysis/test/euphonic_test/test_spectrum1d.py
+++ b/tests_and_analysis/test/euphonic_test/test_spectrum1d.py
@@ -7,7 +7,8 @@ import numpy.testing as npt
 
 from euphonic import ureg
 from euphonic.spectra import Spectrum1D
-from tests_and_analysis.test.utils import get_data_path, check_unit_conversion
+from tests_and_analysis.test.utils import (
+    get_data_path, check_unit_conversion, check_json_metadata)
 
 class ExpectedSpectrum1D:
     def __init__(self, spectrum1d_json_file: str):
@@ -171,21 +172,15 @@ class TestSpectrum1DCreation:
 @pytest.mark.unit
 class TestSpectrum1DSerialisation:
 
-    @pytest.fixture(params=[
+    @pytest.mark.parametrize('spec1d', [
         get_spectrum1d('quartz_666_dos.json'),
         get_spectrum1d('xsq_spectrum1d.json'),
         get_spectrum1d('xsq_bin_edges_spectrum1d.json')])
-    def serialise_to_json_file(self, request, tmpdir):
-        spec1d = request.param
-        # Serialise
+    def test_serialise_to_json_file(self, spec1d, tmpdir):
         output_file = str(tmpdir.join('tmp.test'))
         spec1d.to_json_file(output_file)
-        # Deserialise
+        check_json_metadata(output_file, 'Spectrum1D')
         deserialised_spec1d = Spectrum1D.from_json_file(output_file)
-        return spec1d, deserialised_spec1d
-
-    def test_serialise_to_file(self, serialise_to_json_file):
-        spec1d, deserialised_spec1d = serialise_to_json_file
         check_spectrum1d(spec1d, deserialised_spec1d)
 
     @pytest.fixture(params=[

--- a/tests_and_analysis/test/euphonic_test/test_spectrum2d.py
+++ b/tests_and_analysis/test/euphonic_test/test_spectrum2d.py
@@ -7,7 +7,8 @@ import numpy.testing as npt
 
 from euphonic import ureg
 from euphonic.spectra import Spectrum2D
-from tests_and_analysis.test.utils import get_data_path, check_unit_conversion
+from tests_and_analysis.test.utils import (
+    get_data_path, check_unit_conversion, check_json_metadata)
 
 class ExpectedSpectrum2D:
     def __init__(self, spectrum2d_json_file: str):
@@ -198,22 +199,16 @@ class TestSpectrum2DCreation:
 @pytest.mark.unit
 class TestSpectrum2DSerialisation:
 
-    @pytest.fixture(params=[
+    @pytest.mark.parametrize('spec2d', [
         get_spectrum2d('quartz_bandstructure_sqw.json'),
         get_spectrum2d('example_spectrum2d.json'),
         get_spectrum2d('example_xbin_edges_spectrum2d.json'),
         get_spectrum2d('example_xybin_edges_spectrum2d.json')])
-    def serialise_to_json_file(self, request, tmpdir):
-        spec2d = request.param
-        # Serialise
+    def test_serialise_to_json_file(self, spec2d, tmpdir):
         output_file = str(tmpdir.join('tmp.test'))
         spec2d.to_json_file(output_file)
-        # Deserialise
+        check_json_metadata(output_file, 'Spectrum2D')
         deserialised_spec2d = Spectrum2D.from_json_file(output_file)
-        return spec2d, deserialised_spec2d
-
-    def test_serialise_to_file(self, serialise_to_json_file):
-        spec2d, deserialised_spec2d = serialise_to_json_file
         check_spectrum2d(spec2d, deserialised_spec2d)
 
     @pytest.fixture(params=[

--- a/tests_and_analysis/test/euphonic_test/test_structure_factor.py
+++ b/tests_and_analysis/test/euphonic_test/test_structure_factor.py
@@ -14,7 +14,8 @@ from tests_and_analysis.test.euphonic_test.test_spectrum2d import (
 from tests_and_analysis.test.euphonic_test.test_spectrum1d import (
     get_expected_spectrum1d, check_spectrum1d)
 from tests_and_analysis.test.utils import (
-    get_data_path, check_mode_values_at_qpts, check_unit_conversion)
+    get_data_path, check_mode_values_at_qpts, check_unit_conversion,
+    check_json_metadata)
 
 
 class ExpectedStructureFactor:
@@ -289,21 +290,15 @@ class TestStructureFactorCreation:
 @pytest.mark.unit
 class TestStructureFactorSerialisation:
 
-    @pytest.fixture(params=[
+    @pytest.mark.parametrize('sf', [
         get_sf('quartz', 'quartz_0K_structure_factor.json'),
         get_sf('CaHgO2', 'CaHgO2_300K_structure_factor.json')])
-    def serialise_to_json_file(self, request, tmpdir):
-        sf = request.param
-        # Serialise
+    def test_serialise_to_json_file(self, sf, tmpdir):
         output_file = str(tmpdir.join('tmp.test'))
         sf.to_json_file(output_file)
-        # Deserialise
+        check_json_metadata(output_file, 'StructureFactor')
         deserialised_sf = StructureFactor.from_json_file(output_file)
-        return sf, deserialised_sf
-
-    def test_serialise_to_file(self, serialise_to_json_file):
-        sf, deserialised_sf = serialise_to_json_file
-        check_structure_factor(sf, deserialised_sf, sum_sf=False)
+        check_structure_factor(sf, deserialised_sf)
 
     @pytest.fixture(params=[
         ('quartz', 'quartz_0K_structure_factor.json'),

--- a/tests_and_analysis/test/utils.py
+++ b/tests_and_analysis/test/utils.py
@@ -1,10 +1,11 @@
 import os
+import json
 from typing import Optional
 
 import numpy as np
 import numpy.testing as npt
 
-from euphonic import ureg
+from euphonic import ureg, __version__
 
 def get_data_path() -> str:
     """
@@ -141,3 +142,23 @@ def check_unit_conversion(obj, attr, unit):
         assert getattr(obj, attr).units == ureg(unit)
     npt.assert_allclose(getattr(obj, attr).magnitude,
                         original_attr_value.to(unit).magnitude)
+
+
+def check_json_metadata(json_file: str, class_name: str):
+    """
+    Utility function to check that .json file metadata has been output
+    correctly
+
+    Parameters
+    ----------
+    json_file
+        Path and name of the .json file
+    class_name
+        The name of the class that should've been written to the file.
+        Using a string rather than cls.__name__ so it is more explicit
+        for testing
+    """
+    with open(json_file, 'r') as f:
+        data = json.loads(f.read())
+    assert data['__euphonic_class__'] == class_name
+    assert data['__euphonic_version__'] == __version__


### PR DESCRIPTION
Adds metadata to .json outputs describing the Euphonic version, and the class being written, to make it easier to automatically determine object types from files. This is to aid in reading files for command line tools, and came about as a result of https://github.com/pace-neutrons/Euphonic/pull/100#discussion_r517954830.