### PR TITLE
Enable saving as JSON from CL tools

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,9 @@
     ``euphonic-intensity-map`` command-line tools can now read
     files that don't contain eigenvectors, if eigenvectors are
     not required for the chosen options.
+  - A new ``--save-json`` option is available for command-line tools
+    which produce plots, this will output the produced spectrum to
+    a Euphonic .json file.
   - There is now the option to use a fast, approximate variable-width broadening method when
     adaptively broadening dos:
 

--- a/doc/source/powder-map-script.rst
+++ b/doc/source/powder-map-script.rst
@@ -4,7 +4,12 @@
 euphonic-powder-map
 ======================
 
+.. contents:: :local:
+
 .. highlight:: bash
+
+Overview
+--------
 
 The ``euphonic-powder-map`` program can be used to sample
 spherically-averaged properties from force constants data over a range
@@ -35,6 +40,7 @@ q range with denser sampling, in THz and with the intensity widget disabled::
    :alt: 2D intensity map with |q| from 0.01 to 4.0 on the x-axis,
          and energy on the y axis, showing powder-averaged coherent
          inelastic neutron scattering intensities for NaCl.
+
 
 To see all the command line options, run::
 
@@ -72,6 +78,13 @@ Progress bars
 Sampling many q-points can be computationally expensive, so a progress
 bar will automatically be displayed if `tqdm <https://tqdm.github.io/>`_
 is installed
+
+Output to file
+--------------
+
+The ``--save-json`` option can be used to output the produced
+:ref:`Spectrum2D` object as a Euphonic .json file with a specified
+name for further use in Euphonic or other programs.
 
 Command Line Options
 --------------------

--- a/euphonic/cli/dispersion.py
+++ b/euphonic/cli/dispersion.py
@@ -52,6 +52,8 @@ def main(params: Optional[List[str]] = None) -> None:
     style = _compose_style(user_args=args,
                            base=[base_style])
 
+    if args.save_json:
+        spectrum.to_json_file(args.save_json)
     with matplotlib.style.context(style):
         _ = plot_1d(spectra,
                     ymin=args.e_min,

--- a/euphonic/cli/dos.py
+++ b/euphonic/cli/dos.py
@@ -79,6 +79,8 @@ def main(params: Optional[List[str]] = None) -> None:
     plot_label_kwargs = _plot_label_kwargs(
         args, default_xlabel=f"Energy / {dos.x_data.units:~P}")
 
+    if args.save_json:
+        dos.to_json_file(args.save_json)
     style = _compose_style(user_args=args, base=[base_style])
     with matplotlib.style.context(style):
         _ = plot_1d(dos, ymin=0, **plot_label_kwargs)

--- a/euphonic/cli/intensity_map.py
+++ b/euphonic/cli/intensity_map.py
@@ -89,6 +89,8 @@ def main(params: Optional[List[str]] = None) -> None:
     if len(spectra) > 1:
         print(f"Found {len(spectra)} regions in q-point path")
 
+    if args.save_json:
+        spectrum.to_json_file(args.save_json)
     style = _compose_style(user_args=args, base=[base_style])
     with matplotlib.style.context(style):
 

--- a/euphonic/cli/powder_map.py
+++ b/euphonic/cli/powder_map.py
@@ -161,6 +161,8 @@ def main(params: Optional[List[str]] = None) -> None:
         args, default_xlabel=f"|q| / {q_min.units:~P}",
         default_ylabel=f"Energy / {spectrum.y_data.units:~P}")
 
+    if args.save_json:
+        spectrum.to_json_file(args.save_json)
     if args.disable_widgets:
         base = [base_style]
     else:
@@ -205,6 +207,5 @@ def main(params: Optional[List[str]] = None) -> None:
                 fig.canvas.draw()
             minbox.on_submit(update_min)
             maxbox.on_submit(update_max)
-        if args.save_json:
-            spectrum.to_json_file(args.save_json)
+
         matplotlib_save_or_show(save_filename=args.save_to)

--- a/euphonic/cli/powder_map.py
+++ b/euphonic/cli/powder_map.py
@@ -205,5 +205,6 @@ def main(params: Optional[List[str]] = None) -> None:
                 fig.canvas.draw()
             minbox.on_submit(update_min)
             maxbox.on_submit(update_max)
-
+        if args.save_json:
+            spectrum.to_json_file(args.save_json)
         matplotlib_save_or_show(save_filename=args.save_to)

