### PR TITLE
Test optional dependencies

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -37,11 +37,11 @@ jobs:
         if: startsWith(matrix.os, 'ubuntu')
         with:
           project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
-          coverage-reports: tests_and_analysis/test/reports/coverage.xml
+          coverage-reports: tests_and_analysis/test/reports/coverage*.xml
       - uses: codecov/codecov-action@v2
         if: startsWith(matrix.os, 'ubuntu')
         with:
-          files: tests_and_analysis/test/reports/coverage.xml
+          files: tests_and_analysis/test/reports/coverage*.xml
 
   publish-test-results:
     needs: test

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,0 @@
-[pytest]
-markers =
-    phonopy_reader: requires euphonic[phonopy_reader] extra to be installed

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+markers =
+    phonopy_reader: requires euphonic[phonopy_reader] extra to be installed

--- a/tests_and_analysis/test/euphonic_test/test_calculate_structure_factor.py
+++ b/tests_and_analysis/test/euphonic_test/test_calculate_structure_factor.py
@@ -20,68 +20,50 @@ from tests_and_analysis.test.euphonic_test.test_structure_factor import (
 @pytest.mark.integration
 class TestCalculateStructureFactorFromForceConstants:
 
-    def get_multithreaded_kwargs(self, n_threads):
-        kwargs = {}
+    def get_quartz_fc():
+        return ForceConstants.from_castep(
+            get_castep_path('quartz', 'quartz.castep_bin'))
+
+    def get_si2_fc():
+        return ForceConstants.from_castep(
+            get_castep_path('Si2-sc-skew', 'Si2-sc-skew.castep_bin'))
+
+
+    tol_kwargs = {'sf_atol': 3e-3,
+                  'sf_rtol': 3e-4,
+                  'freq_atol': 1e-4,
+                  'freq_rtol': 3e-4,
+                  'freq_gamma_atol': 0.55,
+                  'sf_gamma_atol': 3e2}
+
+    @pytest.mark.parametrize(
+        'material, fc, qpt_ph_modes_args, dw_file, expected_sf_file', [
+            ('quartz', get_quartz_fc(), (get_test_qpts('split'), {}),
+             'quartz_666_0K_debye_waller.json',
+             'quartz_0K_fc_structure_factor.json'),
+            ('quartz', get_quartz_fc(), (get_test_qpts('split'), {}),
+             'quartz_666_300K_debye_waller.json',
+             'quartz_300K_fc_structure_factor.json'),
+            ('quartz', get_quartz_fc(), (get_test_qpts('split'), {}),
+             None,
+             'quartz_fc_structure_factor.json'),
+            ('Si2-sc-skew', get_si2_fc(), (get_test_qpts(), {}),
+             'Si2-sc-skew_666_300K_debye_waller.json',
+             'Si2-sc-skew_300K_fc_structure_factor.json'),
+            ('quartz', get_quartz_fc(),
+             (get_test_qpts('split'), {'asr': 'reciprocal'}),
+             'quartz_666_300K_debye_waller.json',
+             'quartz_recip_asr_300K_fc_structure_factor.json')])
+    @pytest.mark.parametrize('n_threads', [0, 1, 2])
+    def test_calculate_structure_factor(self, material, fc, qpt_ph_modes_args,
+                                        dw_file, expected_sf_file, n_threads):
+        args, kwargs = qpt_ph_modes_args
         if n_threads == 0:
             kwargs['use_c'] = False
         else:
             kwargs['use_c'] = True
             kwargs['n_threads'] = n_threads
-        return kwargs
-
-    @pytest.fixture(params=[0, 1, 2])
-    def get_quartz_qpt_ph_modes_recip(self, request):
-        fc = ForceConstants.from_castep(
-            get_castep_path('quartz', 'quartz.castep_bin'))
-        kwargs = self.get_multithreaded_kwargs(request.param)
-        return fc.calculate_qpoint_phonon_modes(
-            get_test_qpts('split'), asr='reciprocal', **kwargs)
-
-    @pytest.fixture(params=[0, 1, 2])
-    def get_quartz_qpt_ph_modes(self, request):
-        fc = ForceConstants.from_castep(
-            get_castep_path('quartz', 'quartz.castep_bin'))
-        kwargs = self.get_multithreaded_kwargs(request.param)
-        return fc.calculate_qpoint_phonon_modes(
-            get_test_qpts('split'), **kwargs)
-
-    @pytest.fixture(params=[0, 1, 2])
-    def get_si2_qpt_ph_modes(self, request):
-        fc = ForceConstants.from_castep(
-            get_castep_path('Si2-sc-skew', 'Si2-sc-skew.castep_bin'))
-        kwargs = self.get_multithreaded_kwargs(request.param)
-        return fc.calculate_qpoint_phonon_modes(get_test_qpts(), **kwargs)
-
-    @pytest.fixture(params=[0, 1, 2])
-    def get_cahgo2_qpt_ph_modes(self, request):
-        fc = ForceConstants.from_phonopy(
-            path=get_phonopy_path('CaHgO2', ''),
-            summary_name='mp-7041-20180417.yaml')
-        kwargs = self.get_multithreaded_kwargs(request.param)
-        return fc.calculate_qpoint_phonon_modes(get_test_qpts(), **kwargs)
-
-    @pytest.mark.parametrize(
-        'material, qpt_ph_modes, dw_file, expected_sf_file', [
-            ('quartz', pytest.lazy_fixture('get_quartz_qpt_ph_modes'),
-             'quartz_666_0K_debye_waller.json',
-             'quartz_0K_fc_structure_factor.json'),
-            ('quartz', pytest.lazy_fixture('get_quartz_qpt_ph_modes'),
-             'quartz_666_300K_debye_waller.json',
-             'quartz_300K_fc_structure_factor.json'),
-            ('quartz', pytest.lazy_fixture('get_quartz_qpt_ph_modes'),
-             None,
-             'quartz_fc_structure_factor.json'),
-            ('Si2-sc-skew', pytest.lazy_fixture('get_si2_qpt_ph_modes'),
-             'Si2-sc-skew_666_300K_debye_waller.json',
-             'Si2-sc-skew_300K_fc_structure_factor.json'),
-            ('CaHgO2', pytest.lazy_fixture('get_cahgo2_qpt_ph_modes'),
-             'CaHgO2_666_300K_debye_waller.json',
-             'CaHgO2_300K_fc_structure_factor.json'),
-            ('quartz', pytest.lazy_fixture('get_quartz_qpt_ph_modes_recip'),
-             'quartz_666_300K_debye_waller.json',
-             'quartz_recip_asr_300K_fc_structure_factor.json')])
-    def test_calculate_structure_factor(self, material, qpt_ph_modes,
-                                        dw_file, expected_sf_file):
+        qpt_ph_modes = fc.calculate_qpoint_phonon_modes(args, **kwargs)
         if dw_file is not None:
             sf = qpt_ph_modes.calculate_structure_factor(
                 dw=get_dw(material, dw_file))
@@ -89,19 +71,43 @@ class TestCalculateStructureFactorFromForceConstants:
             sf = qpt_ph_modes.calculate_structure_factor()
         sf_file = os.path.join(get_sf_dir(material), expected_sf_file)
         expected_sf = StructureFactor.from_json_file(sf_file)
-        tol_kwargs = {}
         # Use larger tolerances with reciprocal ASR - formalism works
         # only at gamma but is applied to all q, so problem is less
         # well conditioned leading to larger f.p errors on different systems
         if 'recip' in expected_sf_file:
-            tol_kwargs['sf_atol'] = 3e-3
-            tol_kwargs['sf_rtol'] = 3e-4
-            tol_kwargs['freq_atol'] = 1e-4
-            tol_kwargs['freq_rtol'] = 3e-4
-            tol_kwargs['freq_gamma_atol'] = 0.55
-            tol_kwargs['sf_gamma_atol'] = 3e2
-
+            tol_kwargs = self.tol_kwargs
+        else:
+            tol_kwargs = {}
         check_structure_factor(sf, expected_sf, **tol_kwargs)
+
+    @pytest.mark.phonopy_reader
+    @pytest.mark.parametrize(
+        'material, fc_kwargs, qpt_ph_modes_args, dw_file, expected_sf_file', [
+            ('CaHgO2', {'path': get_phonopy_path('CaHgO2', ''),
+                        'summary_name': 'mp-7041-20180417.yaml'},
+             (get_test_qpts(), {}),
+             'CaHgO2_666_300K_debye_waller.json',
+             'CaHgO2_300K_fc_structure_factor.json')])
+    @pytest.mark.parametrize('n_threads', [0, 1, 2])
+    def test_calculate_structure_factor_from_phonopy(
+            self, material, fc_kwargs, qpt_ph_modes_args, dw_file,
+            expected_sf_file, n_threads):
+        fc = ForceConstants.from_phonopy(**fc_kwargs)
+        args, kwargs = qpt_ph_modes_args
+        if n_threads == 0:
+            kwargs['use_c'] = False
+        else:
+            kwargs['use_c'] = True
+            kwargs['n_threads'] = n_threads
+        qpt_ph_modes = fc.calculate_qpoint_phonon_modes(args, **kwargs)
+        if dw_file is not None:
+            sf = qpt_ph_modes.calculate_structure_factor(
+                dw=get_dw(material, dw_file))
+        else:
+            sf = qpt_ph_modes.calculate_structure_factor()
+        sf_file = os.path.join(get_sf_dir(material), expected_sf_file)
+        expected_sf = StructureFactor.from_json_file(sf_file)
+        check_structure_factor(sf, expected_sf)
 
 
 @pytest.mark.unit
@@ -114,12 +120,6 @@ class TestCalculateStructureFactorFromQpointPhononModes:
     def get_si2_qpt_ph_modes():
         return QpointPhononModes.from_castep(
             get_castep_path('Si2-sc-skew', 'Si2-sc-skew.phonon'))
-
-    def get_cahgo2_qpt_ph_modes():
-        return QpointPhononModes.from_phonopy(
-            path=get_phonopy_path('CaHgO2', ''),
-            summary_name='mp-7041-20180417.yaml',
-            phonon_name='qpoints.yaml')
 
     @pytest.mark.parametrize(
         'material, qpt_ph_modes, dw_file, expected_sf_file', [
@@ -134,12 +134,29 @@ class TestCalculateStructureFactorFromQpointPhononModes:
              'quartz_structure_factor.json'),
             ('Si2-sc-skew', get_si2_qpt_ph_modes(),
              'Si2-sc-skew_666_300K_debye_waller.json',
-             'Si2-sc-skew_300K_structure_factor.json'),
-            ('CaHgO2', get_cahgo2_qpt_ph_modes(),
-             'CaHgO2_666_300K_debye_waller.json',
-             'CaHgO2_300K_structure_factor.json')])
+             'Si2-sc-skew_300K_structure_factor.json')])
     def test_calculate_structure_factor(self, material, qpt_ph_modes,
                                         dw_file, expected_sf_file):
+        if dw_file is not None:
+            sf = qpt_ph_modes.calculate_structure_factor(
+                dw=get_dw(material, dw_file))
+        else:
+            sf = qpt_ph_modes.calculate_structure_factor()
+        sf_file = os.path.join(get_sf_dir(material), expected_sf_file)
+        expected_sf = StructureFactor.from_json_file(sf_file)
+        check_structure_factor(sf, expected_sf)
+
+    @pytest.mark.phonopy_reader
+    @pytest.mark.parametrize(
+        'material, qpt_ph_modes_kwargs, dw_file, expected_sf_file', [
+            ('CaHgO2', {'path': get_phonopy_path('CaHgO2', ''),
+             'summary_name': 'mp-7041-20180417.yaml',
+             'phonon_name': 'qpoints.yaml'},
+             'CaHgO2_666_300K_debye_waller.json',
+             'CaHgO2_300K_structure_factor.json')])
+    def test_calculate_structure_factor_from_phonopy(
+            self, material, qpt_ph_modes_kwargs, dw_file, expected_sf_file):
+        qpt_ph_modes = QpointPhononModes.from_phonopy(**qpt_ph_modes_kwargs)
         if dw_file is not None:
             sf = qpt_ph_modes.calculate_structure_factor(
                 dw=get_dw(material, dw_file))

--- a/tests_and_analysis/test/euphonic_test/test_calculate_structure_factor.py
+++ b/tests_and_analysis/test/euphonic_test/test_calculate_structure_factor.py
@@ -17,16 +17,17 @@ from tests_and_analysis.test.euphonic_test.test_structure_factor import (
     check_structure_factor, get_sf_dir)
 
 
+def get_quartz_fc():
+    return ForceConstants.from_castep(
+        get_castep_path('quartz', 'quartz.castep_bin'))
+
+
+def get_si2_fc():
+    return ForceConstants.from_castep(
+        get_castep_path('Si2-sc-skew', 'Si2-sc-skew.castep_bin'))
+
+
 class TestCalculateStructureFactorFromForceConstants:
-
-    def get_quartz_fc():
-        return ForceConstants.from_castep(
-            get_castep_path('quartz', 'quartz.castep_bin'))
-
-    def get_si2_fc():
-        return ForceConstants.from_castep(
-            get_castep_path('Si2-sc-skew', 'Si2-sc-skew.castep_bin'))
-
 
     tol_kwargs = {'sf_atol': 3e-3,
                   'sf_rtol': 3e-4,
@@ -109,15 +110,17 @@ class TestCalculateStructureFactorFromForceConstants:
         check_structure_factor(sf, expected_sf)
 
 
+def get_quartz_qpt_ph_modes():
+    return QpointPhononModes.from_castep(
+        get_castep_path('quartz', 'quartz_nosplit.phonon'))
+
+
+def get_si2_qpt_ph_modes():
+    return QpointPhononModes.from_castep(
+        get_castep_path('Si2-sc-skew', 'Si2-sc-skew.phonon'))
+
+
 class TestCalculateStructureFactorFromQpointPhononModes:
-
-    def get_quartz_qpt_ph_modes():
-        return QpointPhononModes.from_castep(
-            get_castep_path('quartz', 'quartz_nosplit.phonon'))
-
-    def get_si2_qpt_ph_modes():
-        return QpointPhononModes.from_castep(
-            get_castep_path('Si2-sc-skew', 'Si2-sc-skew.phonon'))
 
     @pytest.mark.parametrize(
         'material, qpt_ph_modes, dw_file, expected_sf_file', [

--- a/tests_and_analysis/test/euphonic_test/test_calculate_structure_factor.py
+++ b/tests_and_analysis/test/euphonic_test/test_calculate_structure_factor.py
@@ -29,12 +29,6 @@ def get_si2_fc():
 
 class TestCalculateStructureFactorFromForceConstants:
 
-    tol_kwargs = {'sf_atol': 3e-3,
-                  'sf_rtol': 3e-4,
-                  'freq_atol': 1e-4,
-                  'freq_rtol': 3e-4,
-                  'freq_gamma_atol': 0.55,
-                  'sf_gamma_atol': 3e2}
 
     @pytest.mark.parametrize(
         'material, fc, qpt_ph_modes_args, dw_file, expected_sf_file', [
@@ -75,7 +69,12 @@ class TestCalculateStructureFactorFromForceConstants:
         # only at gamma but is applied to all q, so problem is less
         # well conditioned leading to larger f.p errors on different systems
         if 'recip' in expected_sf_file:
-            tol_kwargs = self.tol_kwargs
+            tol_kwargs = {'sf_atol': 3e-3,
+                          'sf_rtol': 3e-4,
+                          'freq_atol': 1e-4,
+                          'freq_rtol': 3e-4,
+                          'freq_gamma_atol': 0.55,
+                          'sf_gamma_atol': 3e2}
         else:
             tol_kwargs = {}
         check_structure_factor(sf, expected_sf, **tol_kwargs)

--- a/tests_and_analysis/test/euphonic_test/test_calculate_structure_factor.py
+++ b/tests_and_analysis/test/euphonic_test/test_calculate_structure_factor.py
@@ -17,7 +17,6 @@ from tests_and_analysis.test.euphonic_test.test_structure_factor import (
     check_structure_factor, get_sf_dir)
 
 
-@pytest.mark.integration
 class TestCalculateStructureFactorFromForceConstants:
 
     def get_quartz_fc():
@@ -110,7 +109,6 @@ class TestCalculateStructureFactorFromForceConstants:
         check_structure_factor(sf, expected_sf)
 
 
-@pytest.mark.unit
 class TestCalculateStructureFactorFromQpointPhononModes:
 
     def get_quartz_qpt_ph_modes():
@@ -177,7 +175,6 @@ class TestCalculateStructureFactorFromQpointPhononModes:
                 dw=get_dw(dw_material, dw_file))
 
 
-@pytest.mark.unit
 class TestCalculateStructureFactorUsingReferenceData:
     @pytest.fixture
     def quartz_modes(self):

--- a/tests_and_analysis/test/euphonic_test/test_castep_reader.py
+++ b/tests_and_analysis/test/euphonic_test/test_castep_reader.py
@@ -15,7 +15,6 @@ from euphonic import ureg
 def get_filepath(filename):
     return os.path.join(get_data_path(), 'readers', filename)
 
-@pytest.mark.unit
 class TestReadPhononDosData:
 
     @pytest.mark.parametrize(

--- a/tests_and_analysis/test/euphonic_test/test_crystal.py
+++ b/tests_and_analysis/test/euphonic_test/test_crystal.py
@@ -115,7 +115,6 @@ def check_crystal(crystal, expected_crystal):
         atol=np.finfo(np.float64).eps)
 
 
-@pytest.mark.unit
 class TestCrystalCreation:
 
     @pytest.fixture(params=[get_expected_crystal('quartz'),
@@ -209,7 +208,6 @@ class TestCrystalCreation:
             Crystal(*faulty_args)
 
 
-@pytest.mark.unit
 class TestCrystalSerialisation:
 
     @pytest.mark.parametrize('crystal', [
@@ -246,7 +244,6 @@ class TestCrystalSerialisation:
         check_crystal(crystal, expected_crystal)
 
 
-@pytest.mark.unit
 class TestCrystalUnitConversion:
 
     @pytest.mark.parametrize('material, attr, unit_val', [
@@ -267,7 +264,6 @@ class TestCrystalUnitConversion:
             setattr(crystal, unit_attr, unit_val)
 
 
-@pytest.mark.unit
 class TestCrystalSetters:
 
     @pytest.mark.parametrize('material, attr, unit, scale', [
@@ -292,7 +288,6 @@ class TestCrystalSetters:
             setattr(crystal, attr, new_attr)
 
 
-@pytest.mark.unit
 class TestCrystalMethods:
 
     quartz_reciprocal_cell = np.array([

--- a/tests_and_analysis/test/euphonic_test/test_debye_waller.py
+++ b/tests_and_analysis/test/euphonic_test/test_debye_waller.py
@@ -90,7 +90,6 @@ def check_debye_waller(
                         atol=dw_atol,
                         rtol=dw_rtol)
 
-@pytest.mark.unit
 class TestDebyeWallerCreation:
 
     @pytest.fixture(params=[
@@ -168,7 +167,6 @@ class TestDebyeWallerCreation:
             DebyeWaller(*faulty_args)
 
 
-@pytest.mark.unit
 class TestDebyeWallerSerialisation:
 
     @pytest.mark.parametrize('dw', [
@@ -201,7 +199,6 @@ class TestDebyeWallerSerialisation:
         check_debye_waller(dw, expected_dw)
 
 
-@pytest.mark.unit
 class TestDebyeWallerUnitConversion:
 
     @pytest.mark.parametrize('material, json_file, attr, unit_val', [
@@ -226,7 +223,6 @@ class TestDebyeWallerUnitConversion:
             setattr(dw, unit_attr, unit_val)
 
 
-@pytest.mark.unit
 class TestDebyeWallerSetters:
 
     @pytest.mark.parametrize('material, json_file, attr, unit, scale', [

--- a/tests_and_analysis/test/euphonic_test/test_force_constants.py
+++ b/tests_and_analysis/test/euphonic_test/test_force_constants.py
@@ -294,6 +294,14 @@ class TestForceConstantsCreation:
           'path': get_phonopy_path('NaCl', '')})])
     def test_create_from_phonopy_without_installed_modules_raises_err(
             self, phonopy_args, mocker):
+        # Mock import of yaml, h5py to raise ModuleNotFoundError
+        import builtins
+        real_import = builtins.__import__
+        def mocked_import(name, *args, **kwargs):
+            if name == 'h5py' or name == 'yaml':
+                raise ModuleNotFoundError
+            return real_import(name, *args, **kwargs)
+        mocker.patch('builtins.__import__', side_effect=mocked_import)
         with pytest.raises(ImportPhonopyReaderError):
             ForceConstants.from_phonopy(**phonopy_args)
 

--- a/tests_and_analysis/test/euphonic_test/test_force_constants_calculate_qpoint_frequencies.py
+++ b/tests_and_analysis/test/euphonic_test/test_force_constants_calculate_qpoint_frequencies.py
@@ -15,7 +15,6 @@ from tests_and_analysis.test.euphonic_test.test_force_constants import (
     get_fc, get_fc_dir)
 
 
-@pytest.mark.unit
 class TestForceConstantsCalculateQPointFrequencies:
 
     def get_lzo_fc():

--- a/tests_and_analysis/test/euphonic_test/test_force_constants_calculate_qpoint_phonon_modes.py
+++ b/tests_and_analysis/test/euphonic_test/test_force_constants_calculate_qpoint_phonon_modes.py
@@ -18,7 +18,6 @@ from tests_and_analysis.test.euphonic_test.test_force_constants import (
     get_fc, get_fc_dir)
 
 
-@pytest.mark.unit
 class TestForceConstantsCalculateQPointPhononModes:
 
     def get_lzo_fc():
@@ -340,7 +339,6 @@ class TestForceConstantsCalculateQPointPhononModes:
             fc.calculate_qpoint_phonon_modes(get_test_qpts(), asr=asr)
 
 
-@pytest.mark.unit
 class TestForceConstantsCalculateQPointPhononModesWithoutCExtensionInstalled:
 
     @pytest.fixture
@@ -376,7 +374,6 @@ class TestForceConstantsCalculateQPointPhononModesWithoutCExtensionInstalled:
         assert len(warn_record) == 0
 
 
-@pytest.mark.unit
 class TestForceConstantsCalculateQPointPhononModesWithCExtensionInstalled:
 
     @pytest.fixture

--- a/tests_and_analysis/test/euphonic_test/test_install.py
+++ b/tests_and_analysis/test/euphonic_test/test_install.py
@@ -1,5 +1,6 @@
 from importlib_resources import open_text
-import yaml
+
+import pytest
 
 import euphonic
 
@@ -11,7 +12,9 @@ class TestInstalledFiles:
             license_data = fp.readlines()
         assert 'GNU GENERAL PUBLIC LICENSE' in license_data[0]
 
+    @pytest.mark.phonopy_reader  # Needs pyyaml
     def test_citation_cff_is_installed(self):
+        import yaml
         with open_text(euphonic, 'CITATION.cff') as fp:
             citation_data = yaml.safe_load(fp)
         assert 'cff-version' in citation_data

--- a/tests_and_analysis/test/euphonic_test/test_install.py
+++ b/tests_and_analysis/test/euphonic_test/test_install.py
@@ -12,9 +12,12 @@ class TestInstalledFiles:
             license_data = fp.readlines()
         assert 'GNU GENERAL PUBLIC LICENSE' in license_data[0]
 
-    @pytest.mark.phonopy_reader  # Needs pyyaml
     def test_citation_cff_is_installed(self):
-        import yaml
+        # yaml dependency is optional
+        try:
+            import yaml
+        except ModuleNotFoundError:
+            pytest.skip()
         with open_text(euphonic, 'CITATION.cff') as fp:
             citation_data = yaml.safe_load(fp)
         assert 'cff-version' in citation_data

--- a/tests_and_analysis/test/euphonic_test/test_plot.py
+++ b/tests_and_analysis/test/euphonic_test/test_plot.py
@@ -1,17 +1,24 @@
 import pytest
-import matplotlib
-matplotlib.use('Agg')
-import matplotlib.pyplot as plt
 import numpy as np
 import numpy.testing as npt
 
 from euphonic import ureg
-import euphonic.plot
-from euphonic.plot import plot_1d, plot_1d_to_axis
 from euphonic.spectra import Spectrum1D, Spectrum1DCollection
 
 from ..script_tests.utils import get_ax_image_data
 
+# Allow tests with matplotlib marker to be collected and
+# deselected if Matplotlib is not installed
+pytestmark = pytest.mark.matplotlib
+try:
+    import matplotlib
+    matplotlib.use('Agg')
+    import matplotlib.pyplot as plt
+
+    import euphonic.plot
+    from euphonic.plot import plot_1d, plot_1d_to_axis
+except ModuleNotFoundError:
+    pass
 
 @pytest.fixture
 def figure():
@@ -31,7 +38,6 @@ def axes_with_line_and_legend(axes):
     axes.legend()
     return axes
 
-@pytest.mark.unit
 def test_missing_matplotlib(mocker):
     from builtins import __import__ as builtins_import
     from importlib import reload
@@ -50,7 +56,6 @@ def test_missing_matplotlib(mocker):
             in mnf_error.value.args[0])
 
 
-@pytest.mark.unit
 class TestPlot1DCore:
     @pytest.mark.parametrize('spectra, expected_error',
                              [('wrong_type', TypeError), ])
@@ -176,7 +181,6 @@ class TestPlot1DCore:
         with pytest.raises(ValueError):
             plot_1d_to_axis(spec, axes, labels=labels)
 
-@pytest.mark.unit
 class TestPlot1D:
     @staticmethod
     def mock_core(mocker):
@@ -291,7 +295,6 @@ class TestPlot1D:
             plot_1d(spec1d, **kwargs)
 
 
-@pytest.mark.unit
 class TestPlot2D:
     @staticmethod
     def mock_core(mocker):
@@ -384,7 +387,6 @@ class TestPlot2D:
             euphonic.plot.plot_2d(spectrum, **kwargs)
 
 
-@pytest.mark.unit
 @pytest.mark.parametrize('labels, rotate',
                          [([(1, 'A'), (3, 'B'), (4, 'CDEF')], False),
                           ([(0, 'A'), (3, 'THISISALONGLABEL')], True)])

--- a/tests_and_analysis/test/euphonic_test/test_powder.py
+++ b/tests_and_analysis/test/euphonic_test/test_powder.py
@@ -25,7 +25,6 @@ def jitter(request):
     return request.param
 
 
-@pytest.mark.unit
 @pytest.mark.parametrize('npts, sampling, sampling_args, sampling_kwargs',
                          [(10, 'golden', (10,), {'jitter': None}),
                           # 31 pts rounded up to 2N^2 -> 4 cols, 8 rows
@@ -143,7 +142,6 @@ class TestSphereSampledProperties:
     _energy_bins = np.linspace(1., 10., 5)
     _scattering_lengths = {'Si': 4. * ureg('fm')}
 
-    @pytest.mark.unit
     @pytest.mark.parametrize('energy_bins', [_energy_bins, None])
     def test_sample_sphere_dos(self,
                                mocker, mock_fc, mock_qpf, random_qpts_array,
@@ -162,14 +160,12 @@ class TestSphereSampledProperties:
             mock_fc.calculate_qpoint_frequencies.call_args[0][0])
         mock_qpf.calculate_dos.assert_called_with(return_bins)
 
-    @pytest.mark.unit
     def test_sample_sphere_structure_factor_error(self, mock_fc, mock_dw):
         with pytest.raises(ValueError):
             sample_sphere_structure_factor(mock_fc, 1. * ureg('1 / angstrom'),
                                            dw=mock_dw,
                                            temperature=(100. * ureg('K')))
 
-    @pytest.mark.unit
     @pytest.mark.parametrize('options',
                              [dict(mod_q=1.2 * ureg('1 / angstrom'),
                                    npts=400, jitter=True,
@@ -276,7 +272,6 @@ class TestQpointConversion:
                          [0, np.pi / 2, np.pi / 3]]}
 
     @staticmethod
-    @pytest.mark.unit
     def test_qpts_cart_to_frac_trivial(trivial_crystal, trivial_qpts):
         """Check internal method for q-point conversion with trivial example"""
         cart_qpts = np.asarray(trivial_qpts['cart'], dtype=float
@@ -287,7 +282,6 @@ class TestQpointConversion:
         npt.assert_almost_equal(calc_frac_qpts, frac_qpts)
 
     @staticmethod
-    @pytest.mark.unit
     def test_qpts_cart_to_frac_roundtrip(random_qpts_array,
                                          nontrivial_crystal):
         frac_qpts = random_qpts_array

--- a/tests_and_analysis/test/euphonic_test/test_qpoint_frequencies.py
+++ b/tests_and_analysis/test/euphonic_test/test_qpoint_frequencies.py
@@ -125,7 +125,6 @@ def check_qpt_freqs(
         atol=np.finfo(np.float64).eps)
 
 
-@pytest.mark.unit
 class TestQpointFrequenciesCreation:
 
     @pytest.mark.parametrize('expected_qpt_freqs', [
@@ -319,7 +318,6 @@ class TestQpointFrequenciesCreation:
         check_qpt_freqs(qpt_freqs, expected_qpt_freqs)
 
 
-@pytest.mark.unit
 class TestQpointFrequenciesSerialisation:
 
     @pytest.mark.parametrize('qpt_freqs', [
@@ -349,7 +347,6 @@ class TestQpointFrequenciesSerialisation:
         check_qpt_freqs(qpt_freqs, qpt_freqs_from_dict)
 
 
-@pytest.mark.unit
 class TestQpointFrequenciesUnitConversion:
 
     @pytest.mark.parametrize('material, json_file, attr, unit_val', [
@@ -373,7 +370,6 @@ class TestQpointFrequenciesUnitConversion:
             setattr(qpt_freqs, unit_attr, unit_val)
 
 
-@pytest.mark.unit
 class TestQpointFrequenciesSetters:
 
     @pytest.mark.parametrize('material, json_file, attr, unit, scale', [
@@ -398,7 +394,6 @@ class TestQpointFrequenciesSetters:
             setattr(qpt_freqs, attr, new_attr)
 
 
-@pytest.mark.unit
 class TestQpointFrequenciesCalculateDos:
 
     @pytest.mark.parametrize(
@@ -488,7 +483,6 @@ class TestQpointFrequenciesCalculateDos:
             dos = qpt_freqs.calculate_dos(ebins)
         assert len(warn_record) == 0
 
-@pytest.mark.unit
 class TestQpointFrequenciesCalculateDosMap:
     @pytest.mark.parametrize(
         'material, qpt_freqs_json, ebins, expected_dos_map_json', [
@@ -545,7 +539,6 @@ class TestQpointFrequenciesCalculateDosMap:
             dos_map_at_qpt = Spectrum1D(dos_map.y_data, dos_map.z_data[qpt])
             check_spectrum1d(dos_map_at_qpt, dos_single_qpt)
 
-@pytest.mark.unit
 class TestQpointFrequenciesGetDispersion:
 
     @pytest.mark.parametrize(

--- a/tests_and_analysis/test/euphonic_test/test_qpoint_frequencies.py
+++ b/tests_and_analysis/test/euphonic_test/test_qpoint_frequencies.py
@@ -246,7 +246,7 @@ class TestQpointFrequenciesCreation:
          get_expected_qpt_freqs(
              'quartz', 'quartz_666_qpoint_frequencies.json').weights[:5],
          ValueError)])
-    def inject_faulty_elements(
+    def test_faulty_object_creation(
             self, faulty_arg, faulty_value, expected_exception):
         expected_qpt_freqs = get_expected_qpt_freqs(
             'quartz', 'quartz_666_qpoint_frequencies.json')

--- a/tests_and_analysis/test/euphonic_test/test_qpoint_frequencies.py
+++ b/tests_and_analysis/test/euphonic_test/test_qpoint_frequencies.py
@@ -128,44 +128,44 @@ def check_qpt_freqs(
 @pytest.mark.unit
 class TestQpointFrequenciesCreation:
 
-    @pytest.fixture(params=[
+    @pytest.mark.parametrize('expected_qpt_freqs', [
         get_expected_qpt_freqs(
             'quartz', 'quartz_666_qpoint_frequencies.json'),
         get_expected_qpt_freqs(
             'quartz', 'quartz_bandstructure_qpoint_frequencies.json'),
         get_expected_qpt_freqs(
             'quartz', 'quartz_666_cv_only_qpoint_frequencies.json')])
-    def create_from_constructor(self, request):
-        expected_qpt_freqs = request.param
+    def test_create_from_constructor(self, expected_qpt_freqs):
         args, kwargs = expected_qpt_freqs.to_constructor_args()
         qpt_freqs = QpointFrequencies(*args, **kwargs)
-        return qpt_freqs, expected_qpt_freqs
+        check_qpt_freqs(qpt_freqs, expected_qpt_freqs)
 
-    @pytest.fixture(params=[
+    @pytest.mark.parametrize('expected_qpt_freqs', [
         get_expected_qpt_freqs(
             'quartz', 'quartz_bandstructure_qpoint_frequencies.json')])
-    def create_from_constructor_without_weights(self, request):
-        expected_qpt_freqs = request.param
+    def test_create_from_constructor_without_weights(
+            self, expected_qpt_freqs):
         args, kwargs = expected_qpt_freqs.to_constructor_args(weights=False)
         qpt_freqs = QpointFrequencies(*args, **kwargs)
-        return qpt_freqs, expected_qpt_freqs
+        check_qpt_freqs(qpt_freqs, expected_qpt_freqs)
 
-    @pytest.fixture(params=[
+    @pytest.mark.parametrize('material, phonon_file, json_file', [
         ('LZO', 'La2Zr2O7.phonon',
          'LZO_qpoint_frequencies.json'),
         ('quartz', 'quartz-666-grid.phonon',
          'quartz_666_qpoint_frequencies.json'),
         ('quartz', 'quartz_split_qpts.phonon',
          'quartz_split_from_castep_qpoint_frequencies.json')])
-    def create_from_castep(self, request):
-        material, phonon_file, json_file = request.param
+    def test_create_from_castep(self, material, phonon_file, json_file):
         qpt_freqs = QpointFrequencies.from_castep(
             get_castep_path(material, phonon_file))
         expected_qpt_freqs = ExpectedQpointFrequencies(
             os.path.join(get_qpt_freqs_dir(material), json_file))
-        return qpt_freqs, expected_qpt_freqs
+        check_qpt_freqs(qpt_freqs, expected_qpt_freqs)
 
-    @pytest.fixture(params=[
+    @pytest.mark.phonopy_reader
+    @pytest.mark.parametrize(
+            'material, subdir, phonopy_args, json_file', [
         ('NaCl', 'band', {'summary_name': 'should_not_be_read',
                           'phonon_name': 'band.yaml'},
          'NaCl_band_yaml_from_phonopy_qpoint_frequencies.json'),
@@ -195,48 +195,35 @@ class TestQpointFrequenciesCreation:
         ('CaHgO2', '', {'summary_name': 'mp-7041-20180417.yaml',
                         'phonon_name': 'qpoints.yaml'},
          'CaHgO2_from_phonopy_qpoint_frequencies.json')])
-    def create_from_phonopy(self, request):
-        material, subdir, phonopy_args, json_file = request.param
+    def test_create_from_phonopy(
+            self, material, subdir, phonopy_args, json_file):
         phonopy_args['path'] = get_phonopy_path(material, subdir)
         qpt_freqs = QpointFrequencies.from_phonopy(**phonopy_args)
         json_path = os.path.join(
             get_qpt_freqs_dir(material), json_file)
         expected_qpt_freqs = ExpectedQpointFrequencies(json_path)
-        return qpt_freqs, expected_qpt_freqs
+        check_qpt_freqs(qpt_freqs, expected_qpt_freqs)
 
-    @pytest.fixture(params=[
+    @pytest.mark.parametrize('material, json_file', [
         ('quartz', 'quartz_666_qpoint_frequencies.json'),
         ('quartz', 'quartz_bandstructure_qpoint_frequencies.json'),
         ('quartz', 'quartz_666_cv_only_qpoint_frequencies.json')])
-    def create_from_json(self, request):
-        material, json_file = request.param
+    def test_create_from_json(self, material, json_file):
         expected_qpt_freqs = get_expected_qpt_freqs(material, json_file)
         qpt_freqs = get_qpt_freqs(material, json_file)
-        return qpt_freqs, expected_qpt_freqs
+        check_qpt_freqs(qpt_freqs, expected_qpt_freqs)
 
-    @pytest.fixture(params=[
+    @pytest.mark.parametrize('material, json_file', [
         ('quartz', 'quartz_666_qpoint_frequencies.json'),
         ('quartz', 'quartz_bandstructure_qpoint_frequencies.json'),
         ('quartz', 'quartz_666_cv_only_qpoint_frequencies.json')])
-    def create_from_dict(self, request):
-        material, json_file = request.param
+    def test_create_from_dict(self, material, json_file):
         expected_qpt_freqs = get_expected_qpt_freqs(material, json_file)
         qpt_freqs = QpointFrequencies.from_dict(
             expected_qpt_freqs.to_dict())
-        return qpt_freqs, expected_qpt_freqs
-
-    @pytest.mark.parametrize(('qpt_freqs_creator'), [
-        pytest.lazy_fixture('create_from_constructor'),
-        pytest.lazy_fixture('create_from_constructor_without_weights'),
-        pytest.lazy_fixture('create_from_dict'),
-        pytest.lazy_fixture('create_from_json'),
-        pytest.lazy_fixture('create_from_castep'),
-        pytest.lazy_fixture('create_from_phonopy')])
-    def test_correct_object_creation(self, qpt_freqs_creator):
-        qpt_freqs, expected_qpt_freqs = qpt_freqs_creator
         check_qpt_freqs(qpt_freqs, expected_qpt_freqs)
 
-    @pytest.fixture(params=[
+    @pytest.mark.parametrize('faulty_arg, faulty_value, expected_exception', [
         ('qpts',
          get_expected_qpt_freqs(
              'quartz', 'quartz_666_qpoint_frequencies.json').qpts[:3],
@@ -259,19 +246,15 @@ class TestQpointFrequenciesCreation:
          get_expected_qpt_freqs(
              'quartz', 'quartz_666_qpoint_frequencies.json').weights[:5],
          ValueError)])
-    def inject_faulty_elements(self, request):
-        faulty_arg, faulty_value, expected_exception = request.param
+    def inject_faulty_elements(
+            self, faulty_arg, faulty_value, expected_exception):
         expected_qpt_freqs = get_expected_qpt_freqs(
             'quartz', 'quartz_666_qpoint_frequencies.json')
         # Inject the faulty value and get a tuple of constructor arguments
         args, kwargs = expected_qpt_freqs.to_constructor_args(
             **{faulty_arg: faulty_value})
-        return args, kwargs, expected_exception
-
-    def test_faulty_object_creation(self, inject_faulty_elements):
-        faulty_args, faulty_kwargs, expected_exception = inject_faulty_elements
         with pytest.raises(expected_exception):
-            QpointFrequencies(*faulty_args, **faulty_kwargs)
+            QpointFrequencies(*args, **kwargs)
 
     @pytest.mark.parametrize('material, subdir, phonopy_args', [
         ('NaCl', 'qpoints', {'summary_name': 'phonopy.yaml',
@@ -292,6 +275,7 @@ class TestQpointFrequenciesCreation:
         with pytest.raises(ImportPhonopyReaderError):
             QpointFrequencies.from_phonopy(**phonopy_args)
 
+    @pytest.mark.phonopy_reader
     @pytest.mark.parametrize('material, subdir, phonopy_args, err', [
         ('NaCl', 'qpoints', {'summary_name': 'phonopy.yaml',
                              'phonon_name': 'qpoints_hdf5.test'},
@@ -310,6 +294,7 @@ class TestQpointFrequenciesCreation:
         with pytest.raises(err):
             QpointFrequencies.from_phonopy(**phonopy_args)
 
+    @pytest.mark.phonopy_reader
     @pytest.mark.parametrize('material, subdir, phonopy_args, json_file', [
         ('CaHgO2', '', {'summary_name': 'mp-7041-20180417.yaml',
                         'phonon_name': 'qpoints.yaml'},

--- a/tests_and_analysis/test/euphonic_test/test_qpoint_phonon_modes.py
+++ b/tests_and_analysis/test/euphonic_test/test_qpoint_phonon_modes.py
@@ -157,7 +157,6 @@ def check_qpt_ph_modes(
         atol=np.finfo(np.float64).eps)
 
 
-@pytest.mark.unit
 class TestQpointPhononModesCreation:
 
     @pytest.mark.parametrize('expected_qpt_ph_modes', [
@@ -358,7 +357,6 @@ class TestQpointPhononModesCreation:
         check_qpt_ph_modes(qpt_ph_modes, expected_qpt_ph_modes,
                            check_evecs=True)
 
-@pytest.mark.unit
 class TestQpointPhononModesSerialisation:
 
     @pytest.mark.parametrize('qpt_ph_modes', [
@@ -403,7 +401,6 @@ class TestQpointPhononModesSerialisation:
 
 
 
-@pytest.mark.unit
 class TestQpointPhononModesUnitConversion:
 
     @pytest.mark.parametrize('material, attr, unit_val', [
@@ -421,7 +418,6 @@ class TestQpointPhononModesUnitConversion:
             setattr(qpt_ph_modes, unit_attr, unit_val)
 
 
-@pytest.mark.unit
 class TestQpointPhononModesSetters:
 
     @pytest.mark.parametrize('material, attr, unit, scale', [
@@ -441,7 +437,6 @@ class TestQpointPhononModesSetters:
             setattr(qpt_ph_modes, attr, new_attr)
 
 
-@pytest.mark.unit
 class TestQpointPhononModesReorderFrequencies:
 
     @pytest.mark.parametrize(
@@ -460,7 +455,6 @@ class TestQpointPhononModesReorderFrequencies:
         check_qpt_ph_modes(qpt_ph_modes, expected_qpt_ph_modes)
 
 
-@pytest.mark.unit
 class TestQpointPhononModesCalculateDebyeWaller:
 
     @pytest.mark.parametrize(
@@ -513,7 +507,6 @@ class TestQpointPhononModesCalculateDebyeWaller:
         check_debye_waller(dw, expected_dw, dw_atol=1e-12)
 
 
-@pytest.mark.unit
 class TestQpointPhononModesCalculateDos:
 
     @pytest.mark.parametrize(
@@ -594,7 +587,6 @@ class TestQpointPhononModesCalculateDos:
             dos = qpt_ph_modes.calculate_dos(ebins)
         assert len(warn_record) == 0
 
-@pytest.mark.unit
 class TestQpointPhononModesCalculatePdos:
 
     @pytest.mark.parametrize(
@@ -706,7 +698,6 @@ class TestQpointPhononModesCalculatePdos:
 
 
 
-@pytest.mark.unit
 class TestQpointPhononModesGetDispersion:
 
     @pytest.mark.parametrize(

--- a/tests_and_analysis/test/euphonic_test/test_qpoint_phonon_modes.py
+++ b/tests_and_analysis/test/euphonic_test/test_qpoint_phonon_modes.py
@@ -160,24 +160,27 @@ def check_qpt_ph_modes(
 @pytest.mark.unit
 class TestQpointPhononModesCreation:
 
-    @pytest.fixture(params=[get_expected_qpt_ph_modes('quartz'),
-                            get_expected_qpt_ph_modes('LZO'),
-                            get_expected_qpt_ph_modes('NaCl')])
-    def create_from_constructor(self, request):
-        expected_qpt_ph_modes = request.param
+    @pytest.mark.parametrize('expected_qpt_ph_modes', [
+        get_expected_qpt_ph_modes('quartz'),
+        get_expected_qpt_ph_modes('LZO'),
+        get_expected_qpt_ph_modes('NaCl')])
+    def test_create_from_constructor(self, expected_qpt_ph_modes):
         args, kwargs = expected_qpt_ph_modes.to_constructor_args()
         qpt_ph_modes = QpointPhononModes(*args, **kwargs)
-        return qpt_ph_modes, expected_qpt_ph_modes
+        check_qpt_ph_modes(qpt_ph_modes, expected_qpt_ph_modes,
+                           check_evecs=True)
 
-    @pytest.fixture(params=[get_expected_qpt_ph_modes('quartz'),
-                            get_expected_qpt_ph_modes('NaCl')])
-    def create_from_constructor_without_weights(self, request):
-        expected_qpt_ph_modes = request.param
+    @pytest.mark.parametrize('expected_qpt_ph_modes', [
+        get_expected_qpt_ph_modes('quartz'),
+        get_expected_qpt_ph_modes('NaCl')])
+    def test_create_from_constructor_without_weights(
+            self, expected_qpt_ph_modes):
         args, kwargs = expected_qpt_ph_modes.to_constructor_args(weights=False)
         qpt_ph_modes = QpointPhononModes(*args, **kwargs)
-        return qpt_ph_modes, expected_qpt_ph_modes
+        check_qpt_ph_modes(qpt_ph_modes, expected_qpt_ph_modes,
+                           check_evecs=True)
 
-    @pytest.fixture(params=[
+    @pytest.mark.parametrize('material, phonon_file, json_file', [
         ('LZO', 'La2Zr2O7.phonon',
          'LZO_from_castep_qpoint_phonon_modes.json'),
         ('Si2-sc-skew', 'Si2-sc-skew.phonon',
@@ -186,15 +189,16 @@ class TestQpointPhononModesCreation:
          'quartz_from_castep_qpoint_phonon_modes.json'),
         ('quartz', 'quartz_split_qpts.phonon',
          'quartz_split_from_castep_qpoint_phonon_modes.json')])
-    def create_from_castep(self, request):
-        material, phonon_file, json_file = request.param
+    def test_create_from_castep(self, material, phonon_file, json_file):
         qpt_ph_modes = QpointPhononModes.from_castep(
             get_castep_path(material, phonon_file))
         expected_qpt_ph_modes = ExpectedQpointPhononModes(
             os.path.join(get_qpt_ph_modes_dir(material), json_file))
-        return qpt_ph_modes, expected_qpt_ph_modes
+        check_qpt_ph_modes(qpt_ph_modes, expected_qpt_ph_modes,
+                           check_evecs=True)
 
-    @pytest.fixture(params=[
+    @pytest.mark.phonopy_reader
+    @pytest.mark.parametrize('material, subdir, phonopy_args, json_file', [
         ('NaCl', 'band', {'summary_name': 'should_not_be_read',
                           'phonon_name': 'band.yaml'},
          'NaCl_band_yaml_from_phonopy_qpoint_phonon_modes.json'),
@@ -224,43 +228,31 @@ class TestQpointPhononModesCreation:
         ('CaHgO2', '', {'summary_name': 'mp-7041-20180417.yaml',
                         'phonon_name': 'qpoints.yaml'},
          'CaHgO2_from_phonopy_qpoint_phonon_modes.json')])
-    def create_from_phonopy(self, request):
-        material, subdir, phonopy_args, json_file = request.param
+    def test_create_from_phonopy(self, material, subdir, phonopy_args, json_file):
         phonopy_args['path'] = get_phonopy_path(material, subdir)
         qpt_ph_modes = QpointPhononModes.from_phonopy(**phonopy_args)
         json_path = os.path.join(
             get_qpt_ph_modes_dir(material), json_file)
         expected_qpt_ph_modes = ExpectedQpointPhononModes(json_path)
-        return qpt_ph_modes, expected_qpt_ph_modes
-
-    @pytest.fixture(params=['LZO', 'quartz', 'NaCl'])
-    def create_from_json(self, request):
-        material = request.param
-        expected_qpt_ph_modes = get_expected_qpt_ph_modes(material)
-        qpt_ph_modes = get_qpt_ph_modes(material)
-        return qpt_ph_modes, expected_qpt_ph_modes
-
-    @pytest.fixture(params=['LZO', 'quartz', 'NaCl'])
-    def create_from_dict(self, request):
-        material = request.param
-        expected_qpt_ph_modes = get_expected_qpt_ph_modes(material)
-        qpt_ph_modes = QpointPhononModes.from_dict(
-            expected_qpt_ph_modes.to_dict())
-        return qpt_ph_modes, expected_qpt_ph_modes
-
-    @pytest.mark.parametrize(('qpt_ph_modes_creator'), [
-        pytest.lazy_fixture('create_from_constructor'),
-        pytest.lazy_fixture('create_from_constructor_without_weights'),
-        pytest.lazy_fixture('create_from_dict'),
-        pytest.lazy_fixture('create_from_json'),
-        pytest.lazy_fixture('create_from_castep'),
-        pytest.lazy_fixture('create_from_phonopy')])
-    def test_correct_object_creation(self, qpt_ph_modes_creator):
-        qpt_ph_modes, expected_qpt_ph_modes = qpt_ph_modes_creator
         check_qpt_ph_modes(qpt_ph_modes, expected_qpt_ph_modes,
                            check_evecs=True)
 
-    @pytest.fixture(params=[
+    @pytest.mark.parametrize('material', ['LZO', 'quartz', 'NaCl'])
+    def test_create_from_json(self, material):
+        expected_qpt_ph_modes = get_expected_qpt_ph_modes(material)
+        qpt_ph_modes = get_qpt_ph_modes(material)
+        check_qpt_ph_modes(qpt_ph_modes, expected_qpt_ph_modes,
+                           check_evecs=True)
+
+    @pytest.mark.parametrize('material', ['LZO', 'quartz', 'NaCl'])
+    def test_create_from_dict(self, material):
+        expected_qpt_ph_modes = get_expected_qpt_ph_modes(material)
+        qpt_ph_modes = QpointPhononModes.from_dict(
+            expected_qpt_ph_modes.to_dict())
+        check_qpt_ph_modes(qpt_ph_modes, expected_qpt_ph_modes,
+                           check_evecs=True)
+
+    @pytest.mark.parametrize('faulty_arg, faulty_value, expected_exception', [
         ('qpts',
          get_expected_qpt_ph_modes('quartz').qpts[:3],
          ValueError),
@@ -285,19 +277,14 @@ class TestQpointPhononModesCreation:
         ('crystal',
          get_crystal('LZO'),
          ValueError)])
-    def inject_faulty_elements(self, request):
-        faulty_arg, faulty_value, expected_exception = request.param
+    def test_faulty_object_creation(
+            self, faulty_arg, faulty_value, expected_exception):
         expected_qpt_ph_modes = get_expected_qpt_ph_modes('quartz')
         # Inject the faulty value and get a tuple of constructor arguments
         args, kwargs = expected_qpt_ph_modes.to_constructor_args(
             **{faulty_arg: faulty_value})
-        return args, kwargs, expected_exception
-
-    def test_faulty_object_creation(self, inject_faulty_elements):
-        faulty_args, faulty_kwargs, expected_exception = inject_faulty_elements
         with pytest.raises(expected_exception):
-            QpointPhononModes(*faulty_args, **faulty_kwargs)
-
+            QpointPhononModes(*args, **kwargs)
 
     @pytest.mark.parametrize('material, subdir, phonopy_args', [
         ('NaCl', 'qpoints', {'summary_name': 'phonopy.yaml',
@@ -307,17 +294,10 @@ class TestQpointPhononModesCreation:
     def test_create_from_phonopy_without_installed_modules_raises_err(
             self, material, subdir, phonopy_args, mocker):
         phonopy_args['path'] = get_phonopy_path(material, subdir)
-        # Mock import of yaml, h5py to raise ModuleNotFoundError
-        import builtins
-        real_import = builtins.__import__
-        def mocked_import(name, *args, **kwargs):
-            if name == 'h5py' or name == 'yaml':
-                raise ModuleNotFoundError
-            return real_import(name, *args, **kwargs)
-        mocker.patch('builtins.__import__', side_effect=mocked_import)
         with pytest.raises(ImportPhonopyReaderError):
             QpointPhononModes.from_phonopy(**phonopy_args)
 
+    @pytest.mark.phonopy_reader
     @pytest.mark.parametrize('material, subdir, phonopy_args, err', [
         ('NaCl', 'qpoints', {'summary_name': 'phonopy.yaml',
                              'phonon_name': 'qpoints_hdf5.test'},
@@ -345,6 +325,7 @@ class TestQpointPhononModesCreation:
         with pytest.raises(err):
             QpointPhononModes.from_phonopy(**phonopy_args)
 
+    @pytest.mark.phonopy_reader
     @pytest.mark.parametrize('material, subdir, phonopy_args, json_file', [
         ('CaHgO2', '', {'summary_name': 'mp-7041-20180417.yaml',
                         'phonon_name': 'qpoints.yaml'},
@@ -496,19 +477,28 @@ class TestQpointPhononModesCalculateDebyeWaller:
             ('Si2-sc-skew', 'Si2-sc-skew-666-grid.phonon',
                 'Si2-sc-skew_666_300K_symm_debye_waller.json', 300,
                 {'symmetrise': True}),
+        ])
+    def test_calculate_debye_waller(self, material, qpt_ph_modes_file,
+                                    expected_dw_json, temperature, kwargs):
+        qpt_ph_modes = QpointPhononModes.from_castep(
+            get_castep_path(material, qpt_ph_modes_file))
+        dw = qpt_ph_modes.calculate_debye_waller(
+            temperature*ureg('K'), **kwargs)
+        expected_dw = get_expected_dw(material, expected_dw_json)
+        check_debye_waller(dw, expected_dw, dw_atol=1e-12)
+
+    @pytest.mark.phonopy_reader
+    @pytest.mark.parametrize(
+        'material, qpt_ph_modes_file, expected_dw_json, temperature, kwargs', [
             ('CaHgO2', 'CaHgO2-666-grid.yaml',
                 'CaHgO2_666_300K_debye_waller.json', 300,
                 {'symmetrise': False})
         ])
-    def test_calculate_debye_waller(self, material, qpt_ph_modes_file,
-                                    expected_dw_json, temperature, kwargs):
-        if qpt_ph_modes_file.endswith('.phonon'):
-            qpt_ph_modes = QpointPhononModes.from_castep(
-                get_castep_path(material, qpt_ph_modes_file))
-        else:
-            qpt_ph_modes = QpointPhononModes.from_phonopy(
-                phonon_name=get_phonopy_path(material, qpt_ph_modes_file))
-
+    def test_calculate_debye_waller_from_phonopy(
+            self, material, qpt_ph_modes_file,
+            expected_dw_json, temperature, kwargs):
+        qpt_ph_modes = QpointPhononModes.from_phonopy(
+            phonon_name=get_phonopy_path(material, qpt_ph_modes_file))
         dw = qpt_ph_modes.calculate_debye_waller(
             temperature*ureg('K'), **kwargs)
         expected_dw = get_expected_dw(material, expected_dw_json)
@@ -522,17 +512,26 @@ class TestQpointPhononModesCalculateDos:
         'material, qpt_ph_modes_file, expected_dos_json, ebins', [
             ('quartz', 'quartz-666-grid.phonon',
              'quartz_666_dos.json', np.arange(0, 155, 0.5)*ureg('meV')),
-            ('CaHgO2', 'CaHgO2-666-grid.yaml',
-             'CaHgO2_666_dos.json', np.arange(0, 95, 0.4)*ureg('meV'))
         ])
     def test_calculate_dos(self, material, qpt_ph_modes_file,
                            expected_dos_json, ebins):
-        if qpt_ph_modes_file.endswith('.phonon'):
-            qpt_ph_modes = QpointPhononModes.from_castep(
-                get_castep_path(material, qpt_ph_modes_file))
-        else:
-            qpt_ph_modes = QpointPhononModes.from_phonopy(
-                phonon_name=get_phonopy_path(material, qpt_ph_modes_file))
+        qpt_ph_modes = QpointPhononModes.from_castep(
+            get_castep_path(material, qpt_ph_modes_file))
+        dos = qpt_ph_modes.calculate_dos(ebins)
+        expected_dos = get_expected_spectrum1d(expected_dos_json)
+        check_spectrum1d(dos, expected_dos)
+
+    @pytest.mark.phonopy_reader
+    @pytest.mark.parametrize(
+        'material, qpt_ph_modes_file, expected_dos_json, ebins', [
+            ('CaHgO2', 'CaHgO2-666-grid.yaml',
+             'CaHgO2_666_dos.json', np.arange(0, 95, 0.4)*ureg('meV'))
+        ])
+    def test_calculate_dos_from_phonopy(
+            self, material, qpt_ph_modes_file,
+            expected_dos_json, ebins):
+        qpt_ph_modes = QpointPhononModes.from_phonopy(
+            phonon_name=get_phonopy_path(material, qpt_ph_modes_file))
         dos = qpt_ph_modes.calculate_dos(ebins)
         expected_dos = get_expected_spectrum1d(expected_dos_json)
         check_spectrum1d(dos, expected_dos)

--- a/tests_and_analysis/test/euphonic_test/test_qpoint_phonon_modes.py
+++ b/tests_and_analysis/test/euphonic_test/test_qpoint_phonon_modes.py
@@ -294,6 +294,14 @@ class TestQpointPhononModesCreation:
     def test_create_from_phonopy_without_installed_modules_raises_err(
             self, material, subdir, phonopy_args, mocker):
         phonopy_args['path'] = get_phonopy_path(material, subdir)
+        # Mock import of yaml, h5py to raise ModuleNotFoundError
+        import builtins
+        real_import = builtins.__import__
+        def mocked_import(name, *args, **kwargs):
+            if name == 'h5py' or name == 'yaml':
+                raise ModuleNotFoundError
+            return real_import(name, *args, **kwargs)
+        mocker.patch('builtins.__import__', side_effect=mocked_import)
         with pytest.raises(ImportPhonopyReaderError):
             QpointPhononModes.from_phonopy(**phonopy_args)
 

--- a/tests_and_analysis/test/euphonic_test/test_ref_data.py
+++ b/tests_and_analysis/test/euphonic_test/test_ref_data.py
@@ -7,7 +7,6 @@ from euphonic import ureg
 from euphonic.util import get_reference_data
 
 
-@pytest.mark.unit
 class TestReferenceData:
 
     def test_bad_collection(self):

--- a/tests_and_analysis/test/euphonic_test/test_spectrum1d.py
+++ b/tests_and_analysis/test/euphonic_test/test_spectrum1d.py
@@ -116,7 +116,6 @@ def check_spectrum1d(actual_spectrum1d, expected_spectrum1d):
                 == expected_spectrum1d.metadata)
 
 
-@pytest.mark.unit
 class TestSpectrum1DCreation:
 
     # As x_data can be either bin centres or edges, test both cases with
@@ -212,7 +211,6 @@ class TestSpectrum1DCreation:
             Spectrum1D(*faulty_args, **faulty_kwargs)
 
 
-@pytest.mark.unit
 class TestSpectrum1DSerialisation:
 
     # Note that when writing .text there must be the same number of
@@ -258,7 +256,6 @@ class TestSpectrum1DSerialisation:
         check_spectrum1d(spec1d_from_dict, expected_spec1d)
 
 
-@pytest.mark.unit
 class TestSpectrum1DUnitConversion:
 
     @pytest.mark.parametrize('spectrum1d_file, attr, unit_val', [
@@ -278,7 +275,6 @@ class TestSpectrum1DUnitConversion:
             setattr(spec1d, unit_attr, unit_val)
 
 
-@pytest.mark.unit
 class TestSpectrum1DSetters:
 
     @pytest.mark.parametrize('spectrum1d_file, attr, unit, scale', [
@@ -303,7 +299,6 @@ class TestSpectrum1DSetters:
             setattr(spec1d, attr, new_attr)
 
 
-@pytest.mark.unit
 class TestSpectrum1DMethods:
     @pytest.mark.parametrize(
         'args, spectrum1d_file, split_spectrum_files', [

--- a/tests_and_analysis/test/euphonic_test/test_spectrum1dcollection.py
+++ b/tests_and_analysis/test/euphonic_test/test_spectrum1dcollection.py
@@ -119,7 +119,6 @@ def check_spectrum1dcollection(actual_spectrum, expected_spectrum):
                 == expected_spectrum.metadata)
 
 
-@pytest.mark.unit
 class TestSpectrum1DCollectionCreation:
     @pytest.fixture(params=[
         get_expected_spectrum1dcollection('gan_bands.json'),
@@ -270,7 +269,6 @@ class TestSpectrum1DCollectionCreation:
             Spectrum1DCollection.from_spectra(input_spectra)
 
 
-@pytest.mark.unit
 class TestSpectrum1DCollectionSerialisation:
 
     # Note that when writing .text there must be the same number of
@@ -321,7 +319,6 @@ class TestSpectrum1DCollectionSerialisation:
         check_spectrum1dcollection(spectrum_from_dict, expected_spectrum)
 
 
-@pytest.mark.unit
 class TestSpectrum1DCollectionUnitConversion:
 
     @pytest.mark.parametrize('spectrum1d_file, attr, unit_val', [
@@ -341,7 +338,6 @@ class TestSpectrum1DCollectionUnitConversion:
             setattr(spec1d, unit_attr, unit_val)
 
 
-@pytest.mark.unit
 class TestSpectrum1DCollectionSetters:
 
     @pytest.mark.parametrize('spectrum1d_file, attr, unit, scale', [
@@ -366,7 +362,6 @@ class TestSpectrum1DCollectionSetters:
             setattr(spec1d, attr, new_attr)
 
 
-@pytest.mark.unit
 class TestSpectrum1DCollectionIndexAccess:
     @pytest.mark.parametrize(
         'spectrum, index, expected_spectrum1d',
@@ -422,7 +417,6 @@ class TestSpectrum1DCollectionIndexAccess:
             spectrum[index]
 
 
-@pytest.mark.unit
 class TestSpectrum1DCollectionMethods:
     @pytest.mark.parametrize(
         'spectrum, split_kwargs, expected_spectra',

--- a/tests_and_analysis/test/euphonic_test/test_spectrum2d.py
+++ b/tests_and_analysis/test/euphonic_test/test_spectrum2d.py
@@ -129,7 +129,6 @@ def check_spectrum2d(actual_spectrum2d, expected_spectrum2d):
                 == expected_spectrum2d.metadata)
 
 
-@pytest.mark.unit
 class TestSpectrum2DCreation:
 
     # As x_data and y_data can be either bin centres or edges, test all
@@ -219,7 +218,6 @@ class TestSpectrum2DCreation:
             Spectrum2D(*faulty_args, **faulty_kwargs)
 
 
-@pytest.mark.unit
 class TestSpectrum2DSerialisation:
 
     @pytest.mark.parametrize('spec2d', [
@@ -253,7 +251,6 @@ class TestSpectrum2DSerialisation:
         check_spectrum2d(spec2d, expected_spec2d)
 
 
-@pytest.mark.unit
 class TestSpectrum2DUnitConversion:
 
     @pytest.mark.parametrize('spectrum2d_file, attr, unit_val', [
@@ -275,7 +272,6 @@ class TestSpectrum2DUnitConversion:
             setattr(spec2d, unit_attr, unit_val)
 
 
-@pytest.mark.unit
 class TestSpectrum2DSetters:
 
     @pytest.mark.parametrize('spectrum2d_file, attr, unit, scale', [
@@ -302,7 +298,6 @@ class TestSpectrum2DSetters:
             setattr(spec2d, attr, new_attr)
 
 
-@pytest.mark.unit
 class TestSpectrum2DMethods:
     @pytest.mark.parametrize(
         'args, spectrum2d_file, split_spectrum_files',

--- a/tests_and_analysis/test/euphonic_test/test_structure_factor.py
+++ b/tests_and_analysis/test/euphonic_test/test_structure_factor.py
@@ -183,7 +183,6 @@ def check_structure_factor(
         gamma_atol=sf_gamma_atol)
 
 
-@pytest.mark.unit
 class TestStructureFactorCreation:
 
     @pytest.fixture(params=[
@@ -287,7 +286,6 @@ class TestStructureFactorCreation:
             StructureFactor(*faulty_args, **faulty_kwargs)
 
 
-@pytest.mark.unit
 class TestStructureFactorSerialisation:
 
     @pytest.mark.parametrize('sf', [
@@ -331,7 +329,6 @@ class TestStructureFactorSerialisation:
         check_qpt_freqs(qpt_freqs, expected_qpt_freqs)
 
 
-@pytest.mark.unit
 class TestStructureFactorUnitConversion:
 
     @pytest.mark.parametrize('material, json_file, attr, unit_val', [
@@ -360,7 +357,6 @@ class TestStructureFactorUnitConversion:
             setattr(sf, unit_attr, unit_val)
 
 
-@pytest.mark.unit
 class TestStructureFactorSetters:
 
     @pytest.mark.parametrize('material, json_file, attr, unit, scale', [
@@ -395,7 +391,6 @@ class TestStructureFactorSetters:
             setattr(sf, attr, new_attr)
 
 
-@pytest.mark.unit
 class TestStructureFactorCalculateSqwMap:
 
     @pytest.mark.parametrize(
@@ -443,7 +438,6 @@ class TestStructureFactorCalculateSqwMap:
         with pytest.raises(err):
             sf.calculate_sqw_map(ebins, **kwargs)
 
-@pytest.mark.unit
 class TestStructureFactorCalculate1dAverage:
 
     @pytest.mark.parametrize(
@@ -467,7 +461,6 @@ class TestStructureFactorCalculate1dAverage:
         expected_sw = get_expected_spectrum1d(expected_1d_json)
         check_spectrum1d(sw, expected_sw)
 
-@pytest.mark.unit
 class TestStructureFactorGetDispersion:
 
     @pytest.mark.parametrize(
@@ -485,7 +478,6 @@ class TestStructureFactorGetDispersion:
             expected_dispersion_json)
         check_spectrum1dcollection(disp, expected_disp)
 
-@pytest.mark.unit
 class TestStructureFactorCalculateDos:
 
     @pytest.mark.parametrize(

--- a/tests_and_analysis/test/euphonic_test/test_util.py
+++ b/tests_and_analysis/test/euphonic_test/test_util.py
@@ -14,7 +14,6 @@ from tests_and_analysis.test.euphonic_test.test_force_constants import (
     get_fc_dir)
 
 
-@pytest.mark.unit
 class TestDirectionChanged:
 
     def test_direction_changed_nah(self):
@@ -31,7 +30,6 @@ class TestDirectionChanged:
                          expected_direction_changed)
 
 
-@pytest.mark.unit
 class TestMPGrid:
 
     def test_444_grid(self):
@@ -41,7 +39,6 @@ class TestMPGrid:
         npt.assert_equal(qpts, expected_qpts)
 
 
-@pytest.mark.unit
 class TestGetQptLabels:
 
     @pytest.mark.parametrize('qpts, kwargs, expected_labels', [
@@ -80,7 +77,6 @@ def get_modg_norm(mode_gradients_file):
     return np.linalg.norm(modg.magnitude, axis=-1)*modg.units
 
 
-@pytest.mark.unit
 class TestModeGradientsToWidths:
 
     @pytest.mark.parametrize('mode_grads, cell_vecs, expected_mode_widths_file', [

--- a/tests_and_analysis/test/pytest.ini
+++ b/tests_and_analysis/test/pytest.ini
@@ -1,4 +1,4 @@
 [pytest]
 markers =
-    unit: mark tests as a unit test
-    integration: mark tests as an integration test
+    phonopy_reader: requires euphonic[phonopy_reader] extra to be installed
+    matplotlib: requires euphonic[matplotlib] extra to be installed

--- a/tests_and_analysis/test/run_tests.py
+++ b/tests_and_analysis/test/run_tests.py
@@ -11,14 +11,14 @@ import coverage
 def main():
     test_dir, reports_dir = _get_test_and_reports_dir()
 
-    do_report_coverage, do_report_tests, tests, markers_to_run = \
-        _get_parsed_args(test_dir)
+    (do_report_coverage, do_report_tests, tests,
+     markers_to_run) = _get_parsed_args(test_dir)
 
     pytest_options: List[str] = _build_pytest_options(
         reports_dir, do_report_tests, tests, markers_to_run)
 
-    test_exit_code: int = \
-        run_tests(pytest_options, do_report_coverage, reports_dir, test_dir)
+    test_exit_code: int = run_tests(
+        pytest_options, do_report_coverage, reports_dir, test_dir)
 
     # Exit with a failure code if there are any errors or failures
     sys.exit(test_exit_code)

--- a/tests_and_analysis/test/run_tests.py
+++ b/tests_and_analysis/test/run_tests.py
@@ -49,7 +49,7 @@ def _get_parsed_args(test_dir: str) -> Tuple[bool, bool, str, str]:
     parser = argparse.ArgumentParser()
     parser.add_argument(
         "--cov", action="store_true",
-        help="If present report coverage in a coverage.xml file in reports")
+        help="If present report coverage in a coverage*.xml file in reports")
     parser.add_argument(
         "--report", action="store_true",
         help="If present report test results to junit_report*.xml files")
@@ -110,7 +110,7 @@ def run_tests(pytest_options: List[str], do_report_coverage: bool,
     pytest_options : List[str]
         The options to pass to pytest
     do_report_coverage : bool
-        If true report coverage to coverage.xml
+        If true report coverage to coverage*.xml
     reports_dir : str
         The directory to report coverage to
     test_dir: str
@@ -141,7 +141,8 @@ def run_tests(pytest_options: List[str], do_report_coverage: bool,
     # Report coverage if requested
     if do_report_coverage and cov is not None:
         cov.stop()
-        coverage_xml_filepath = os.path.join(reports_dir, "coverage.xml")
+        coverage_xml_filepath = os.path.join(
+            reports_dir, f"coverage_{int(time.time())}.xml")
         cov.xml_report(outfile=coverage_xml_filepath)
 
     return test_exit_code

--- a/tests_and_analysis/test/run_tests.py
+++ b/tests_and_analysis/test/run_tests.py
@@ -64,7 +64,7 @@ def _get_parsed_args(test_dir: str) -> Tuple[bool, bool, str, str]:
             args_parsed.markers_to_run)
 
 
-def _build_pytest_options(reports_dir: str, do_report_tests: bool, tests: str,
+def _build_pytest_options(do_report_tests: bool, tests: str,
                           markers: str) -> List[str]:
     """
     Build the options for pytest to use.
@@ -154,7 +154,7 @@ if __name__ == "__main__":
         _get_parsed_args(test_dir)
 
     pytest_options: List[str] = _build_pytest_options(
-        reports_dir, do_report_tests, tests, markers_to_run)
+        do_report_tests, tests, markers_to_run)
 
     test_exit_code: int = \
         run_tests(pytest_options, do_report_coverage, reports_dir, test_dir)

--- a/tests_and_analysis/test/run_tests.py
+++ b/tests_and_analysis/test/run_tests.py
@@ -8,6 +8,22 @@ import pytest
 import coverage
 
 
+def main():
+    test_dir, reports_dir = _get_test_and_reports_dir()
+
+    do_report_coverage, do_report_tests, tests, markers_to_run = \
+        _get_parsed_args(test_dir)
+
+    pytest_options: List[str] = _build_pytest_options(
+        reports_dir, do_report_tests, tests, markers_to_run)
+
+    test_exit_code: int = \
+        run_tests(pytest_options, do_report_coverage, reports_dir, test_dir)
+
+    # Exit with a failure code if there are any errors or failures
+    sys.exit(test_exit_code)
+
+
 def _get_test_and_reports_dir() -> Tuple[str, str]:
     """
     Get the directory that holds the tests and the directory to write
@@ -64,8 +80,8 @@ def _get_parsed_args(test_dir: str) -> Tuple[bool, bool, str, str]:
             args_parsed.markers_to_run)
 
 
-def _build_pytest_options(do_report_tests: bool, tests: str,
-                          markers: str) -> List[str]:
+def _build_pytest_options(reports_dir: str, do_report_tests: bool,
+                          tests: str, markers: str) -> List[str]:
     """
     Build the options for pytest to use.
 
@@ -93,7 +109,7 @@ def _build_pytest_options(do_report_tests: bool, tests: str,
         filename_prefix = "junit_report"
         filenum = int(time.time())
         junit_xml_filepath = os.path.join(
-            test_dir, "reports", f"{filename_prefix}_{filenum}.xml")
+            reports_dir, f"{filename_prefix}_{filenum}.xml")
         options.append(f"--junitxml={junit_xml_filepath}")
     # Only run the specified markers
     options.append(f"-m={markers}")
@@ -149,16 +165,4 @@ def run_tests(pytest_options: List[str], do_report_coverage: bool,
 
 
 if __name__ == "__main__":
-    test_dir, reports_dir = _get_test_and_reports_dir()
-
-    do_report_coverage, do_report_tests, tests, markers_to_run = \
-        _get_parsed_args(test_dir)
-
-    pytest_options: List[str] = _build_pytest_options(
-        do_report_tests, tests, markers_to_run)
-
-    test_exit_code: int = \
-        run_tests(pytest_options, do_report_coverage, reports_dir, test_dir)
-
-    # Exit with a failure code if there are any errors or failures
-    sys.exit(test_exit_code)
+    main()

--- a/tests_and_analysis/test/run_tests.py
+++ b/tests_and_analysis/test/run_tests.py
@@ -1,9 +1,11 @@
+import argparse
 import sys
 import os
+import time
+from typing import Tuple, List, Union
+
 import pytest
 import coverage
-import argparse
-from typing import Tuple, List, Union
 
 
 def _get_test_and_reports_dir() -> Tuple[str, str]:
@@ -87,17 +89,14 @@ def _build_pytest_options(reports_dir: str, do_report_tests: bool, tests: str,
     options: List[str] = [tests]
     # Add reporting of test results
     if do_report_tests:
-        # We may have multiple reports, so do not overwrite them
+        # We may have multiple reports, so get a unique filename
         filename_prefix = "junit_report"
-        filenum = 0
-        for filename in os.listdir(reports_dir):
-            if filename_prefix in filename:
-                filenum += 1
-        junit_xml_filepath: str = os.path.join(
-            test_dir, "reports", "{}{}.xml".format(filename_prefix, filenum))
-        options.append("--junitxml={}".format(junit_xml_filepath))
+        filenum = int(time.time())
+        junit_xml_filepath = os.path.join(
+            test_dir, "reports", f"{filename_prefix}_{filenum}.xml")
+        options.append(f"--junitxml={junit_xml_filepath}")
     # Only run the specified markers
-    options.append("-m={}".format(markers))
+    options.append(f"-m={markers}")
     return options
 
 

--- a/tests_and_analysis/test/script_tests/test_dispersion.py
+++ b/tests_and_analysis/test/script_tests/test_dispersion.py
@@ -56,7 +56,6 @@ disp_params_from_phonopy =  [
 disp_params_macos_segfault =  [[cahgo2_fc_file, '--reorder']]
 
 
-@pytest.mark.integration
 class TestRegression:
 
     @pytest.fixture

--- a/tests_and_analysis/test/script_tests/test_dispersion.py
+++ b/tests_and_analysis/test/script_tests/test_dispersion.py
@@ -6,8 +6,6 @@ from platform import platform
 
 import pytest
 import numpy.testing as npt
-# Required for mocking
-import matplotlib.pyplot
 from packaging import version
 from scipy import __version__ as scipy_ver
 
@@ -15,8 +13,15 @@ from tests_and_analysis.test.utils import (
     get_data_path, get_castep_path, get_phonopy_path)
 from tests_and_analysis.test.script_tests.utils import (
     get_script_test_data_path, get_current_plot_line_data, args_to_key)
-import euphonic.cli.dispersion
 
+pytestmark = pytest.mark.matplotlib
+# Allow tests with matplotlib marker to be collected and
+# deselected if Matplotlib is not installed
+try:
+    import matplotlib.pyplot
+    import euphonic.cli.dispersion
+except ModuleNotFoundError:
+    pass
 
 cahgo2_fc_file = get_phonopy_path('CaHgO2', 'mp-7041-20180417.yaml')
 lzo_fc_file = os.path.join(

--- a/tests_and_analysis/test/script_tests/test_dispersion.py
+++ b/tests_and_analysis/test/script_tests/test_dispersion.py
@@ -31,6 +31,10 @@ quartz_phonon_file = os.path.join(
     'quartz_bandstructure_qpoint_phonon_modes.json')
 disp_output_file = os.path.join(get_script_test_data_path(), 'dispersion.json')
 disp_params =  [
+    [lzo_fc_file],
+    [quartz_phonon_file],
+    [quartz_phonon_file, '--btol=1000']]
+disp_params_from_phonopy =  [
     [cahgo2_fc_file],
     [cahgo2_fc_file, '--energy-unit=hartree'],
     [cahgo2_fc_file, '--x-label=wavenumber', '--y-label=Energy (meV)',
@@ -41,10 +45,7 @@ disp_params =  [
     [cahgo2_fc_file, '--q-spacing=0.02'],
     [cahgo2_fc_file, '--asr'],
     [cahgo2_fc_file, '--asr=realspace'],
-    [lzo_fc_file],
     [nacl_fc_file],
-    [quartz_phonon_file],
-    [quartz_phonon_file, '--btol=1000'],
     [nacl_phonon_file],
     [nacl_phonon_hdf5_file]]
 disp_params_macos_segfault =  [[cahgo2_fc_file, '--reorder']]
@@ -93,6 +94,13 @@ class TestRegression:
     def test_dispersion_plot_data(self, inject_mocks, dispersion_args):
         self.run_dispersion_and_test_result(dispersion_args)
 
+    @pytest.mark.phonopy_reader
+    @pytest.mark.parametrize('dispersion_args', disp_params_from_phonopy)
+    def test_dispersion_plot_data_from_phonopy(
+            self, inject_mocks, dispersion_args):
+        self.run_dispersion_and_test_result(dispersion_args)
+
+    @pytest.mark.phonopy_reader
     @pytest.mark.parametrize('dispersion_args', disp_params_macos_segfault)
     @pytest.mark.skipif(
         (any([s in platform() for s in ['Darwin', 'macOS']])

--- a/tests_and_analysis/test/script_tests/test_dos.py
+++ b/tests_and_analysis/test/script_tests/test_dos.py
@@ -45,7 +45,6 @@ dos_params = [
     [quartz_fc_file, '--grid', '5', '5', '4', '--adaptive', '--eb', '2']]
 
 
-@pytest.mark.integration
 class TestRegression:
 
     @pytest.fixture

--- a/tests_and_analysis/test/script_tests/test_dos.py
+++ b/tests_and_analysis/test/script_tests/test_dos.py
@@ -6,16 +6,21 @@ from unittest.mock import patch
 import pytest
 import numpy as np
 import numpy.testing as npt
-# Required for mocking
-import matplotlib.pyplot
 
 from tests_and_analysis.test.utils import get_data_path, get_castep_path
 from tests_and_analysis.test.script_tests.utils import (
     get_script_test_data_path, get_current_plot_line_data,
     args_to_key)
 from euphonic.cli.utils import _get_pdos_weighting
-import euphonic.cli.dos
 
+pytestmark = pytest.mark.matplotlib
+# Allow tests with matplotlib marker to be collected and
+# deselected if Matplotlib is not installed
+try:
+    import matplotlib.pyplot
+    import euphonic.cli.dos
+except ModuleNotFoundError:
+    pass
 
 nah_phonon_file = get_castep_path('NaH', 'NaH.phonon')
 quartz_fc_file = get_castep_path('quartz', 'quartz.castep_bin')

--- a/tests_and_analysis/test/script_tests/test_intensity_map.py
+++ b/tests_and_analysis/test/script_tests/test_intensity_map.py
@@ -51,7 +51,6 @@ intensity_map_params_macos_segfault = [
     [graphite_fc_file, '--weighting=coherent', '--temperature=800']]
 
 
-@pytest.mark.integration
 class TestRegression:
 
     @pytest.fixture

--- a/tests_and_analysis/test/script_tests/test_intensity_map.py
+++ b/tests_and_analysis/test/script_tests/test_intensity_map.py
@@ -5,16 +5,21 @@ from platform import platform
 
 import pytest
 import numpy.testing as npt
-# Required for mocking
-import matplotlib.pyplot
 from packaging import version
 from scipy import __version__ as scipy_ver
 
 from tests_and_analysis.test.utils import get_data_path, get_castep_path
 from tests_and_analysis.test.script_tests.utils import (
     get_script_test_data_path, get_current_plot_image_data, args_to_key)
-import euphonic.cli.intensity_map
 
+pytestmark = pytest.mark.matplotlib
+# Allow tests with matplotlib marker to be collected and
+# deselected if Matplotlib is not installed
+try:
+    import matplotlib.pyplot
+    import euphonic.cli.intensity_map
+except ModuleNotFoundError:
+    pass
 
 quartz_phonon_file = os.path.join(
     get_data_path(), 'qpoint_phonon_modes', 'quartz',

--- a/tests_and_analysis/test/script_tests/test_optimise_dipole_parameter.py
+++ b/tests_and_analysis/test/script_tests/test_optimise_dipole_parameter.py
@@ -46,6 +46,7 @@ class TestRegression:
         euphonic.cli.optimise_dipole_parameter.main(
             optimise_dipole_parameter_args)
 
+    @pytest.mark.phonopy_reader
     def test_reading_nacl_default_reads_born(self, recwarn):
         # BORN should be read by default so no warning should
         # be raised

--- a/tests_and_analysis/test/script_tests/test_optimise_dipole_parameter.py
+++ b/tests_and_analysis/test/script_tests/test_optimise_dipole_parameter.py
@@ -20,7 +20,6 @@ nacl_default_yaml = get_phonopy_path("NaCl_default", "phonopy.yaml")
 quick_calc_params = ['-n=10', '--min=0.5', '--max=0.5']
 
 
-@pytest.mark.integration
 class TestRegression:
 
     def test_default_dipole_parameters(self):

--- a/tests_and_analysis/test/script_tests/test_powder_map.py
+++ b/tests_and_analysis/test/script_tests/test_powder_map.py
@@ -22,12 +22,6 @@ powder_map_output_file = os.path.join(get_script_test_data_path(),
 
 quick_calc_params = ['--npts=10', '--npts-min=10', '--q-spacing=1']
 powder_map_params = [
-    [nacl_prim_fc_file],
-    [nacl_prim_fc_file, '--temperature=1000', *quick_calc_params],
-    [nacl_prim_fc_file, '--v-min=0', '--v-max=1e-10', *quick_calc_params],
-    [nacl_prim_fc_file, '--energy-unit=meV', *quick_calc_params],
-    [nacl_prim_fc_file, '--weighting=coherent', '--c-map=bone',
-     *quick_calc_params],
     [graphite_fc_file, '-w', 'dos', '--y-label=DOS', '--title=DOS TITLE',
      *quick_calc_params],
     [graphite_fc_file, '--e-min=50', '-u=cm^-1', '--x-label=wavenumber',
@@ -42,6 +36,13 @@ powder_map_params = [
      *quick_calc_params],
     [graphite_fc_file, '--asr', *quick_calc_params],
     [graphite_fc_file, '--asr=realspace', '--dipole-parameter=0.75',
+     *quick_calc_params]]
+powder_map_params_from_phonopy = [
+    [nacl_prim_fc_file],
+    [nacl_prim_fc_file, '--temperature=1000', *quick_calc_params],
+    [nacl_prim_fc_file, '--v-min=0', '--v-max=1e-10', *quick_calc_params],
+    [nacl_prim_fc_file, '--energy-unit=meV', *quick_calc_params],
+    [nacl_prim_fc_file, '--weighting=coherent', '--c-map=bone',
      *quick_calc_params],
     [nacl_prim_fc_file, '-w=incoherent-dos', '--pdos=Na', '--no-widget',
      *quick_calc_params],
@@ -99,6 +100,14 @@ class TestRegression:
             self, inject_mocks, powder_map_args):
         self.run_powder_map_and_test_result(powder_map_args)
 
+    @pytest.mark.phonopy_reader
+    @pytest.mark.parametrize(
+        'powder_map_args', powder_map_params_from_phonopy)
+    def test_powder_map_plot_image_from_phonopy(
+            self, inject_mocks, powder_map_args):
+        self.run_powder_map_and_test_result(powder_map_args)
+
+    @pytest.mark.phonopy_reader
     @pytest.mark.parametrize('powder_map_args', powder_map_params_macos_segfault)
     @pytest.mark.skipif(
         (any([s in platform() for s in ['Darwin', 'macOS']])
@@ -109,6 +118,7 @@ class TestRegression:
             self, inject_mocks, powder_map_args):
         self.run_powder_map_and_test_result(powder_map_args)
 
+    @pytest.mark.phonopy_reader
     @pytest.mark.parametrize('powder_map_args', [
         [nacl_prim_fc_file, '--save-to'],
         [nacl_prim_fc_file, '-s']])
@@ -124,6 +134,7 @@ class TestRegression:
         with pytest.raises(ValueError):
             euphonic.cli.powder_map.main(powder_map_args)
 
+    @pytest.mark.phonopy_reader
     @pytest.mark.parametrize('powder_map_args', [
         [nacl_prim_fc_file, '--weights=dos']])
     def test_weights_emits_deprecation_warning(
@@ -140,6 +151,7 @@ class TestRegression:
         assert err.type == SystemExit
         assert err.value.code == 2
 
+    @pytest.mark.phonopy_reader
     @pytest.mark.parametrize('powder_map_args', [
         [nacl_prim_fc_file, '-w=coherent', '--pdos', 'Na']])
     def test_coherent_weighting_and_pdos_raises_value_error(

--- a/tests_and_analysis/test/script_tests/test_powder_map.py
+++ b/tests_and_analysis/test/script_tests/test_powder_map.py
@@ -5,15 +5,21 @@ from platform import platform
 
 import pytest
 import numpy.testing as npt
-# Required for mocking
-import matplotlib.pyplot
 from packaging import version
 from scipy import __version__ as scipy_ver
 
 from tests_and_analysis.test.utils import get_data_path, get_castep_path, get_phonopy_path
 from tests_and_analysis.test.script_tests.utils import (
     get_script_test_data_path, get_current_plot_image_data, args_to_key)
-import euphonic.cli.powder_map
+
+pytestmark = pytest.mark.matplotlib
+# Allow tests with matplotlib marker to be collected and
+# deselected if Matplotlib is not installed
+try:
+    import matplotlib.pyplot
+    import euphonic.cli.powder_map
+except ModuleNotFoundError:
+    pass
 
 graphite_fc_file = get_castep_path('graphite', 'graphite.castep_bin')
 nacl_prim_fc_file = get_phonopy_path('NaCl_prim', 'phonopy_nacl.yaml')

--- a/tests_and_analysis/test/script_tests/test_powder_map.py
+++ b/tests_and_analysis/test/script_tests/test_powder_map.py
@@ -61,7 +61,6 @@ powder_map_params_macos_segfault = [
      *quick_calc_params]]
 
 
-@pytest.mark.integration
 class TestRegression:
 
     @pytest.fixture

--- a/tests_and_analysis/test/script_tests/test_sphere_sampling.py
+++ b/tests_and_analysis/test/script_tests/test_sphere_sampling.py
@@ -6,13 +6,18 @@ from unittest.mock import patch
 import pytest
 import numpy as np
 import numpy.testing as npt
-# Required for mocking
-import matplotlib.pyplot
 
 from tests_and_analysis.test.script_tests.utils import (
     get_script_test_data_path, get_current_plot_offsets)
-import euphonic.cli.show_sampling
 
+pytestmark = pytest.mark.matplotlib
+# Allow tests with matplotlib marker to be collected and
+# deselected if Matplotlib is not installed
+try:
+    import matplotlib.pyplot
+    import euphonic.cli.show_sampling
+except ModuleNotFoundError:
+    pass
 
 sphere_sampling_output_file = os.path.join(get_script_test_data_path(),
                                            "sphere_sampling.json")

--- a/tests_and_analysis/test/script_tests/test_sphere_sampling.py
+++ b/tests_and_analysis/test/script_tests/test_sphere_sampling.py
@@ -37,7 +37,6 @@ sphere_sampling_params =  [
     ['10', 'random-sphere', '--jitter']]
 
 
-@pytest.mark.integration
 class TestRegression:
 
     @pytest.fixture

--- a/tests_and_analysis/test/script_tests/test_styling.py
+++ b/tests_and_analysis/test/script_tests/test_styling.py
@@ -44,14 +44,12 @@ compose_style_cases = [
     ]
 
 
-@pytest.mark.unit
 @pytest.mark.parametrize('kwargs,expected_style', compose_style_cases)
 def test_compose_style(kwargs, expected_style):
     """Internal function which interprets matplotlib style options"""
     assert _compose_style(**kwargs) == expected_style
 
 
-@pytest.mark.integration
 class TestDOSStyling:
 
     @pytest.fixture

--- a/tests_and_analysis/test/script_tests/test_styling.py
+++ b/tests_and_analysis/test/script_tests/test_styling.py
@@ -1,13 +1,20 @@
 from argparse import Namespace
 
 import pytest
-import matplotlib.pyplot
 from numpy.testing import assert_allclose
 
-import euphonic.cli.dos
 from euphonic.cli.utils import _compose_style
 
 from tests_and_analysis.test.utils import get_castep_path
+
+pytestmark = pytest.mark.matplotlib
+# Allow tests with matplotlib marker to be collected and
+# deselected if Matplotlib is not installed
+try:
+    import matplotlib.pyplot
+    import euphonic.cli.dos
+except ModuleNotFoundError:
+    pass
 
 compose_style_cases = [
     ({'user_args': Namespace(unused=1, no_base_style=False, style=None),

--- a/tests_and_analysis/test/script_tests/utils.py
+++ b/tests_and_analysis/test/script_tests/utils.py
@@ -1,7 +1,9 @@
 import os
 # Required for mocking
-import matplotlib.pyplot
-from matplotlib.axes import Axes
+try:
+    import matplotlib.pyplot
+except ModuleNotFoundError:
+    pass
 from typing import Dict, List, Union
 from ..utils import get_data_path
 
@@ -97,8 +99,8 @@ def get_current_plot_image_data() -> Dict[str,
     return data
 
 
-def get_ax_image_data(ax: Axes) -> Dict[str,
-                                        Union[str, List[float], List[int]]]:
+def get_ax_image_data(ax: 'matplotlib.axes.Axes'
+                      ) -> Dict[str, Union[str, List[float], List[int]]]:
     im = ax.get_images()[0]
     # Convert negative zero to positive zero
     im_data = im.get_array()

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,5 @@
 [tox]
-# Use conda to set up the python environments to run in
-# Pin tox-conda 0.7.3 for now as tox-conda 0.8 requires conda 4.9.0
-# which isn't yet installed on all CI nodes
-requires = tox-conda==0.7.3
+requires = tox-conda
 # The python environments to run the tests in
 envlist = py36,py37,py38,py36-minrequirements-linux
 # Skip the execution of setup.py as we do it with the correct arg in commands_pre below
@@ -20,14 +17,11 @@ install_command =
 deps =
     numpy
     -r{toxinidir}/tests_and_analysis/tox_requirements.txt
-commands_pre =
-    python -m pip install \
-    --force-reinstall \
-    --upgrade \
-    --upgrade-strategy eager \
-    '{toxinidir}[matplotlib,phonopy_reader]'
 commands =
-    python run_tests.py --cov --report {posargs}
+    python -m pip install --upgrade --upgrade-strategy eager '{toxinidir}[matplotlib]'
+    python run_tests.py --cov --report -m "not phonopy_reader"
+    python -m pip install --upgrade --upgrade-strategy eager '{toxinidir}[phonopy_reader]'
+    python run_tests.py --cov --report -m "phonopy_reader"
 
 [testenv:py36-minrequirements-linux]
 whitelist_externals = rm
@@ -40,12 +34,14 @@ platform =
     linux: linux
 deps =
     numpy==1.12.1
+    -r{toxinidir}/tests_and_analysis/minimum_euphonic_requirements.txt
+    -r{toxinidir}/tests_and_analysis/tox_requirements.txt
 commands_pre =
-    python -m pip install --force-reinstall -r{toxinidir}/tests_and_analysis/minimum_euphonic_requirements.txt
-    python -m pip install --force-reinstall -r{toxinidir}/tests_and_analysis/tox_requirements.txt
 # Force rebuild of euphonic extension to avoid Numpy clash
 # (it still exists from py36 env)
     rm -rf build
-    python -m pip install '{toxinidir}[matplotlib,phonopy_reader]'
 commands =
-    python run_tests.py {posargs}
+    python -m pip install '{toxinidir}[matplotlib]'
+    python run_tests.py --report -m "not phonopy_reader"
+    python -m pip install '{toxinidir}[matplotlib,phonopy_reader]'
+    python run_tests.py  --report -m "phonopy_reader"

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 requires = tox-conda
 # The python environments to run the tests in
-envlist = {py36,py37,py38}-{base,phonopy_reader},py36-minrequirements-linux
+envlist = py37,py38,py36-{base,matplotlib,phonopy_reader,all},py36-minrequirements-linux
 # Skip the execution of setup.py as we do it with the correct arg in commands_pre below
 skipsdist = True
 
@@ -9,7 +9,7 @@ skipsdist = True
 changedir = tests_and_analysis/test
 test_command = python run_tests.py --report
 
-[testenv:{py36,py37,py38}-base]
+[testenv:{py37,py38}]
 install_command =
     python -m pip install \
         --force-reinstall \
@@ -24,18 +24,52 @@ commands_pre =
     python -m pip install \
         --upgrade \
 	--upgrade-strategy eager \
-	'{toxinidir}[matplotlib]'
-commands = {[testenv]test_command} --cov -m "not phonopy_reader"
+	'{toxinidir}[matplotlib,phonopy_reader]'
+commands = {[testenv]test_command} --cov
 
-[testenv:{py36,py37,py38}-phonopy_reader]
-install_command = {[testenv:py36-base]install_command}
-deps = {[testenv:py36-base]deps}
+# Test with no extras
+[testenv:py36-base]
+install_command = {[testenv:py37]install_command}
+deps = {[testenv:py37]deps}
+commands_pre =
+    python -m pip install \
+        --upgrade \
+	--upgrade-strategy eager \
+        '{toxinidir}'
+commands = {[testenv]test_command} --cov -m "not (phonopy_reader or matplotlib)"
+
+# Test with matplotlib extra only
+[testenv:py36-matplotlib]
+install_command = {[testenv:py37]install_command}
+deps = {[testenv:py37]deps}
+commands_pre =
+    python -m pip install \
+        --upgrade \
+	--upgrade-strategy eager \
+        '{toxinidir}[matplotlib]'
+commands = {[testenv]test_command} --cov -m "matplotlib and not phonopy_reader"
+
+# Test with phonopy_reader extra only
+[testenv:py36-phonopy_reader]
+install_command = {[testenv:py37]install_command}
+deps = {[testenv:py37]deps}
+commands_pre =
+    python -m pip install \
+        --upgrade \
+	--upgrade-strategy eager \
+        '{toxinidir}[phonopy_reader]'
+commands = {[testenv]test_command} --cov -m "phonopy_reader and not matplotlib"
+
+# Run remaining tests that require multiple extras
+[testenv:py36-all]
+install_command = {[testenv:py37]install_command}
+deps = {[testenv:py37]deps}
 commands_pre =
     python -m pip install \
         --upgrade \
 	--upgrade-strategy eager \
         '{toxinidir}[phonopy_reader,matplotlib]'
-commands = {[testenv]test_command} --cov -m "phonopy_reader"
+commands = {[testenv]test_command} --cov -m "phonopy_reader and matplotlib"
 
 [testenv:py36-minrequirements-linux]
 whitelist_externals = rm

--- a/tox.ini
+++ b/tox.ini
@@ -7,6 +7,7 @@ skipsdist = True
 
 [testenv]
 changedir = tests_and_analysis/test
+test_command = python run_tests.py --report
 
 [testenv:{py36,py37,py38}-base]
 install_command =
@@ -14,36 +15,43 @@ install_command =
         --force-reinstall \
         --upgrade \
         --upgrade-strategy eager \
-        {opts} \
-        {packages}
+	{opts} \
+	{packages}
 deps =
     numpy
     -r{toxinidir}/tests_and_analysis/tox_requirements.txt
-commands_pre = python -m pip install --upgrade --upgrade-strategy eager '{toxinidir}[matplotlib]'
-commands = python run_tests.py --cov --report -m "not phonopy_reader"
+commands_pre =
+    python -m pip install \
+        --upgrade \
+	--upgrade-strategy eager \
+	'{toxinidir}[matplotlib]'
+commands = {[testenv]test_command} --cov -m "not phonopy_reader"
 
 [testenv:{py36,py37,py38}-phonopy_reader]
 install_command = {[testenv:py36-base]install_command}
 deps = {[testenv:py36-base]deps}
-commands_pre = python -m pip install --upgrade --upgrade-strategy eager '{toxinidir}[phonopy_reader,matplotlib]'
-commands = python run_tests.py --cov --report -m "phonopy_reader"
+commands_pre =
+    python -m pip install \
+        --upgrade \
+	--upgrade-strategy eager \
+        '{toxinidir}[phonopy_reader,matplotlib]'
+commands = {[testenv]test_command} --cov -m "phonopy_reader"
 
 [testenv:py36-minrequirements-linux]
 whitelist_externals = rm
 install_command =
-    python -m pip install \
-    --force-reinstall \
-    {opts} {packages}
+    python -m pip install --force-reinstall {opts} {packages}
 platform =
     linux: linux
 deps =
     numpy==1.12.1
-    -r{toxinidir}/tests_and_analysis/minimum_euphonic_requirements.txt
-    -r{toxinidir}/tests_and_analysis/tox_requirements.txt
 commands_pre =
+    python -m pip install --force-reinstall \
+        -r{toxinidir}/tests_and_analysis/minimum_euphonic_requirements.txt
+    python -m pip install --force-reinstall \
+        -r{toxinidir}/tests_and_analysis/tox_requirements.txt
 # Force rebuild of euphonic extension to avoid Numpy clash
 # (it still exists from py36 env)
     rm -rf build
     python -m pip install '{toxinidir}[matplotlib,phonopy_reader]'
-commands =
-    python run_tests.py --report
+commands = {[testenv]test_command}

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,14 @@
 [tox]
 requires = tox-conda
 # The python environments to run the tests in
-envlist = py36,py37,py38,py36-minrequirements-linux
+envlist = {py36,py37,py38}-{base,phonopy_reader},py36-minrequirements-linux
 # Skip the execution of setup.py as we do it with the correct arg in commands_pre below
 skipsdist = True
 
 [testenv]
 changedir = tests_and_analysis/test
+
+[testenv:{py36,py37,py38}-base]
 install_command =
     python -m pip install \
         --force-reinstall \
@@ -17,15 +19,17 @@ install_command =
 deps =
     numpy
     -r{toxinidir}/tests_and_analysis/tox_requirements.txt
-commands =
-    python -m pip install --upgrade --upgrade-strategy eager '{toxinidir}[matplotlib]'
-    python run_tests.py --cov --report -m "not phonopy_reader"
-    python -m pip install --upgrade --upgrade-strategy eager '{toxinidir}[phonopy_reader]'
-    python run_tests.py --cov --report -m "phonopy_reader"
+commands_pre = python -m pip install --upgrade --upgrade-strategy eager '{toxinidir}[matplotlib]'
+commands = python run_tests.py --cov --report -m "not phonopy_reader"
+
+[testenv:{py36,py37,py38}-phonopy_reader]
+install_command = {[testenv:py36-base]install_command}
+deps = {[testenv:py36-base]deps}
+commands_pre = python -m pip install --upgrade --upgrade-strategy eager '{toxinidir}[phonopy_reader,matplotlib]'
+commands = python run_tests.py --cov --report -m "phonopy_reader"
 
 [testenv:py36-minrequirements-linux]
 whitelist_externals = rm
-changedir = tests_and_analysis/test
 install_command =
     python -m pip install \
     --force-reinstall \
@@ -40,8 +44,6 @@ commands_pre =
 # Force rebuild of euphonic extension to avoid Numpy clash
 # (it still exists from py36 env)
     rm -rf build
-commands =
-    python -m pip install '{toxinidir}[matplotlib]'
-    python run_tests.py --report -m "not phonopy_reader"
     python -m pip install '{toxinidir}[matplotlib,phonopy_reader]'
-    python run_tests.py  --report -m "phonopy_reader"
+commands =
+    python run_tests.py --report


### PR DESCRIPTION
Addresses #198. I started thinking about this because adding Brille to Euphonic will add another optional dependency and it's probably easier to get on top of this sooner rather than later. You can now run pytest with something like `pytest -v tests_and_analysis/test -m "not matplotlib"` if you don't have Matplotlib installed and want to run every test except the matplotlib-dependent ones, or `pytest -v tests_and_analysis/test -m matplotlib` to _only_ run the matplotlib-dependent ones. This sort of thing is now used in the CI, so if we accidentally use an optional dependency somewhere else we should know about it.

Summary:
* Removed `unit` and `integration` markers as we weren't using them for any practical purposes
* Added `phonopy_reader` and `matplotlib` markers to tests that require each of these extras
* Refactored tests so that optional dependencies aren't imported unless a test is run:
   * Avoid importing dependencies in fixtures (as these are evaluated whether or not the test that uses them is run). For example `ForceConstants/QpointPhononModes/QpointFrequencies.from_x` tests are now tests in their own right rather than using fixtures. I actually think this looks cleaner anyway.
   * Allow `import matplotlib` to fail at the top of test files that have `mark.matplotlib`. Even if the whole file is marked with `pytestmark = pytest.mark.matplotlib` at the top, the file still needs to be imported by pytest even if the tests are not run, which would cause pytest to fail. The other alternative would be importing matplotlib as needed inside every test, and somehow refactor the fixtures, but that seemed like more faff.
   * Split some tests (e.g. going from `QpointPhononModes.from_castep/phonopy` to `StructureFactor`) into separate tests so they can be marked appropriately. There is still some duplication with this but it's not too bad.
   * There are 921 tests in the full suite in master and on this branch so I haven't accidentally dropped any!
* Refactored `tox.ini` to run tests with different extras:
  * py37. py38 tests will run all tests will all extras as normal
  * py36 will run tests with no extras, with each extra matplotlib and phonopy_reader, then run any other tests that require both extras
  * I've done it this way as there's some overhead with creating multiple tox environments. The CI on master takes 21 mins, whereas on this branch takes 23 mins even though we're running the same number of tests. I think running the full suite on py37 and py38, and running for specific extras only on py36 probably gives us a good mix of being thorough and not bloating the CI.
* Have not refactored `release_tox.ini` to test with specific extras, instead only running the whole suite as we're already testing for py36, py37 and py38, conda and pypi wheels and pypi source so adding specific extras tests might get messy. But feel free to disagree.

@jess-farmer Jess, tagging you as an FYI. Hopefully there wont be an issue with merging this with any tests you've already written but if there are feel free to ask me! I imagine you're not using `matplotlib` or `from_phonopy` in any of your tests but if you are you will just need to add the relevant markers, again feel free to ask.