### PR TITLE
Add widget for changing intensity to powder-map plots

### DIFF
--- a/euphonic/cli/powder_map.py
+++ b/euphonic/cli/powder_map.py
@@ -46,8 +46,8 @@ def get_parser() -> 'argparse.ArgumentParser':
                                help="Minimum |q| in 1/LENGTH_UNIT")
     sections['q'].add_argument('--q-max', type=float, default=3., dest='q_max',
                                help="Maximum |q| in 1/LENGTH_UNIT")
-    sections['plotting'].add_argument('--no-widgets', action='store_false',
-                                      dest='use_widgets', default=True,
+    sections['plotting'].add_argument('--no-widgets', action='store_true',
+                                      dest='disable_widgets', default=False,
                                       help=("Don't use Matplotlib widgets to "
                                             "enable interactive setting of "
                                             "colourmap intensity limits"))
@@ -170,14 +170,14 @@ def main(params: List[str] = None):
                                 y_label=y_label,
                                 title=args.title)
 
-    if args.use_widgets == True:
+    if args.disable_widgets is False:
         # TextBox only available from mpl 2.1.0
         try:
             from matplotlib.widgets import TextBox
         except ImportError:
-            args.use_widgets = False
+            args.disable_widgets = True
 
-    if args.use_widgets:
+    if args.disable_widgets is False:
         min_label = f'Min Intensity ({spectrum.z_data.units:~P})'
         max_label = f'Max Intensity ({spectrum.z_data.units:~P})'
         boxw = 0.15

--- a/euphonic/cli/powder_map.py
+++ b/euphonic/cli/powder_map.py
@@ -50,7 +50,7 @@ def get_parser() -> 'argparse.ArgumentParser':
                                       dest='disable_widgets', default=False,
                                       help=("Don't use Matplotlib widgets to "
                                             "enable interactive setting of "
-                                            "colourmap intensity limits"))
+                                            "colormap intensity limits"))
     return parser
 
 

--- a/euphonic/cli/powder_map.py
+++ b/euphonic/cli/powder_map.py
@@ -46,6 +46,11 @@ def get_parser() -> 'argparse.ArgumentParser':
                                help="Minimum |q| in 1/LENGTH_UNIT")
     sections['q'].add_argument('--q-max', type=float, default=3., dest='q_max',
                                help="Maximum |q| in 1/LENGTH_UNIT")
+    sections['plotting'].add_argument('--no-widgets', action='store_false',
+                                      dest='use_widgets', default=True,
+                                      help=("Don't use Matplotlib widgets to "
+                                            "enable interactive setting of "
+                                            "colourmap intensity limits"))
     return parser
 
 
@@ -158,12 +163,48 @@ def main(params: List[str] = None):
     else:
         x_label = args.x_label
 
-    euphonic.plot.plot_2d(spectrum,
-                          cmap=args.cmap,
-                          vmin=args.v_min, vmax=args.v_max,
-                          x_label=x_label,
-                          y_label=y_label,
-                          title=args.title)
+    fig = euphonic.plot.plot_2d(spectrum,
+                                cmap=args.cmap,
+                                vmin=args.v_min, vmax=args.v_max,
+                                x_label=x_label,
+                                y_label=y_label,
+                                title=args.title)
+
+    if args.use_widgets == True:
+        # TextBox only available from mpl 2.1.0
+        try:
+            from matplotlib.widgets import TextBox
+        except ImportError:
+            args.use_widgets = False
+
+    if args.use_widgets:
+        min_label = f'Min Intensity ({spectrum.z_data.units:~P})'
+        max_label = f'Max Intensity ({spectrum.z_data.units:~P})'
+        boxw = 0.15
+        boxh = 0.05
+        x0 = 0.1 + len(min_label)*0.01
+        y0 = 0.025
+        fig.subplots_adjust(bottom=0.25)
+        axmin = fig.add_axes([x0, y0, boxw, boxh])
+        axmax = fig.add_axes([x0, y0 + 0.075, boxw, boxh])
+        image = fig.get_axes()[0].images[0]
+        cmin, cmax = image.get_clim()
+        pad = 0.05
+        fmt_str = '.2e' if cmax < 0.1 else '.2f'
+        minbox = TextBox(axmin, min_label,
+                         initial=f'{cmin:{fmt_str}}', label_pad=pad)
+        maxbox = TextBox(axmax, max_label,
+                         initial=f'{cmax:{fmt_str}}', label_pad=pad)
+        def update_min(min_val):
+            image.set_clim(vmin=float(min_val))
+            fig.canvas.draw()
+
+        def update_max(max_val):
+            image.set_clim(vmax=float(max_val))
+            fig.canvas.draw()
+        minbox.on_submit(update_min)
+        maxbox.on_submit(update_max)
+
     matplotlib_save_or_show(save_filename=args.save_to)
 
 

--- a/tests_and_analysis/test/data/script_data/powder-map.json
+++ b/tests_and_analysis/test/data/script_data/powder-map.json
@@ -3348,7 +3348,7 @@
             0.0
         ]
     },
-    "NaCl_prim phonopy_nacl.yaml -w=incoherent-dos --pdos=Na --npts=10 --npts-min=10 --q-spacing=1": {
+    "NaCl_prim phonopy_nacl.yaml -w=incoherent-dos --pdos=Na --no-widget --npts=10 --npts-min=10 --q-spacing=1": {
         "x_ticklabels": [
             "0.0",
             "0.5",

--- a/tests_and_analysis/test/script_tests/test_powder_map.py
+++ b/tests_and_analysis/test/script_tests/test_powder_map.py
@@ -44,7 +44,7 @@ powder_map_params = [
     [graphite_fc_file, '--asr', *quick_calc_params],
     [graphite_fc_file, '--asr=realspace', '--dipole-parameter=0.75',
      *quick_calc_params],
-    [nacl_prim_fc_file, '-w=incoherent-dos', '--pdos=Na',
+    [nacl_prim_fc_file, '-w=incoherent-dos', '--pdos=Na', '--no-widget',
      *quick_calc_params],
     [nacl_prim_fc_file, '-w=coherent-plus-incoherent-dos', '--pdos=Cl',
      *quick_calc_params]]


### PR DESCRIPTION
After playing with the powder-map script for the workshop, I was finding it painful to have to regenerate plots just to change the intensities, so I've added some widgets to allow putting in min/max intensity without having to recalculate all the q-points. It seems to work well enough (although I can't get it to work via a Jupyter notebook).

I've tried for a while and couldn't find a good way to test it yet, but maybe that could be for another PR, its only on `euphonic-powder-map` and can be disabled so any damage should be minimal.