### PR TITLE
Changelog update for 0.5.0 release

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,4 +1,7 @@
-`Unreleased <https://github.com/pace-neutrons/Euphonic/compare/v0.4.0...HEAD>`_
+`Unreleased <https://github.com/pace-neutrons/Euphonic/compare/v0.5.0...HEAD>`_
+----------
+
+`v0.5.0 <https://github.com/pace-neutrons/Euphonic/compare/v0.4.0...v0.5.0>`_
 ----------
 
 - New Features:

--- a/setup.py
+++ b/setup.py
@@ -89,10 +89,21 @@ def run_setup(build_c=True):
         cmdclass=cmdclass,
         author='Rebecca Fair',
         author_email='rebecca.fair@stfc.ac.uk',
+        classifiers=[
+            'Development Status :: 4 - Beta',
+            'Environment :: Console',
+            'Intended Audience :: Science/Research',
+            'License :: OSI Approved :: GNU General Public License v3 (GPLv3)',
+            'Programming Language :: C',
+            'Programming Language :: Python :: 3',
+            'Topic :: Scientific/Engineering :: Physics',
+            ],
         description=(
             'Euphonic calculates phonon bandstructures and inelastic '
             'neutron scattering intensities from modelling code output '
             '(e.g. CASTEP)'),
+        license='GPLv3',
+        license_files=('LICENSE',),
         long_description=long_description,
         long_description_content_type='text/x-rst',
         url='https://github.com/pace-neutrons/Euphonic',


### PR DESCRIPTION
I would like to make a release as soon as possible so that the setup.py tweaks are available from PyPI for conda builds.

We have added some significant features comparable to other 0.x releases, so I suggest incrementing to 0.5.0.

I have tried building this 0.5.0 release locally with release.py, was able to install and test the resulting .tar.gz package without issue. (I set the v0.5.0 tag locally, have not pushed the tag in case further changes are needed.)
