### PR TITLE
Add property setters

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,9 @@
   - ``euphonic-optimise-dipole-parameter`` can now read from Phonopy sources
   - ``euphonic-optimise-dipole-parameter`` can now also be used for non-polar
     materials to get general per-qpoint timings
+  - Dimensioned Euphonic properties (e.g. ``frequencies``, ``cell_vectors``)
+    now have setters so can be set, previously this would raise an
+    ``AttributeError``
 
 - Changes:
 
@@ -13,7 +16,6 @@
     deprecated, ``dipole_parameter`` should be used instead.
   - This means the ``euphonic-optimise-eta`` script has been renamed to
     ``euphonic-optimise-dipole-parameter``.
-
 
 `v0.5.2 <https://github.com/pace-neutrons/Euphonic/compare/v0.5.1...v0.5.2>`_
 ------

--- a/doc/source/units.rst
+++ b/doc/source/units.rst
@@ -49,14 +49,21 @@ a function:
   scattering_lengths = {'Si': 4.1491*fm, 'O': 5.803*fm}
   sf = phonons.calculate_structure_factor(scattering_lengths)
 
-Changing Units
---------------
+Object Attributes
+-----------------
 
-When creating a Euphonic object, any attributes with units will be
-wrapped as a ``Quantity`` object in default units (e.g. meV for frequencies,
-angstrom for cell vectors). Each ``Quantity`` attribute has an associated
-string attribute that can be used to change the units. See the following
-example to change the units of frequency in ``QpointPhononModes``:
+Any dimensioned attributes (attributes with units) on a Euphonic object,
+for example ``cell_vectors`` or ``frequencies``, are actually properties.
+They are stored internally in atomic units, and only wrapped as a
+``Quantity`` in user-friendly units once they are accessed.
+
+**Changing attribute units**
+
+When a Euphonic object is created, its dimensioned attributes will be
+in default units (e.g. meV for frequencies, angstrom for cell vectors).
+Each ``Quantity`` attribute has an associated string attribute that can
+be used to change the units. See the following example to change the units
+of frequency in ``QpointPhononModes``:
 
 .. code-block:: py
 
@@ -80,3 +87,55 @@ example to change the units of frequency in ``QpointPhononModes``:
 The pattern is the same for any ``Quantity`` attribute e.g.
 ``ForceConstants.force_constants`` has ``ForceConstants.force_constants_unit``,
 ``Crystal.cell_vectors`` has ``Crystal.cell_vectors_unit``
+
+**Changing attribute values**
+
+Each dimensioned property also has a setter which allows it to be set. For
+example, to set new ``Crystal.cell_vectors``:
+
+.. code-block:: py
+
+  >>> from euphonic import ForceConstants
+  >>> fc = ForceConstants.from_castep('quartz.castep_bin')
+  >>> fc.crystal.cell_vectors
+  <Quantity([[ 2.42617588 -4.20225989  0.        ]
+   [ 2.42617588  4.20225989  0.        ]
+   [ 0.          0.          5.35030451]], 'angstrom')>
+  >>> fc.crystal.cell_vectors = np.array(
+  ...     [[ 4.85235176, -8.40451979, 0.],
+  ...      [ 4.85235176,  8.40451979, 0.],
+  ...      [ 0., 0., 10.70060903]])*ureg('angstrom')
+  >>> fc.crystal.cell_vectors
+  <Quantity([[ 4.85235176 -8.40451979  0.        ]
+   [ 4.85235176  8.40451979  0.        ]
+   [ 0.          0.         10.70060903]], 'angstrom')>
+
+However as dimensioned attributes are properties, individual elements can't be
+set by indexing, for example the following to set a single element of
+``Crystal.atom_mass`` does not work:
+
+.. code-block:: py
+
+  >>> from euphonic import ForceConstants
+  >>> fc = ForceConstants.from_castep('quartz.castep_bin')
+  >>> fc.crystal.atom_mass
+  <Quantity([15.99939997 15.99939997 15.99939997 15.99939997 15.99939997 15.99939997
+   28.08549995 28.08549995 28.08549995], 'unified_atomic_mass_unit')>
+  >>> fc.crystal.atom_mass[0] = 17.999*ureg('amu')
+  >>> fc.crystal.atom_mass
+  <Quantity([15.99939997 15.99939997 15.99939997 15.99939997 15.99939997 15.99939997
+   28.08549995 28.08549995 28.08549995], 'unified_atomic_mass_unit')>
+
+Nothing has changed! Instead, get the entire array, change any desired entries and
+then set the whole attribute as follows:
+
+.. code-block:: py
+
+  >>> from euphonic import ForceConstants
+  >>> fc = ForceConstants.from_castep('quartz.castep_bin')
+  >>> atom_mass = fc.crystal.atom_mass
+  >>> atom_mass[0] = 17.999*ureg('amu')
+  >>> fc.crystal.atom_mass = atom_mass
+  >>> fc.crystal.atom_mass
+  <Quantity([17.999      15.99939997 15.99939997 15.99939997 15.99939997 15.99939997
+   28.08549995 28.08549995 28.08549995], 'unified_atomic_mass_unit')>

