### PR TITLE
Make plot kwargs more consistent

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,6 +18,15 @@
   - Internally, plot theming has been adjusted to rely on Matplotlib
     style contexts. This means user changes and style context are more
     likely to be respected.
+  - Additional aliases for plot arguments in the command-line tools have
+    been added, for example either ``--x-label`` or ``--xlabel`` can be used.
+
+- Changes:
+
+  - ``x_label``, ``y_label``, ``y_min`` and ``y_max`` in ``euphonic.plot``
+    functions have been deprecated in favour of ``xlabel``, ``ylabel``,
+    ``ymin`` and ``ymax`` respectively, to match the Matplotlib arguments
+    they refer to, and to match other arguments like ``vmin``, ``vmax``.
 
 `v0.6.2 <https://github.com/pace-neutrons/Euphonic/compare/v0.6.1...v0.6.2>`_
 ------

--- a/doc/source/styling.rst
+++ b/doc/source/styling.rst
@@ -34,7 +34,7 @@ Matplotlib style sheet.
 `A number of popular styles are predefined in Matplotlib <https://matplotlib.org/stable/gallery/style_sheets/style_sheets_reference.html>`_
 and may be accessed by name, e.g.::
 
-  euphonic-dos --style seaborn quartz.castep_bin
+  euphonic-dos --pdos --style seaborn quartz.castep_bin
 
 will yield a plot on a grey background with white gridlines.
 

--- a/euphonic/cli/dispersion.py
+++ b/euphonic/cli/dispersion.py
@@ -10,7 +10,7 @@ from euphonic import Spectrum1D
 from .utils import (load_data_from_file, get_args, _bands_from_force_constants,
                     _compose_style,
                     _get_q_distance, matplotlib_save_or_show, _get_cli_parser,
-                    _calc_modes_kwargs)
+                    _calc_modes_kwargs, _plot_label_kwargs)
 
 
 def main(params: Optional[List[str]] = None) -> None:
@@ -40,14 +40,8 @@ def main(params: Optional[List[str]] = None) -> None:
 
     spectrum = modes.get_dispersion()
 
-    if args.y_label is None:
-        y_label = f"Energy / {spectrum.y_data.units:~P}"
-    else:
-        y_label = args.y_label
-    if args.x_label is None:
-        x_label = ""
-    else:
-        x_label = args.x_label
+    plot_label_kwargs = _plot_label_kwargs(
+        args, default_ylabel=f"Energy / {spectrum.y_data.units:~P}")
 
     if x_tick_labels:
         spectrum.x_tick_labels = x_tick_labels
@@ -59,10 +53,9 @@ def main(params: Optional[List[str]] = None) -> None:
 
     with matplotlib.style.context(style):
         _ = plot_1d(spectra,
-                    title=args.title,
-                    x_label=x_label,
-                    y_label=y_label,
-                    y_min=args.e_min, y_max=args.e_max)
+                    y_min=args.e_min,
+                    y_max=args.e_max,
+                    **plot_label_kwargs)
         matplotlib_save_or_show(save_filename=args.save_to)
 
 

--- a/euphonic/cli/dispersion.py
+++ b/euphonic/cli/dispersion.py
@@ -53,8 +53,8 @@ def main(params: Optional[List[str]] = None) -> None:
 
     with matplotlib.style.context(style):
         _ = plot_1d(spectra,
-                    y_min=args.e_min,
-                    y_max=args.e_max,
+                    ymin=args.e_min,
+                    ymax=args.e_max,
                     **plot_label_kwargs)
         matplotlib_save_or_show(save_filename=args.save_to)
 

--- a/euphonic/cli/dos.py
+++ b/euphonic/cli/dos.py
@@ -11,7 +11,7 @@ from .utils import (load_data_from_file, get_args, matplotlib_save_or_show,
                     _calc_modes_kwargs, _compose_style,
                     _get_cli_parser, _get_energy_bins,
                     _grid_spec_from_args, _get_pdos_weighting,
-                    _arrange_pdos_groups)
+                    _arrange_pdos_groups, _plot_label_kwargs)
 
 
 def main(params: Optional[List[str]] = None) -> None:
@@ -67,19 +67,12 @@ def main(params: Optional[List[str]] = None) -> None:
     if args.energy_broadening and not args.adaptive:
         dos = dos.broaden(args.energy_broadening*ebins.units, shape=args.shape)
 