--- a/euphonic/cli/utils.py
+++ b/euphonic/cli/utils.py
@@ -666,6 +666,9 @@ def _get_cli_parser(features: Collection[str] = {}
     if 'plotting' in features:
         section = sections['plotting']
         section.add_argument(
+            '--save-json', dest='save_json', default=None,
+            help='Save spectrum to a .json file with this name')
+        section.add_argument(
             '-s', '--save-to', dest='save_to', default=None,
             help='Save resulting plot to a file with this name')
         section.add_argument('--title', type=str, default='',

--- a/euphonic/cli/utils.py
+++ b/euphonic/cli/utils.py
@@ -664,10 +664,10 @@ def _get_cli_parser(features: Collection[str] = {}
                   '"golden" and "random-sphere".'))
 
     if 'plotting' in features:
-        section = sections['plotting']
-        section.add_argument(
+        sections['file'].add_argument(
             '--save-json', dest='save_json', default=None,
             help='Save spectrum to a .json file with this name')
+        section = sections['plotting']
         section.add_argument(
             '-s', '--save-to', dest='save_to', default=None,
             help='Save resulting plot to a file with this name')

--- a/euphonic/spectra.py
+++ b/euphonic/spectra.py
@@ -54,6 +54,30 @@ class Spectrum(ABC):
         self.y_data_unit = str(value.units)
         self._y_data = value.to(self._internal_y_data_unit).magnitude
 
+    @property
+    def x_tick_labels(self) -> List[Tuple[int, str]]:
+        return self._x_tick_labels
+
+    @x_tick_labels.setter
+    def x_tick_labels(self, value: Sequence[Tuple[int, str]]) -> None:
+        err_msg = ('x_tick_labels should be of type '
+                   'Sequence[Tuple[int, str]] e.g. '
+                   '[(0, "label1"), (5, "label2")]')
+        if value is not None:
+            if isinstance(value, Sequence):
+                for elem in value:
+                    if not (isinstance(elem, tuple)
+                            and len(elem) == 2
+                            and isinstance(elem[0], Integral)
+                            and isinstance(elem[1], str)):
+                        raise TypeError(err_msg)
+                # Ensure indices in x_tick_labels are plain ints as
+                # np.int64/32 etc. are not JSON serializable
+                value = [(int(idx), label) for idx, label in value]
+            else:
+                raise TypeError(err_msg)
+        self._x_tick_labels = value
+
     @abstractmethod
     def to_dict(self) -> Dict[str, Any]:
         """Write to dict using euphonic.io._obj_to_dict"""

--- a/tests_and_analysis/test/euphonic_test/test_spectrum1d.py
+++ b/tests_and_analysis/test/euphonic_test/test_spectrum1d.py
@@ -193,6 +193,15 @@ class TestSpectrum1DCreation:
         ('x_tick_labels',
          get_expected_spectrum1d('xsq_spectrum1d.json').x_tick_labels[0],
          TypeError),
+        ('x_tick_labels',
+         [(0,), (1, 'one'), (2, 'two')],
+         TypeError),
+        ('x_tick_labels',
+         [(0, 'zero'), (1,), (2,)],
+         TypeError),
+        ('x_tick_labels',
+         [(0, 1), (2, 3), (4, 5)],
+         TypeError),
         ('metadata',
          ['Not', 'a', 'dictionary'],
          TypeError)])
@@ -296,6 +305,27 @@ class TestSpectrum1DSetters:
         new_attr = getattr(spec1d, attr).magnitude*ureg(unit)
         with pytest.raises(err):
             setattr(spec1d, attr, new_attr)
+
+    @pytest.mark.parametrize('value', [[(0, 'zero'), (1, 'one')]])
+    def test_x_tick_labels_setter(self, value):
+         spec1d = get_spectrum1d('xsq_spectrum1d.json')
+         spec1d.x_tick_labels = value
+         assert spec1d.x_tick_labels == value
+
+    @pytest.mark.parametrize('value', [
+        [(0,), (1, 'one')],
+        [(0, 'zero'), ('one', 'one')]])
+    def test_x_tick_labels_incorrect_setter(self, value):
+         spec1d = get_spectrum1d('xsq_spectrum1d.json')
+         with pytest.raises(TypeError):
+             spec1d.x_tick_labels = value
+
+    def test_x_tick_labels_converted_to_plain_int(self):
+        # np.arange returns an array of type np.int32
+        x_tick_labels = [(idx, 'label') for idx in np.arange(5)]
+        spec1d = get_spectrum1d('xsq_spectrum1d.json')
+        spec1d.x_tick_labels = x_tick_labels
+        assert np.all([isinstance(x[0], int) for x in spec1d.x_tick_labels])
 
 
 class TestSpectrum1DMethods:

--- a/tests_and_analysis/test/euphonic_test/test_spectrum1d.py
+++ b/tests_and_analysis/test/euphonic_test/test_spectrum1d.py
@@ -314,7 +314,8 @@ class TestSpectrum1DSetters:
 
     @pytest.mark.parametrize('value', [
         [(0,), (1, 'one')],
-        [(0, 'zero'), ('one', 'one')]])
+        [(0, 'zero'), ('one', 'one')],
+        0])
     def test_x_tick_labels_incorrect_setter(self, value):
          spec1d = get_spectrum1d('xsq_spectrum1d.json')
          with pytest.raises(TypeError):

--- a/tests_and_analysis/test/euphonic_test/test_spectrum1d.py
+++ b/tests_and_analysis/test/euphonic_test/test_spectrum1d.py
@@ -308,18 +308,18 @@ class TestSpectrum1DSetters:
 
     @pytest.mark.parametrize('value', [[(0, 'zero'), (1, 'one')]])
     def test_x_tick_labels_setter(self, value):
-         spec1d = get_spectrum1d('xsq_spectrum1d.json')
-         spec1d.x_tick_labels = value
-         assert spec1d.x_tick_labels == value
+        spec1d = get_spectrum1d('xsq_spectrum1d.json')
+        spec1d.x_tick_labels = value
+        assert spec1d.x_tick_labels == value
 
     @pytest.mark.parametrize('value', [
         [(0,), (1, 'one')],
         [(0, 'zero'), ('one', 'one')],
         0])
     def test_x_tick_labels_incorrect_setter(self, value):
-         spec1d = get_spectrum1d('xsq_spectrum1d.json')
-         with pytest.raises(TypeError):
-             spec1d.x_tick_labels = value
+        spec1d = get_spectrum1d('xsq_spectrum1d.json')
+        with pytest.raises(TypeError):
+            spec1d.x_tick_labels = value
 
     def test_x_tick_labels_converted_to_plain_int(self):
         # np.arange returns an array of type np.int32

--- a/tests_and_analysis/test/script_tests/test_dispersion.py
+++ b/tests_and_analysis/test/script_tests/test_dispersion.py
@@ -9,6 +9,7 @@ import numpy.testing as npt
 from packaging import version
 from scipy import __version__ as scipy_ver
 
+from euphonic import Spectrum1DCollection
 from tests_and_analysis.test.utils import (
     get_data_path, get_castep_path, get_phonopy_path)
 from tests_and_analysis.test.script_tests.utils import (
@@ -125,6 +126,14 @@ class TestRegression:
         output_file = str(tmpdir.join('test.png'))
         euphonic.cli.dispersion.main(dispersion_args + [output_file])
         assert os.path.exists(output_file)
+
+    @pytest.mark.parametrize('dispersion_args', [
+        [quartz_json_file, '--save-json']])
+    def test_plot_save_to_json(self, inject_mocks, tmpdir, dispersion_args):
+        output_file = str(tmpdir.join('test.json'))
+        euphonic.cli.dispersion.main(dispersion_args + [output_file])
+        spec = Spectrum1DCollection.from_json_file(output_file)
+        assert isinstance(spec, Spectrum1DCollection)
 
     @pytest.mark.parametrize('dispersion_args', [
         [quartz_no_evec_json_file, '--reorder']])

--- a/tests_and_analysis/test/script_tests/test_dispersion.py
+++ b/tests_and_analysis/test/script_tests/test_dispersion.py
@@ -128,7 +128,8 @@ class TestRegression:
         assert os.path.exists(output_file)
 
     @pytest.mark.parametrize('dispersion_args', [
-        [quartz_json_file, '--save-json']])
+        [quartz_json_file, '--save-json'],
+        [lzo_fc_file, '--save-json']])
     def test_plot_save_to_json(self, inject_mocks, tmpdir, dispersion_args):
         output_file = str(tmpdir.join('test.json'))
         euphonic.cli.dispersion.main(dispersion_args + [output_file])

--- a/tests_and_analysis/test/script_tests/test_dos.py
+++ b/tests_and_analysis/test/script_tests/test_dos.py
@@ -7,6 +7,7 @@ import pytest
 import numpy as np
 import numpy.testing as npt
 
