### PR TITLE
Change load_libs.c to use scipy cython refs

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,9 +18,10 @@
     frequencies. This improves on the previous behaviour which only excluded
     gamma-point acoustic modes, so would miss small/negative frequencies
     elsewhere
-  - When loading libraries for the C extension in Windows, there are now
-    additional search paths, and ``liblapack.dll`` or ``mkl_rt.1.dll`` will
-    be attempted to be loaded if ``libopenblas.dll`` can't be found
+  - Loading the LAPACK libraries for the C extension now uses the
+    `interface <https://docs.scipy.org/doc/scipy/reference/linalg.cython_lapack.html`_
+    provided by `scipy` for `cython` instead of loading directly from a DLL.
+    The new method means we don't have to guess the DLL filename anymore!
 
 - Changes:
 

--- a/c/_euphonic.c
+++ b/c/_euphonic.c
@@ -32,7 +32,6 @@ static PyObject *calculate_phonons(PyObject *self, PyObject *args) {
     int reciprocal_asr;
     int splitting;
     int n_threads = 1;
-    const char *scipy_dir;
 
     // Define vars to be obtained from ForceConstants attributes
     PyObject *py_crystal; // Crystal object
@@ -94,7 +93,7 @@ static PyObject *calculate_phonons(PyObject *self, PyObject *args) {
     int n_gvecs;
 
     // Parse inputs
-    if (!PyArg_ParseTuple(args, "OO!O!O!O!O!O!O!O!O!iiiO!O!O!O!is",
+    if (!PyArg_ParseTuple(args, "OO!O!O!O!O!O!O!O!O!iiiO!O!O!O!i",
                           &py_idata,
                           &PyArray_Type, &py_cell_vec,
                           &PyArray_Type, &py_recip_vec,
@@ -112,8 +111,7 @@ static PyObject *calculate_phonons(PyObject *self, PyObject *args) {
                           &PyArray_Type, &py_dmats,
                           &PyArray_Type, &py_modegs,
                           &PyArray_Type, &py_all_ogs_cart,
-                          &n_threads,
-                          &scipy_dir)) {
+                          &n_threads)) {
         return NULL;
     }
 
@@ -187,7 +185,7 @@ static PyObject *calculate_phonons(PyObject *self, PyObject *args) {
 
     // Load library functions
     ZheevdFunc zheevd;
-    zheevd = get_zheevd(scipy_dir);
+    zheevd = get_zheevd();
     if (zheevd == NULL) {
         PyErr_Format(PyExc_RuntimeError, "Could not load zheevd function\n");
         return NULL;

--- a/c/load_libs.c
+++ b/c/load_libs.c
@@ -5,7 +5,7 @@
 // Global variable to cache pointer location
 void *ZHEEVD_POINTER = NULL;
 
-ZheevdFunc get_zheevd(const char *scipy_dir) {
+ZheevdFunc get_zheevd() {
     if (!ZHEEVD_POINTER)
     {
         // Take the Global interpreter lock to import scipy.linalg

--- a/c/load_libs.h
+++ b/c/load_libs.h
@@ -5,6 +5,6 @@ typedef void (*ZheevdFunc)(char* jobz, char* uplo, int* n, double* a, int* lda,
     double* w, double* work, int* lwork, double* rwork, int* lrwork,
     int* iwork, int* liwork, int* info);
 
-ZheevdFunc get_zheevd(const char *scipy_dir);
+ZheevdFunc get_zheevd();
 
 #endif

--- a/euphonic/force_constants.py
+++ b/euphonic/force_constants.py
@@ -611,8 +611,7 @@ class ForceConstants:
                     split_idx, q_dirs, fc_img_weighted, sc_origins,
                     recip_asr_correction, dyn_mat_weighting, dipole,
                     reciprocal_asr, splitting, rfreqs, reigenvecs,
-                    rmode_gradients, all_origins_cart, n_threads,
-                    scipy.__path__[0])
+                    rmode_gradients, all_origins_cart, n_threads)
         else:
             q_independent_args = (
                 reduced_qpts, split_idx, q_dirs, fc_img_weighted,

--- a/euphonic/force_constants.py
+++ b/euphonic/force_constants.py
@@ -6,8 +6,6 @@ from typing import Optional, Tuple, Union
 from multiprocessing import cpu_count
 
 import numpy as np
-import scipy
-from scipy.linalg.lapack import zheev
 from scipy.special import erfc
 from threadpoolctl import threadpool_limits
 

--- a/tests_and_analysis/test/euphonic_test/test_force_constants_calculate_qpoint_phonon_modes.py
+++ b/tests_and_analysis/test/euphonic_test/test_force_constants_calculate_qpoint_phonon_modes.py
@@ -305,14 +305,14 @@ class TestForceConstantsCalculateQPointPhononModesWithCExtensionInstalled:
         n_threads = 3
         fc = get_fc('quartz')
         fc.calculate_qpoint_phonon_modes(get_test_qpts(), n_threads=n_threads)
-        assert mocked_cext.call_args[0][-2] == n_threads
+        assert mocked_cext.call_args[0][-1] == n_threads
 
     def test_cext_called_with_n_threads_default_and_env_var(self, mocked_cext):
         n_threads = 4
         os.environ['EUPHONIC_NUM_THREADS'] = str(n_threads)
         fc = get_fc('quartz')
         fc.calculate_qpoint_phonon_modes(get_test_qpts())
-        assert mocked_cext.call_args[0][-2] == n_threads
+        assert mocked_cext.call_args[0][-1] == n_threads
 
     def test_cext_called_with_n_threads_default_and_no_env_var(self, mocked_cext):
         n_threads = cpu_count()
@@ -322,5 +322,5 @@ class TestForceConstantsCalculateQPointPhononModesWithCExtensionInstalled:
             pass
         fc = get_fc('quartz')
         fc.calculate_qpoint_phonon_modes(get_test_qpts())
-        assert mocked_cext.call_args[0][-2] == n_threads
+        assert mocked_cext.call_args[0][-1] == n_threads
 


### PR DESCRIPTION
This PR presents an alternative way to get a pointer to the LAPACK `zheevd` matrix eigensolver function. Instead of loading this from a shared library, it uses the [function pointers](https://docs.scipy.org/doc/scipy/reference/linalg.cython_lapack.html#module-scipy.linalg.cython_lapack) exposed by `scipy` for use by `cython`. These functions have the same Fortran calling convention as `zheevd_` which is loaded from the libraries but should point to whichever function `scipy`/`numpy` was compiled with on the user's system.

The PR:

* Removed searching / loading of shared libraries.
* Instead use the function pointers provided by scipy for use with Cython
* Also implement a simple caching mechanism using a global variable.

Fixes #149, #150