### PR TITLE
Adjust compiler settings, use CC if set and don't assume homebrew

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,7 +1,6 @@
 `Unreleased <https://github.com/pace-neutrons/Euphonic/compare/v0.4.0...HEAD>`_
 ----------
 
-
 - New Features:
 
   - New command-line tool ``euphonic-powder-map`` allows generation
@@ -39,6 +38,17 @@
       sampling with a single-parameter ``--q-spacing`` as an
       alternative to setting Monkhorst-Pack divisions. This approach
       will account for the size and shape of reciprocal-lattice cells.
+
+  - Build process tweaks
+
+    - On Linux, the build process will now respect a user-defined
+      C-compiler variable ``CC``.
+
+    - On Mac OSX, the build process will now respect a user-defined
+      C-compiler variable ``CC``. Homebrew library paths will only be
+      set if ``CC`` is empty and the ``brew`` command is available.
+
+    These tweaks are intended to facilitate Conda packaging.
 
 - Breaking changes:
 

--- a/setup.py
+++ b/setup.py
@@ -33,16 +33,27 @@ def get_c_extension():
         compile_args = ['/openmp']
         link_args = None
     elif platform == 'darwin':
-        # OSX - assume brew install llvm
-        brew_prefix_cmd_return = subprocess.run(["brew", "--prefix"],
-                                                stdout=subprocess.PIPE)
-        brew_prefix = brew_prefix_cmd_return.stdout.decode("utf-8").strip()
-        os.environ['CC'] = '{}/opt/llvm/bin/clang'.format(brew_prefix)
-        compile_args = ['-fopenmp']
-        link_args = ['-L{}/opt/llvm/lib'.format(brew_prefix), '-fopenmp']
+        # OSX - if CC not set, assume brew install llvm
+        try:
+            brew_prefix_cmd_return = subprocess.run(["brew", "--prefix"],
+                                                    stdout=subprocess.PIPE)
+            brew_prefix = brew_prefix_cmd_return.stdout.decode("utf-8").strip()
+        except FileNotFoundError:
+            brew_prefix = None
+
+        if brew_prefix and not os.environ.get['CC']:
+            os.environ['CC'] = '{}/opt/llvm/bin/clang'.format(brew_prefix)
+            link_args = ['-L{}/opt/llvm/lib'.format(brew_prefix), '-fopenmp']
+        else:
+            link_args = ['-fopenmp']
+
+        compile_args = ['-fopenmp']            
+
     else:
-        # Linux - assume gcc
-        os.environ['CC'] = 'gcc'
+        # Linux - assume gcc if CC not set
+        if not os.environ.get('CC'):
+            os.environ['CC'] = 'gcc'
+
         compile_args = ['-fopenmp']
         link_args = ['-fopenmp']
 

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ def get_c_extension():
         except FileNotFoundError:
             brew_prefix = None
 
-        if brew_prefix and not os.environ.get['CC']:
+        if brew_prefix and not os.environ.get('CC'):
             os.environ['CC'] = '{}/opt/llvm/bin/clang'.format(brew_prefix)
             link_args = ['-L{}/opt/llvm/lib'.format(brew_prefix), '-fopenmp']
         else:


### PR DESCRIPTION
The conda-forge CI isn't working with the current setup as it doesn't have =brew= available on Mac and the =gcc= binary on linux has a platform-dependent name.

These tweaks allow the environment CC to be used, and avoid the build script blowing up if homebrew is unavailable.

If this PR is accepted it would be helpful to make a Euphonic point release as soon as possible for use in the conda-forge package.