-    if args.x_label is None:
-        x_label = f"Energy / {dos.x_data.units:~P}"
-    else:
-        x_label = args.x_label
-    if args.y_label is None:
-        y_label = ""
-    else:
-        y_label = args.y_label
+    plot_label_kwargs = _plot_label_kwargs(
+        args, default_xlabel=f"Energy / {dos.x_data.units:~P}")
 
     style = _compose_style(user_args=args, base=[base_style])
     with matplotlib.style.context(style):
-        _ = plot_1d(dos, title=args.title, x_label=x_label, y_label=y_label,
-                    y_min=0)
+        _ = plot_1d(dos, y_min=0, **plot_label_kwargs)
         matplotlib_save_or_show(save_filename=args.save_to)
 
 

--- a/euphonic/cli/dos.py
+++ b/euphonic/cli/dos.py
@@ -72,7 +72,7 @@ def main(params: Optional[List[str]] = None) -> None:
 
     style = _compose_style(user_args=args, base=[base_style])
     with matplotlib.style.context(style):
-        _ = plot_1d(dos, y_min=0, **plot_label_kwargs)
+        _ = plot_1d(dos, ymin=0, **plot_label_kwargs)
         matplotlib_save_or_show(save_filename=args.save_to)
 
 

--- a/euphonic/cli/intensity_map.py
+++ b/euphonic/cli/intensity_map.py
@@ -10,7 +10,7 @@ import euphonic.plot
 from euphonic.util import get_qpoint_labels
 from euphonic.styles import base_style
 from .utils import (_bands_from_force_constants, _calc_modes_kwargs,
-                    _compose_style,
+                    _compose_style, _plot_label_kwargs,
                     get_args, _get_debye_waller,
                     _get_energy_bins, _get_q_distance,
                     _get_cli_parser, load_data_from_file,
@@ -78,14 +78,8 @@ def main(params: Optional[List[str]] = None) -> None:
             shape=args.shape)
 
     print("Plotting figure")
-    if args.y_label is None:
-        y_label = f"Energy / {spectrum.y_data.units:~P}"
-    else:
-        y_label = args.y_label
-    if args.x_label is None:
-        x_label = ""
-    else:
-        x_label = args.x_label
+    plot_label_kwargs = _plot_label_kwargs(
+        args, default_ylabel=f"Energy / {spectrum.y_data.units:~P}")
 
     if x_tick_labels:
         spectrum.x_tick_labels = x_tick_labels
@@ -98,10 +92,9 @@ def main(params: Optional[List[str]] = None) -> None:
     with matplotlib.style.context(style):
 
         euphonic.plot.plot_2d(spectra,
-                              vmin=args.v_min, vmax=args.v_max,
-                              x_label=x_label,
-                              y_label=y_label,
-                              title=args.title)
+                              vmin=args.vmin,
+                              vmax=args.vmax,
+                              **plot_label_kwargs)
         matplotlib_save_or_show(save_filename=args.save_to)
 
 

--- a/euphonic/cli/powder_map.py
+++ b/euphonic/cli/powder_map.py
@@ -10,7 +10,7 @@ from euphonic.cli.utils import (_calc_modes_kwargs, _compose_style,
                                 _get_cli_parser,
                                 _get_debye_waller, _get_energy_bins,
                                 _get_q_distance, _get_pdos_weighting,
-                                _arrange_pdos_groups)
+                                _arrange_pdos_groups, _plot_label_kwargs)
 from euphonic.cli.utils import (force_constants_from_file, get_args,
                                 matplotlib_save_or_show)
 import euphonic.plot
@@ -155,14 +155,9 @@ def main(params: Optional[List[str]] = None) -> None:
             shape=args.shape)
 
     print(f"Plotting figure: max intensity {np.max(spectrum.z_data):~P}")
-    if args.y_label is None:
-        y_label = f"Energy / {spectrum.y_data.units:~P}"
-    else:
-        y_label = args.y_label
-    if args.x_label is None:
-        x_label = f"|q| / {q_min.units:~P}"
-    else:
-        x_label = args.x_label
+    plot_label_kwargs = _plot_label_kwargs(
+        args, default_xlabel=f"|q| / {q_min.units:~P}",
+        default_ylabel=f"Energy / {spectrum.y_data.units:~P}")
 
     if args.disable_widgets:
         base = [base_style]
