### PR TITLE
Install llvm on mac

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -25,6 +25,9 @@ jobs:
       - uses: conda-incubator/setup-miniconda@v2
         with:
           python-version: 3.6
+      - name: Install llvm on Macos
+        if: startsWith(matrix.os, 'macos')
+        run: brew install llvm
       - name: Update pip and install dependencies
         shell: bash -l {0}
         run: |


### PR DESCRIPTION
Looks like the reason #218 is failing is due to llvm suddenly not being installed on macos-latest 

See https://github.com/actions/virtual-environments issue 5846