### PR TITLE
Update Python test/release versions

### DIFF
--- a/.github/workflows/build_upload_pypi_wheels.yml
+++ b/.github/workflows/build_upload_pypi_wheels.yml
@@ -8,11 +8,11 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [windows-2019, macos-latest, ubuntu-latest]
+        os: [windows-latest, macos-latest, ubuntu-latest]
         architecture: [x64]
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.6, 3.7, 3.8, 3.9, 3.10]
         include:
-          - os: windows-2019
+          - os: windows-latest
             wheelname: win
           - os: macos-latest
             wheelname: macos
@@ -28,6 +28,12 @@ jobs:
           - python-version: 3.8
             manylinux-version-tag: cp38-cp38
             numpy-version: 1.17.3
+          - python-version: 3.9
+            manylinux-version-tag: cp39-cp39
+            numpy-version: 1.19.3
+          - python-version: 3.10
+            manylinux-version-tag: cp310-cp310
+            numpy-version: 1.21.3
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:
@@ -63,7 +69,7 @@ jobs:
           pip-wheel-args: '--no-deps -w wheelhouse'
 
       - name: Create source distribution
-        if: matrix.os == 'windows-2019' && matrix.python-version == '3.8'
+        if: matrix.os == 'windows-latest' && matrix.python-version == '3.10'
         run: |
           python setup.py sdist
         shell: bash
@@ -74,7 +80,7 @@ jobs:
             name: wheels
             path: wheelhouse/*-${{ matrix.wheelname }}*.whl
       - name: Upload source dist to PyPI
-        if: matrix.os == 'windows-2019' && matrix.python-version == '3.8'
+        if: matrix.os == 'windows-latest' && matrix.python-version == '3.10'
         env:
           TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
           TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -6,7 +6,7 @@ on:
       - '**_run_ci**'
       - '**release**'
   pull_request:
-    types: [opened, reopened, labeled]
+    types: [opened, reopened, labeled, synchronize]
   workflow_dispatch:
 
 jobs:
@@ -17,7 +17,7 @@ jobs:
        (github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'no_ci'))
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-2019, macos-latest]
+        os: [ubuntu-latest, windows-latest, macos-latest]
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -33,7 +33,14 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install -r tests_and_analysis/ci_requirements.txt
-      - name: Run tests
+      - name: Run tests, skip Python 3.8, 3.9 unless workflow dispatch
+        if: github.event_name != 'workflow_dispatch'
+        env:
+          TOX_SKIP_ENV: '.*?(py38|py39).*?'
+        shell: bash -l {0}
+        run: python -m tox
+      - name: Run tests, workflow dispatch so test all Python versions
+        if: github.event_name == 'workflow_dispatch'
         shell: bash -l {0}
         run: python -m tox
       - name: Upload test results

--- a/.github/workflows/test_release.yml
+++ b/.github/workflows/test_release.yml
@@ -10,7 +10,7 @@ jobs:
   test:
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-2019, macos-latest]
+        os: [ubuntu-latest, windows-latest, macos-latest]
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:

--- a/release_tox.ini
+++ b/release_tox.ini
@@ -2,7 +2,7 @@
 # Use conda to set up the python environments to run in
 requires = tox-conda
 # The python environments to run the tests in
-envlist = pypi-py36,{pypi,conda}-{py37,py38},conda-{py39,py310},pypisource-{py36,py310}
+envlist = pypi-py36,{pypi,conda}-{py37,py38,py39,py310},pypisource-{py36,py310}
 # Skip the execution of setup.py as we do it with the correct version in commands_pre below
 skipsdist = True
 
@@ -24,7 +24,7 @@ commands_pre =
     --no-binary 'euphonic'
 
 
-[testenv:pypi-{py36,py37,py38}]
+[testenv:pypi-{py36,py37,py38,py39,py310}]
 install_command = python -m pip install {opts} {packages}
 deps =
     numpy

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 requires = tox-conda
 # The python environments to run the tests in
-envlist = py37,py38,py36-{base,matplotlib,phonopy_reader,all},py36-minrequirements-linux
+envlist = py37,py38,py39,py310,py36-{base,matplotlib,phonopy_reader,all},py36-minrequirements-linux
 # Skip the execution of setup.py as we do it with the correct arg in commands_pre below
 skipsdist = True
 
@@ -9,7 +9,7 @@ skipsdist = True
 changedir = tests_and_analysis/test
 test_command = python run_tests.py --report
 
-[testenv:{py37,py38}]
+[testenv:{py37,py38,py39,py310}]
 install_command =
     python -m pip install \
         --force-reinstall \


### PR DESCRIPTION
The upcoming `0.6.5` release of Euphonic will support Python versions `3.6-3.10`, this PR updates the CI and release scripts for those versions.

Regularly testing on Python 3.6, 3.7, 3.8, 3.9 and 3.10 is overkill and will make the CI take ages, so the tests for 3.8 and 3.9 will generally be skipped. If we run the CI explicitly via a workflow dispatch, tests for all versions will be run. We can do this just before a release to ensure everything works on all versions.