--- a/euphonic/crystal.py
+++ b/euphonic/crystal.py
@@ -84,10 +84,20 @@ class Crystal:
         return self._cell_vectors*ureg('bohr').to(
             self.cell_vectors_unit)
 
+    @cell_vectors.setter
+    def cell_vectors(self, value):
+        self.cell_vectors_unit = str(value.units)
+        self._cell_vectors = value.to('bohr').magnitude
+
     @property
     def atom_mass(self):
         return self._atom_mass*ureg('m_e').to(
             self.atom_mass_unit)
+
+    @atom_mass.setter
+    def atom_mass(self, value):
+        self.atom_mass_unit = str(value.units)
+        self._atom_mass = value.to('m_e').magnitude
 
     def __setattr__(self, name, value):
         _check_unit_conversion(self, name, value,

--- a/euphonic/debye_waller.py
+++ b/euphonic/debye_waller.py
@@ -55,10 +55,20 @@ class DebyeWaller:
         return self._debye_waller*ureg('bohr**2').to(
             self.debye_waller_unit)
 
+    @debye_waller.setter
+    def debye_waller(self, value):
+        self.debye_waller_unit = str(value.units)
+        self._debye_waller = value.to('bohr**2').magnitude
+
     @property
     def temperature(self):
         # See https://pint.readthedocs.io/en/latest/nonmult.html
         return Quantity(self._temperature, ureg('K')).to(self.temperature_unit)
+
+    @temperature.setter
+    def temperature(self, value):
+        self.temperature_unit = str(value.units)
+        self._temperature = value.to('K').magnitude
 
     def __setattr__(self, name, value):
         _check_unit_conversion(self, name, value,

--- a/euphonic/force_constants.py
+++ b/euphonic/force_constants.py
@@ -110,12 +110,22 @@ class ForceConstants:
             'hartree/bohr**2').to(
                 self.force_constants_unit)
 
+    @force_constants.setter
+    def force_constants(self, value):
+        self.force_constants_unit = str(value.units)
+        self._force_constants = value.to('hartree/bohr**2').magnitude
+
     @property
     def born(self):
         if self._born is not None:
             return self._born*ureg('e').to(self.born_unit)
         else:
             return None
+
+    @born.setter
+    def born(self, value):
+        self.born_unit = str(value.units)
+        self._born = value.to('e').magnitude
 
     @property
     def dielectric(self):
@@ -124,6 +134,11 @@ class ForceConstants:
                 'e**2/(bohr*hartree)')).to(self.dielectric_unit)
         else:
             return None