@@ -171,10 +166,9 @@ def main(params: Optional[List[str]] = None) -> None:
     style = _compose_style(user_args=args, base=base)
     with matplotlib.style.context(style):
         fig = euphonic.plot.plot_2d(spectrum,
-                                    vmin=args.v_min, vmax=args.v_max,
-                                    x_label=x_label,
-                                    y_label=y_label,
-                                    title=args.title)
+                                    vmin=args.vmin,
+                                    vmax=args.vmax,
+                                    **plot_label_kwargs)
 
         if args.disable_widgets is False:
             # TextBox only available from mpl 2.1.0

--- a/euphonic/cli/utils.py
+++ b/euphonic/cli/utils.py
@@ -417,12 +417,12 @@ def _plot_label_kwargs(args: Namespace, default_xlabel: str = '',
     """Collect title/label arguments that can be passed to plot_nd
     """
     plot_kwargs = dict(title=args.title,
-                       x_label=default_xlabel,
-                       y_label=default_ylabel)
+                       xlabel=default_xlabel,
+                       ylabel=default_ylabel)
     if args.ylabel is not None:
-        plot_kwargs['y_label'] = args.ylabel
+        plot_kwargs['ylabel'] = args.ylabel
     if args.xlabel is not None:
-        plot_kwargs['x_label'] = args.xlabel
+        plot_kwargs['xlabel'] = args.xlabel
     return plot_kwargs
 
 