+from euphonic import Spectrum1D
 from tests_and_analysis.test.utils import (
     get_data_path, get_castep_path, get_phonopy_path)
 from tests_and_analysis.test.script_tests.utils import (
@@ -96,6 +97,14 @@ class TestRegression:
         output_file = str(tmpdir.join('test.png'))
         euphonic.cli.dos.main(dos_args + [output_file])
         assert os.path.exists(output_file)
+
+    @pytest.mark.parametrize('dos_args', [
+        [nah_phonon_file, '--save-json']])
+    def test_plot_save_to_json(self, inject_mocks, tmpdir, dos_args):
+        output_file = str(tmpdir.join('test.json'))
+        euphonic.cli.dos.main(dos_args + [output_file])
+        spec = Spectrum1D.from_json_file(output_file)
+        assert isinstance(spec, Spectrum1D)
 
     @pytest.mark.parametrize('dos_args', [
         [get_data_path('crystal', 'crystal_LZO.json')]])

--- a/tests_and_analysis/test/script_tests/test_intensity_map.py
+++ b/tests_and_analysis/test/script_tests/test_intensity_map.py
@@ -8,6 +8,7 @@ import numpy.testing as npt
 from packaging import version
 from scipy import __version__ as scipy_ver
 
+from euphonic import Spectrum2D
 from tests_and_analysis.test.utils import get_data_path, get_castep_path
 from tests_and_analysis.test.script_tests.utils import (
     get_script_test_data_path, get_current_plot_image_data, args_to_key)
@@ -117,6 +118,14 @@ class TestRegression:
         output_file = str(tmpdir.join('test.png'))
         euphonic.cli.intensity_map.main(intensity_map_args + [output_file])
         assert os.path.exists(output_file)
+
+    @pytest.mark.parametrize('intensity_map_args', [
+        [quartz_json_file, '--save-json']])
+    def test_plot_save_to_json(self, inject_mocks, tmpdir, intensity_map_args):
+        output_file = str(tmpdir.join('test.json'))
+        euphonic.cli.intensity_map.main(intensity_map_args + [output_file])
+        spec = Spectrum2D.from_json_file(output_file)
+        assert isinstance(spec, Spectrum2D)
 
     @pytest.mark.parametrize('intensity_map_args', [
         [get_data_path('util', 'qgrid_444.txt')]])

--- a/tests_and_analysis/test/script_tests/test_powder_map.py
+++ b/tests_and_analysis/test/script_tests/test_powder_map.py
@@ -8,6 +8,7 @@ import numpy.testing as npt
 from packaging import version
 from scipy import __version__ as scipy_ver
 
+from euphonic import Spectrum2D
 from tests_and_analysis.test.utils import get_data_path, get_castep_path, get_phonopy_path
 from tests_and_analysis.test.script_tests.utils import (
     get_script_test_data_path, get_current_plot_image_data, args_to_key)
@@ -132,6 +133,15 @@ class TestRegression:
         euphonic.cli.powder_map.main(powder_map_args + [output_file]
                                      + quick_calc_params)
         assert os.path.exists(output_file)
+
+    @pytest.mark.parametrize('powder_map_args', [
+        [graphite_fc_file, '--save-json']])
+    def test_plot_save_to_json(self, inject_mocks, tmpdir, powder_map_args):
+        output_file = str(tmpdir.join('test.json'))
+        euphonic.cli.powder_map.main(powder_map_args + [output_file]
+                                     + quick_calc_params)
+        spec = Spectrum2D.from_json_file(output_file)
+        assert isinstance(spec, Spectrum2D)
 
     @pytest.mark.parametrize('powder_map_args', [
         [os.path.join(get_data_path(), 'util', 'qgrid_444.txt')]])


### PR DESCRIPTION
Partially addresses #130

I decided to just do the simple thing for now and just add a `--save-json` option to the CL tools, as this is sorely needed by the `euphonic-powder-map` tool and has been requested for quite a while...

In doing so I found a strange bug, in that the values produced by `euphonic.cli.utils._get_tick_labels` are actually of type `List[Tuple[np.int32, str]]` rather than using plain `int`, so it was not JSON serialisable! This is due to the call to `np.where`, which produces an array of type `np.int64`. I could've probably just fixed this in that function, but thought that setting the `x_tick_labels` on an existing object is actually probably a common thing to do, especially with values produced by `np.where`. So instead I fixed it in the `Spectrum` object itself, and we actually weren't doing much type checking on x_tick_labels when we probably should be.