+
+    @dielectric.setter
+    def dielectric(self, value):
+        self.dielectric_unit = str(value.units)
+        self._dielectric = value.to('e**2/(bohr*hartree)').magnitude
 
     def __setattr__(self, name, value):
         _check_unit_conversion(self, name, value,

--- a/euphonic/qpoint_frequencies.py
+++ b/euphonic/qpoint_frequencies.py
@@ -79,6 +79,11 @@ class QpointFrequencies:
     def frequencies(self):
         return self._frequencies*ureg('hartree').to(self.frequencies_unit)
 
+    @frequencies.setter
+    def frequencies(self, value):
+        self.frequencies_unit = str(value.units)
+        self._frequencies = value.to('hartree').magnitude
+
     def __setattr__(self, name, value):
         _check_unit_conversion(self, name, value,
                                ['frequencies_unit'])

--- a/euphonic/spectra.py
+++ b/euphonic/spectra.py
@@ -38,10 +38,20 @@ class Spectrum(ABC):
         return self._x_data*ureg(self._internal_x_data_unit).to(
             self.x_data_unit)
 
+    @x_data.setter
+    def x_data(self, value):
+        self.x_data_unit = str(value.units)
+        self._x_data = value.to(self._internal_x_data_unit).magnitude
+
     @property
     def y_data(self):
         return self._y_data*ureg(self._internal_y_data_unit).to(
             self.y_data_unit)
+
+    @y_data.setter
+    def y_data(self, value):
+        self.y_data_unit = str(value.units)
+        self._y_data = value.to(self._internal_y_data_unit).magnitude
 
     @abstractmethod
     def to_dict(self) -> Dict[str, Any]:
@@ -767,6 +777,11 @@ class Spectrum2D(Spectrum):
     def z_data(self):
         return self._z_data*ureg(self._internal_z_data_unit).to(
             self.z_data_unit)
+
+    @z_data.setter
+    def z_data(self, value):
+        self.z_data_unit = str(value.units)
+        self._z_data = value.to(self._internal_z_data_unit).magnitude
 
     def __setattr__(self, name: str, value: Any) -> None:
         _check_unit_conversion(self, name, value,

--- a/euphonic/structure_factor.py
+++ b/euphonic/structure_factor.py
@@ -95,6 +95,11 @@ class StructureFactor(QpointFrequencies):
         return self._structure_factors*ureg('bohr**2').to(
             self.structure_factors_unit)
 
+    @structure_factors.setter
+    def structure_factors(self, value):
+        self.structure_factors_unit = str(value.units)
+        self._structure_factors = value.to('bohr**2').magnitude
+
     @property
     def temperature(self):
         if self._temperature is not None:
@@ -103,6 +108,11 @@ class StructureFactor(QpointFrequencies):
                             ureg('K')).to(self.temperature_unit)
         else:
             return None
+
+    @temperature.setter
+    def temperature(self, value):
+        self.temperature_unit = str(value.units)
+        self._temperature = value.to('K').magnitude
 
     def __setattr__(self, name, value):
         _check_unit_conversion(self, name, value,

--- a/tests_and_analysis/test/euphonic_test/test_qpoint_frequencies.py
+++ b/tests_and_analysis/test/euphonic_test/test_qpoint_frequencies.py
@@ -19,7 +19,7 @@ from tests_and_analysis.test.euphonic_test.test_spectrum1dcollection import (
 from tests_and_analysis.test.utils import (
     get_data_path, get_castep_path, get_phonopy_path,
     check_frequencies_at_qpts, check_unit_conversion,
-    check_json_metadata)
+    check_json_metadata, check_property_setters)
 
 
 class ExpectedQpointFrequencies:
@@ -383,6 +383,31 @@ class TestQpointFrequenciesUnitConversion:
         qpt_freqs = get_qpt_freqs(material, json_file)
         with pytest.raises(err):
             setattr(qpt_freqs, unit_attr, unit_val)
+
+
+@pytest.mark.unit
+class TestQpointFrequenciesSetters:
+
+    @pytest.mark.parametrize('material, json_file, attr, unit, scale', [
+        ('quartz', 'quartz_reciprocal_qpoint_frequencies.json',
+         'frequencies', '1/cm', 2.),
+        ('quartz', 'quartz_reciprocal_qpoint_frequencies.json',
+         'frequencies', 'meV', 3.)
+        ])
+    def test_setter_correct_units(self, material, json_file, attr,
+                                  unit, scale):
+        qpt_freqs = get_qpt_freqs(material, json_file)
+        check_property_setters(qpt_freqs, attr, unit, scale)
+
+    @pytest.mark.parametrize('material, json_file, attr, unit, err', [
+        ('quartz', 'quartz_reciprocal_qpoint_frequencies.json',
+         'frequencies', '1/cm**2', ValueError)])
+    def test_incorrect_unit_conversion(self, material, json_file, attr,
+                                       unit, err):
+        qpt_freqs = get_qpt_freqs(material, json_file)
+        new_attr = getattr(qpt_freqs, attr).magnitude*ureg(unit)
+        with pytest.raises(err):
+            setattr(qpt_freqs, attr, new_attr)
 
 
 @pytest.mark.unit

--- a/tests_and_analysis/test/euphonic_test/test_qpoint_phonon_modes.py
+++ b/tests_and_analysis/test/euphonic_test/test_qpoint_phonon_modes.py
@@ -21,7 +21,7 @@ from tests_and_analysis.test.euphonic_test.test_spectrum1dcollection import (
 from tests_and_analysis.test.utils import (
     get_data_path, get_castep_path, get_phonopy_path,
     check_frequencies_at_qpts, check_unit_conversion,
-    check_json_metadata)
+    check_json_metadata, check_property_setters)
 
 
 class ExpectedQpointPhononModes:
@@ -428,6 +428,26 @@ class TestQpointPhononModesUnitConversion:
         qpt_ph_modes = get_qpt_ph_modes(material)
         with pytest.raises(err):
             setattr(qpt_ph_modes, unit_attr, unit_val)
+
+
+@pytest.mark.unit
+class TestQpointPhononModesSetters:
+
+    @pytest.mark.parametrize('material, attr, unit, scale', [
+        ('quartz', 'frequencies', '1/cm', 2.),
+        ('quartz', 'frequencies', 'meV', 3.)
+        ])
+    def test_setter_correct_units(self, material, attr, unit, scale):
+        qpt_ph_modes = get_qpt_ph_modes(material)
+        check_property_setters(qpt_ph_modes, attr, unit, scale)
+
+    @pytest.mark.parametrize('material, attr, unit, err', [
+        ('quartz', 'frequencies', '1/cm**2', ValueError)])
+    def test_incorrect_unit_conversion(self, material, attr, unit, err):
+        qpt_ph_modes = get_qpt_ph_modes(material)
+        new_attr = getattr(qpt_ph_modes, attr).magnitude*ureg(unit)
+        with pytest.raises(err):
+            setattr(qpt_ph_modes, attr, new_attr)
 
 
 @pytest.mark.unit

--- a/tests_and_analysis/test/utils.py
+++ b/tests_and_analysis/test/utils.py
@@ -154,17 +154,17 @@ def check_mode_values_at_qpts(qpts, values, expected_values, atol, rtol,
         atol=atol, rtol=rtol)
 
 
-def check_unit_conversion(obj, attr, unit):
+def check_unit_conversion(obj: object, attr: str, unit: str) -> None:
     """
     Utility function to check unit conversions in Euphonic objects
 
     Parameters
     ----------
-    obj : Object
+    obj
         The object to check
-    attr : str
+    attr
         The name of the attribute to change the units of
-    unit : str
+    unit
         The unit to change attr to
     """
     unit_attr = attr + '_unit'
@@ -183,8 +183,30 @@ def check_unit_conversion(obj, attr, unit):
     npt.assert_allclose(getattr(obj, attr).magnitude,
                         original_attr_value.to(unit).magnitude)
 
+def check_property_setters(obj: object, attr: str, unit: str,
+                           scale: float) -> None:
+    """
+    Utility function to check setters for Quantity properties in
+    Euphonic objects
 
-def check_json_metadata(json_file: str, class_name: str):
+    Parameters
+    ----------
+    obj
+        The object to check
+    attr
+        The name of the attribute to set
+    unit
+        The unit the attribute should be set to
+    scale
+        What to scale the attribute by, so we can check its been changed
+    """
+    new_attr = scale*getattr(obj, attr).to(unit)
+    setattr(obj, attr, new_attr)
+    set_attr = getattr(obj, attr)
+    assert set_attr.units == new_attr.units
+    npt.assert_allclose(set_attr.magnitude, new_attr.magnitude)
+
+def check_json_metadata(json_file: str, class_name: str) -> None:
     """
     Utility function to check that .json file metadata has been output
     correctly


### PR DESCRIPTION
Addresses #120

This isn't in need of a review as such, it's more of just a heads up. I haven't added any shape/type checking on the properties, I thought that would be inconsistent with other non-property attributes, we still only check on object creation. I think that's fine for now?

We could get shape checking for free on the properties by indexing into the internal attribute like:

```
@cell_vectors.setter
def cell_vectors(self, value):
    self.cell_vectors_unit = str(value.units)
    self._cell_vectors[:] = value.to('bohr').magnitude
```

But we don't do any checks when setting things like eigenvectors so I feel like that would be inconsistent.