--- a/euphonic/cli/utils.py
+++ b/euphonic/cli/utils.py
@@ -412,6 +412,20 @@ def _arrange_pdos_groups(pdos: Spectrum1DCollection,
     return dos
 
 
+def _plot_label_kwargs(args: Namespace, default_xlabel: str = '',
+                       default_ylabel: str = '') -> Dict[str, str]:
+    """Collect title/label arguments that can be passed to plot_nd
+    """
+    plot_kwargs = dict(title=args.title,
+                       x_label=default_xlabel,
+                       y_label=default_ylabel)
+    if args.ylabel is not None:
+        plot_kwargs['y_label'] = args.ylabel
+    if args.xlabel is not None:
+        plot_kwargs['x_label'] = args.xlabel
+    return plot_kwargs
+
+
 def _calc_modes_kwargs(args: Namespace) -> Dict[str, Any]:
     """Collect arguments that can be passed to calculate_qpoint_phonon_modes()
     """
@@ -525,7 +539,7 @@ def _get_cli_parser(features: Collection[str] = {}
             help=('Force use of compiled C extension when computing '
                   'phonon frequencies/eigenvectors (or raise error).'))
         use_c.add_argument(
-            '--disable-c', action='store_false', dest='use_c',
+            '--disable-c', action='store_false', dest='use_c', default=None,
             help=('Do not attempt to use compiled C extension when computing '
                   'phonon frequencies/eigenvectors.'))
         sections['performance'].add_argument(
@@ -636,10 +650,10 @@ def _get_cli_parser(features: Collection[str] = {}
             help='Save resulting plot to a file with this name')
         section.add_argument('--title', type=str, default='',
                              help='Plot title')
-        section.add_argument('--x-label', type=str, default=None,
-                             dest='x_label', help='Plot x-axis label')
-        section.add_argument('--y-label', type=str, default=None,
-                             dest='y_label', help='Plot y-axis label')
+        section.add_argument('--x-label', '--xlabel', type=str, default=None,
+                             dest='xlabel', help='Plot x-axis label')
+        section.add_argument('--y-label', '--ylabel', type=str, default=None,
+                             dest='ylabel', help='Plot y-axis label')
         section.add_argument('--style', type=str, nargs='+',
                              help='Matplotlib styles (name or file)')
         section.add_argument('--no-base-style', action='store_true',
@@ -651,17 +665,20 @@ def _get_cli_parser(features: Collection[str] = {}
                                    'known to Matplotlib. font-family will be '
                                    'set to sans-serif; it doesn\'t matter if)'
                                    'the font is actually sans-serif.'))
-        section.add_argument('--fontsize', type=float, default=None,
+        section.add_argument('--font-size', '--fontsize', type=float,
+                             default=None, dest='fontsize',
                              help='Set base font size in pt.')
-        section.add_argument('--figsize', type=float, nargs=2, default=None,
+        section.add_argument('--fig-size', '--figsize', type=float, nargs=2,
+                             default=None, dest='figsize',
                              help='Figure canvas size in FIGSIZE-UNITS')
-        section.add_argument('--figsize-unit', type=str, default='cm',
-                             dest='figsize_unit',
+        section.add_argument('--fig-size-unit', '--figsize-unit', type=str,
+                             default='cm', dest='figsize_unit',
                              help='Unit of length for --figsize')
 
     if ('plotting' in features) and not ('map' in features):
         section = sections['plotting']
-        section.add_argument('--linewidth', type=float, default=None,
+        section.add_argument('--line-width', '--linewidth', type=float,
+                             default=None, dest='linewidth',
                              help='Set line width in pt.')
 
     if {'ebins', 'q-e'}.intersection(features):
@@ -726,13 +743,14 @@ def _get_cli_parser(features: Collection[str] = {}
 
     if 'map' in features:
         sections['plotting'].add_argument(
-            '--v-min', type=float, default=None, dest='v_min',
+            '--v-min', '--vmin', type=float, default=None, dest='vmin',
             help='Minimum of data range for colormap.')
         sections['plotting'].add_argument(
-            '--v-max', type=float, default=None, dest='v_max',
+            '--v-max', '--vmax', type=float, default=None, dest='vmax',
             help='Maximum of data range for colormap.')
         sections['plotting'].add_argument(
-            '--cmap', type=str, default=None, help='Matplotlib colormap')
+            '--c-map', '--cmap', type=str, default=None, dest='cmap',
+            help='Matplotlib colormap')
 
     if 'btol' in features:
         sections['q'].add_argument(

--- a/euphonic/force_constants.py
+++ b/euphonic/force_constants.py
@@ -18,7 +18,8 @@ from euphonic.io import (_obj_to_json_file, _obj_from_json_file,
 from euphonic.readers import castep, phonopy
 from euphonic.util import (is_gamma, get_all_origins,
                            mode_gradients_to_widths,
-                           _get_supercell_relative_idx)
+                           _get_supercell_relative_idx,
+                           _deprecation_warn)
 from euphonic import (ureg, Quantity, Crystal, QpointPhononModes,
                       QpointFrequencies)
 
@@ -203,9 +204,8 @@ class ForceConstants:
             euphonic-optimise-dipole-parameter program for help on choosing
             a good dipole_parameter.
         eta_scale
-
             .. deprecated:: 0.6.0
-            Please use dipole_parameter instead
+               Please use dipole_parameter instead
         splitting
             Whether to calculate the LO-TO splitting at the gamma
             points. Only applied if dipole is True and the Born charges
@@ -242,15 +242,14 @@ class ForceConstants:
             widths and used in adaptive broadening for DOS. For details
             on how these are calculated see the Notes section
         return_mode_widths
-
             .. deprecated:: 0.5.2
-            The mode widths as calculated were only applicable for
-            adaptive broadening of DOS, this argument will be removed
-            in favour of the more flexible return_mode_gradients,
-            which will allow the calculation of direction-specific
-            mode widths in the future, for example. The mode widths
-            can still be obtained from the mode gradients using
-            euphonic.util.mode_gradients_to_widths
+               The mode widths as calculated were only applicable for
+               adaptive broadening of DOS, this argument will be removed
+               in favour of the more flexible return_mode_gradients,
+               which will allow the calculation of direction-specific
+               mode widths in the future, for example. The mode widths
+               can still be obtained from the mode gradients using
+               euphonic.util.mode_gradients_to_widths
 
         Returns
         -------
@@ -483,10 +482,7 @@ class ForceConstants:
                 category=DeprecationWarning, stacklevel=3)
             return_mode_gradients = True
         if eta_scale != 1.0:
-            warnings.warn(
-                'eta_scale has been deprecated and will be removed '
-                'in a future release. Please use dipole_parameter instead ',
-                category=DeprecationWarning, stacklevel=3)
+            _deprecation_warn('eta_scale', 'dipole_parameter', stacklevel=4)
             dipole_parameter = eta_scale
         # Check weights is of appropriate type and shape, to avoid doing all
         # the interpolation only for it to fail creating QpointPhononModes

--- a/euphonic/plot.py
+++ b/euphonic/plot.py
@@ -17,6 +17,7 @@ import numpy as np
 
 from euphonic import Quantity
 from euphonic.spectra import Spectrum1D, Spectrum1DCollection, Spectrum2D
+from euphonic.util import _deprecation_warn
 
 
 def plot_1d_to_axis(spectra: Union[Spectrum1D, Spectrum1DCollection],
@@ -101,11 +102,15 @@ def plot_1d(spectra: Union[Spectrum1D,
                            Sequence[Spectrum1D],
                            Sequence[Spectrum1DCollection]],
             title: str = '',
+            xlabel: str = '',
+            ylabel: str = '',
+            ymin: float = None,
+            ymax: float = None,
+            labels: Optional[Sequence[str]] = None,
             x_label: str = '',
             y_label: str = '',
             y_min: float = None,
             y_max: float = None,
-            labels: Optional[Sequence[str]] = None,
             **line_kwargs) -> Figure:
     """
     Creates a Matplotlib figure for a Spectrum1D object, or multiple
@@ -134,15 +139,16 @@ def plot_1d(spectra: Union[Spectrum1D,
 
     title
         Plot title
-    x_label
+    xlabel
         X-axis label
-    y_label
+    ylabel
         Y-axis label
-    y_min
+    ymin
         Minimum value on the y-axis. Can be useful to set y-axis minimum
         to 0 for energy, for example.
-    y_max
+    ymax
         Maximum value on the y-axis.
+
     labels
         A sequence of labels corresponding to the sequence of lines in
         spectra, used to label each line. If this is None, the
@@ -150,6 +156,18 @@ def plot_1d(spectra: Union[Spectrum1D,
         spectra.metadata['line_data'][i]['label']
         (Spectrum1DCollection) will be used. To disable labelling for a
         specific line, pass an empty string.
+    x_label
+        .. deprecated:: 0.6.3
+           Please use xlabel instead
+    y_label
+        .. deprecated:: 0.6.3
+           Please use ylabel instead
+    y_min
+        .. deprecated:: 0.6.3
+           Please use ymin instead
+    y_max
+        .. deprecated:: 0.6.3
+           Please use ymax instead
     **line_kwargs
         matplotlib.line.Line2D properties, optional
         Used in the axes.plot command to specify properties like
@@ -160,6 +178,18 @@ def plot_1d(spectra: Union[Spectrum1D,
     fig : matplotlib.figure.Figure
 
     """
+    if x_label:
+        _deprecation_warn('x_label', 'xlabel')
+        xlabel = x_label
+    if y_label:
+        _deprecation_warn('y_label', 'ylabel')
+        ylabel = y_label
+    if y_min is not None:
+        _deprecation_warn('y_min', 'ymin')
+        ymin = y_min
+    if y_max is not None:
+        _deprecation_warn('y_max', 'ymax')
+        ymax = y_max
     if isinstance(spectra, (Spectrum1D, Spectrum1DCollection)):
         spectra = (spectra,)
     else:
@@ -183,14 +213,14 @@ def plot_1d(spectra: Union[Spectrum1D,
             leg_handles, leg_labels = ax.get_legend_handles_labels()
             if len(leg_labels) > 0:
                 ax.legend()
-        ax.set_ylim(bottom=y_min, top=y_max)
+        ax.set_ylim(bottom=ymin, top=ymax)
 
     # Add an invisible large axis for common labels
     ax = fig.add_subplot(111, frameon=False)
     ax.grid(False)
     ax.tick_params(labelcolor="none", bottom=False, left=False)
-    ax.set_xlabel(x_label)
-    ax.set_ylabel(y_label)
+    ax.set_xlabel(xlabel)
+    ax.set_ylabel(ylabel)
 
     fig.suptitle(title)
     return fig
@@ -250,7 +280,11 @@ def plot_2d(spectra: Union[Spectrum2D, Sequence[Spectrum2D]],
             vmin: Optional[float] = None,
             vmax: Optional[float] = None,
             cmap: Optional[Union[str, Colormap]] = None,
-            title: str = '', x_label: str = '', y_label: str = '') -> Figure:
+            title: str = '',
+            xlabel: str = '',
+            ylabel: str = '',
+            x_label: str = '',
+            y_label: str = '') -> Figure:
     """
     Creates a Matplotlib figure for a Spectrum2D object
 
@@ -269,16 +303,28 @@ def plot_2d(spectra: Union[Spectrum2D, Sequence[Spectrum2D]],
         Which colormap to use, see Matplotlib docs
     title
         Set a title for the Figure.
-    x_label
+    xlabel
         X-axis label
-    y_label
+    ylabel
         Y-axis label
+    x_label
+        .. deprecated:: 0.6.3
+           Please use xlabel instead
+    y_label
+        .. deprecated:: 0.6.3
+           Please use ylabel instead
 
     Returns
     -------
     fig : matplotlib.figure.Figure
         The Figure instance
     """
+    if x_label:
+        _deprecation_warn('x_label', 'xlabel')
+        xlabel = x_label
+    if y_label:
+        _deprecation_warn('y_label', 'ylabel')
+        ylabel = y_label
 
     # Wrap a bare spectrum in list so treatment is consistent with sequences
     if isinstance(spectra, Spectrum2D):
@@ -316,8 +362,8 @@ def plot_2d(spectra: Union[Spectrum2D, Sequence[Spectrum2D]],
     ax = fig.add_subplot(111, frameon=False)
     ax.grid(False)
     ax.tick_params(labelcolor="none", bottom=False, left=False)
-    ax.set_xlabel(x_label)
-    ax.set_ylabel(y_label)
+    ax.set_xlabel(xlabel)
+    ax.set_ylabel(ylabel)
 
     fig.suptitle(title)
 

--- a/euphonic/util.py
+++ b/euphonic/util.py
@@ -570,3 +570,13 @@ def _get_supercell_relative_idx(cell_origins: np.ndarray,
         if np.any(dist_min > 16*sys.float_info.epsilon):
             raise Exception('Couldn\'t find supercell relative index')
     return sc_relative_index
+
+
+def _deprecation_warn(old_arg: str, new_arg: str, stacklevel: int = 3):
+    """
+    Emits a deprecation warning with a generic message
+    """
+    warnings.warn(f'{old_arg} has been deprecated and will be removed '
+                  f'in a future release. Please use {new_arg} instead.',
+                  category=DeprecationWarning,
+                  stacklevel=stacklevel)

--- a/tests_and_analysis/test/data/script_data/intensity-map.json
+++ b/tests_and_analysis/test/data/script_data/intensity-map.json
@@ -571,7 +571,7 @@
             0.0
         ]
     },
-    "graphite graphite.castep_bin --v-min=0 --v-max=1e-10": {
+    "graphite graphite.castep_bin --vmin=0 --vmax=1e-10": {
         "title": "",
         "x_label": "",
         "y_label": "Energy / meV",
@@ -2858,7 +2858,7 @@
             0.0
         ]
     },
-    "graphite graphite.castep_bin -w dos --y-label=DOS --title=DOS TITLE": {
+    "graphite graphite.castep_bin -w dos --ylabel=DOS --title=DOS TITLE": {
         "title": "DOS TITLE",
         "x_label": "",
         "y_label": "DOS",
@@ -3430,7 +3430,7 @@
             0.0
         ]
     },
-    "graphite graphite.castep_bin --e-min=50 -u=cm^-1 --x-label=wavenumber": {
+    "graphite graphite.castep_bin --e-min=50 -u=cm^-1 --xlabel=wavenumber": {
         "title": "",
         "x_label": "wavenumber",
         "y_label": "Energy / 1/cm",

--- a/tests_and_analysis/test/data/script_data/powder-map.json
+++ b/tests_and_analysis/test/data/script_data/powder-map.json
@@ -1306,7 +1306,7 @@
             0.5664594179188575
         ]
     },
-    "NaCl_prim phonopy_nacl.yaml --weighting=coherent --cmap=bone --npts=10 --npts-min=10 --q-spacing=1": {
+    "NaCl_prim phonopy_nacl.yaml --weighting=coherent --c-map=bone --npts=10 --npts-min=10 --q-spacing=1": {
         "x_ticklabels": [
             "0.0",
             "0.5",

--- a/tests_and_analysis/test/euphonic_test/test_plot.py
+++ b/tests_and_analysis/test/euphonic_test/test_plot.py
@@ -239,9 +239,10 @@ class TestPlot1D:
             plot_1d([spec1, spec2])
 
     @pytest.mark.parametrize('kwargs, expected_labels',
-        [({'labels': ['band A'], 'x_label': 'X_LABEL', 'y_label': 'Y_LABEL',
+        [({'labels': ['band A'], 'xlabel': 'X_LABEL', 'ylabel': 'Y_LABEL',
            'title': 'TITLE'},
          ['band A']),
+         ({'ymin': 0, 'ymax': 1.5}, None),
          ({},
           None)])
     def test_plot_multi_segments(
@@ -260,22 +261,34 @@ class TestPlot1D:
         for ax in fig.axes[1:]:
             assert ax.get_legend() == None
 
-        if 'x_label' in kwargs:
-            assert fig.axes[-1].get_xlabel() == kwargs['x_label']
-        if 'y_label' in kwargs:
-            assert fig.axes[-1].get_ylabel() == kwargs['y_label']
+        if 'xlabel' in kwargs:
+            assert fig.axes[-1].get_xlabel() == kwargs['xlabel']
+        if 'ylabel' in kwargs:
+            assert fig.axes[-1].get_ylabel() == kwargs['ylabel']
         if 'title' in kwargs:
             suptitle.assert_called_once_with(kwargs['title'])
 
         for ax in fig.axes[:-1]:
-            if 'y_min' in kwargs:
-                assert ax.get_ylim()[0] == pytest.approx(kwargs.get('y_min'))
-            if 'y_max' in kwargs:
-                assert ax.get_ylim()[0] == pytest.approx(kwargs.get('y_max'))
+            if 'ymin' in kwargs:
+                assert ax.get_ylim()[0] == pytest.approx(kwargs.get('ymin'))
+            if 'ymax' in kwargs:
+                assert ax.get_ylim()[1] == pytest.approx(kwargs.get('ymax'))
 
     def test_plot_with_incorrect_labels_raises_valueerror(self, band_segments):
         with pytest.raises(ValueError):
             fig = plot_1d(band_segments, labels=['Band A', 'Band B'])
+
+    @pytest.mark.parametrize('kwargs', [
+        {'y_label': 'Y_LABEL'},
+        {'x_label': 'X_LABEL'},
+        {'y_min': 0},
+        {'y_max': 1.5}])
+    def test_deprecated_kwargs_raise_deprecation_warning(
+            self, kwargs):
+        spec1d = Spectrum1D([0., 1., 2.] * ureg('meV'),
+                            [1., 2., 1.] * ureg('angstrom^-2'))
+        with pytest.warns(DeprecationWarning):
+            plot_1d(spec1d, **kwargs)
 
 
 @pytest.mark.unit
@@ -319,8 +332,8 @@ class TestPlot2D:
 
     @pytest.mark.parametrize('kwargs',
                              [{'title': 'TITLE',
-                               'x_label': 'X_LABEL',
-                               'y_label': 'Y_LABEL'},
+                               'xlabel': 'X_LABEL',
+                               'ylabel': 'Y_LABEL'},
                               {'vmin': 1.,
                                'vmax': 2.,
                                'cmap': 'magma'}])
@@ -341,14 +354,15 @@ class TestPlot2D:
             if attr in kwargs:
                 assert getattr(norm, attr) == pytest.approx(kwargs[attr])
 
-        if 'x_label' in kwargs:
-            assert fig.axes[-1].get_xlabel() == kwargs['x_label']
-        if 'y_label' in kwargs:
-            assert fig.axes[-1].get_ylabel() == kwargs['y_label']
+        if 'xlabel' in kwargs:
+            assert fig.axes[-1].get_xlabel() == kwargs['xlabel']
+        if 'ylabel' in kwargs:
+            assert fig.axes[-1].get_ylabel() == kwargs['ylabel']
         if 'title' in kwargs:
             suptitle.assert_called_once_with(kwargs['title'])
 
         plt.close(fig)
+
 
     def test_plot_multi(self, mocker, spectrum):
         core = self.mock_core(mocker)
@@ -360,6 +374,14 @@ class TestPlot2D:
 
         assert call_1[0][0] == spectra[0]
         assert call_2[0][0] == spectra[1]
+
+    @pytest.mark.parametrize('kwargs', [
+        {'y_label': 'Y_LABEL'},
+        {'x_label': 'X_LABEL'}])
+    def test_deprecated_kwargs_raise_deprecation_warning(
+            self, spectrum, kwargs):
+        with pytest.warns(DeprecationWarning):
+            euphonic.plot.plot_2d(spectrum, **kwargs)
 
 
 @pytest.mark.unit

--- a/tests_and_analysis/test/script_tests/test_intensity_map.py
+++ b/tests_and_analysis/test/script_tests/test_intensity_map.py
@@ -25,10 +25,10 @@ intensity_map_output_file = os.path.join(get_script_test_data_path(),
                                          'intensity-map.json')
 intensity_map_params = [
     [graphite_fc_file],
-    [graphite_fc_file, '--v-min=0', '--v-max=1e-10'],
+    [graphite_fc_file, '--vmin=0', '--vmax=1e-10'],
     [graphite_fc_file, '--energy-unit=meV'],
-    [graphite_fc_file, '-w', 'dos', '--y-label=DOS', '--title=DOS TITLE'],
-    [graphite_fc_file, '--e-min=50', '-u=cm^-1', '--x-label=wavenumber'],
+    [graphite_fc_file, '-w', 'dos', '--ylabel=DOS', '--title=DOS TITLE'],
+    [graphite_fc_file, '--e-min=50', '-u=cm^-1', '--xlabel=wavenumber'],
     [graphite_fc_file, '--e-min=-100', '--e-max=1000', '--ebins=100',
      '--energy-unit=cm^-1'],
     [graphite_fc_file, '--energy-broadening=2e-3', '-u=eV'],

--- a/tests_and_analysis/test/script_tests/test_powder_map.py
+++ b/tests_and_analysis/test/script_tests/test_powder_map.py
@@ -26,7 +26,7 @@ powder_map_params = [
     [nacl_prim_fc_file, '--temperature=1000', *quick_calc_params],
     [nacl_prim_fc_file, '--v-min=0', '--v-max=1e-10', *quick_calc_params],
     [nacl_prim_fc_file, '--energy-unit=meV', *quick_calc_params],
-    [nacl_prim_fc_file, '--weighting=coherent', '--cmap=bone',
+    [nacl_prim_fc_file, '--weighting=coherent', '--c-map=bone',
      *quick_calc_params],
     [graphite_fc_file, '-w', 'dos', '--y-label=DOS', '--title=DOS TITLE',
      *quick_calc_params],

--- a/tests_and_analysis/test/script_tests/test_styling.py
+++ b/tests_and_analysis/test/script_tests/test_styling.py
@@ -58,17 +58,21 @@ class TestDOSStyling:
         # Ensure figures are closed
         matplotlib.pyplot.close('all')
 
-    def test_dos_styling(self, inject_mocks):
-        nah_phonon_file = get_castep_path('NaH', 'NaH.phonon')
-
-        params = [nah_phonon_file,
-                  '--style=dark_background',
-                  '--linewidth=5.',
-                  '--fontsize=11.',
-                  '--figsize', '4', '4',
-                  '--figsize-unit', 'inch']
-
-        euphonic.cli.dos.main(params=params)
+    @pytest.mark.parametrize('dos_args',
+        [[get_castep_path('NaH', 'NaH.phonon'),
+          '--style=dark_background',
+          '--linewidth=5.',
+          '--fontsize=11.',
+          '--figsize', '4', '4',
+          '--figsize-unit', 'inch'],
+         [get_castep_path('NaH', 'NaH.phonon'),
+          '--style=dark_background',
+          '--line-width=5.',
+          '--font-size=11.',
+          '--fig-size', '4', '4',
+          '--fig-size-unit', 'inch']])
+    def test_dos_styling(self, inject_mocks, dos_args):
+        euphonic.cli.dos.main(params=dos_args)
 
         fig = matplotlib.pyplot.gcf()
 


### PR DESCRIPTION
Addresses #180

Overall it was decided:
- Plot functions in the API should use Matplotlib-like arguments for consistency
- CL tools should allow both Python-like (`--x-label`) and Matplotlib-like (`--xlabel`) arguments for a good balance between consistency, readability and usability