### PR TITLE
Fix PyPI wheel builds

### DIFF
--- a/.github/workflows/build_upload_pypi_wheels.yml
+++ b/.github/workflows/build_upload_pypi_wheels.yml
@@ -42,6 +42,8 @@ jobs:
         with:
           ref: v0.6.5
           fetch-depth: 0 # Ensure tags are fetched for versioning
+      - name: Fix git ownership for manylinux builds, see https://github.com/pypa/manylinux/issues/1309
+        run: git config --global --add safe.directory "*"
       - name: Setup Python ${{ matrix.python-version }} with Conda
         uses: conda-incubator/setup-miniconda@v2
         with:

--- a/.github/workflows/build_upload_pypi_wheels.yml
+++ b/.github/workflows/build_upload_pypi_wheels.yml
@@ -47,21 +47,21 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Update Python pip, wheel, and twine
+        shell: bash -l {0}
         run: |
           python -m pip install --upgrade pip wheel twine
-        shell: bash
       - name: Install llvm on Macos
         if: startsWith(matrix.os, 'macos')
         run: brew install llvm
       - name: Build Python wheel
         if: matrix.os != 'ubuntu-latest'
+        shell: bash -l {0}
         env:
           NUMPY_VERSION: ${{ matrix.numpy-version }}
         run: |
           # Build against lowest required Numpy version
           python -m pip install numpy==${NUMPY_VERSION}
           python -m pip wheel . -w wheelhouse --no-deps
-        shell: bash
 
       - name: Build manylinux Python wheel
         if: matrix.os == 'ubuntu-latest'
@@ -73,9 +73,9 @@ jobs:
 
       - name: Create source distribution
         if: matrix.os == 'windows-latest' && matrix.python-version == '3.10'
+        shell: bash -l {0}
         run: |
           python setup.py sdist
-        shell: bash
 
       - name: Upload as build artifacts
         uses: actions/upload-artifact@v2
@@ -84,17 +84,17 @@ jobs:
             path: wheelhouse/*-${{ matrix.wheelname }}*.whl
       - name: Upload source dist to PyPI
         if: matrix.os == 'windows-latest' && matrix.python-version == '3.10'
+        shell: bash -l {0}
         env:
           TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
           TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
         run: |
           python -m twine upload dist/*.tar.gz
-        shell: bash
       - name: Upload wheel to PyPI
+        shell: bash -l {0}
         env:
           TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
           TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
           WHEEL_NAME: ${{ matrix.wheelname }}
         run: |
           python -m twine upload wheelhouse/*-${WHEEL_NAME}*.whl
-        shell: bash

--- a/.github/workflows/build_upload_pypi_wheels.yml
+++ b/.github/workflows/build_upload_pypi_wheels.yml
@@ -11,7 +11,7 @@ jobs:
       matrix:
         os: [windows-latest, macos-latest, ubuntu-latest]
         architecture: [x64]
-        python-version: [3.6, 3.7, 3.8, 3.9, 3.10]
+        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
         include:
           - os: windows-latest
             wheelname: win
@@ -42,16 +42,17 @@ jobs:
         with:
           ref: v0.6.5
           fetch-depth: 0 # Ensure tags are fetched for versioning
-      - name: Setup Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v1
+      - name: Setup Python ${{ matrix.python-version }} with Conda
+        uses: conda-incubator/setup-miniconda@v2
         with:
-          architecture: ${{ matrix.architecture }}
           python-version: ${{ matrix.python-version }}
       - name: Update Python pip, wheel, and twine
         run: |
           python -m pip install --upgrade pip wheel twine
         shell: bash
-
+      - name: Install llvm on Macos
+        if: startsWith(matrix.os, 'macos')
+        run: brew install llvm
       - name: Build Python wheel
         if: matrix.os != 'ubuntu-latest'
         env:

--- a/.github/workflows/build_upload_pypi_wheels.yml
+++ b/.github/workflows/build_upload_pypi_wheels.yml
@@ -65,7 +65,7 @@ jobs:
 
       - name: Build manylinux Python wheel
         if: matrix.os == 'ubuntu-latest'
-        uses: RalfG/python-wheels-manylinux-build@v0.4.2-manylinux2014_x86_64
+        uses: RalfG/python-wheels-manylinux-build@v0.3.4-manylinux2010_x86_64
         with:
           python-versions: ${{ matrix.manylinux-version-tag }}
           build-requirements: numpy==${{ matrix.numpy-version }}

--- a/.github/workflows/build_upload_pypi_wheels.yml
+++ b/.github/workflows/build_upload_pypi_wheels.yml
@@ -65,7 +65,7 @@ jobs:
 
       - name: Build manylinux Python wheel
         if: matrix.os == 'ubuntu-latest'
-        uses: RalfG/python-wheels-manylinux-build@v0.3.4-manylinux2010_x86_64
+        uses: RalfG/python-wheels-manylinux-build@v0.4.2-manylinux2014_x86_64
         with:
           python-versions: ${{ matrix.manylinux-version-tag }}
           build-requirements: numpy==${{ matrix.numpy-version }}

--- a/.github/workflows/build_upload_pypi_wheels.yml
+++ b/.github/workflows/build_upload_pypi_wheels.yml
@@ -9,7 +9,7 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [windows-latest, macos-latest, ubuntu-latest]
+        os: [ubuntu-latest]
         architecture: [x64]
         python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
         include:

--- a/.github/workflows/build_upload_pypi_wheels.yml
+++ b/.github/workflows/build_upload_pypi_wheels.yml
@@ -3,6 +3,7 @@ name: Build and upload PyPI wheels and source dist
 on:
   release:
     types: [published]
+  push:
 
 jobs:
   build:
@@ -37,8 +38,9 @@ jobs:
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
+          ref: v0.6.5
           fetch-depth: 0 # Ensure tags are fetched for versioning
       - name: Setup Python ${{ matrix.python-version }}
         uses: actions/setup-python@v1

--- a/.github/workflows/build_upload_pypi_wheels.yml
+++ b/.github/workflows/build_upload_pypi_wheels.yml
@@ -10,7 +10,6 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        architecture: [x64]
         python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
         include:
           - os: windows-latest
@@ -21,19 +20,19 @@ jobs:
             wheelname: manylinux
           # Build wheels against the lowest compatible Numpy version
           - python-version: 3.6
-            manylinux-version-tag: cp36-cp36m
+            manylinux-version-tag: cp36
             numpy-version: 1.12.1
           - python-version: 3.7
-            manylinux-version-tag: cp37-cp37m
+            manylinux-version-tag: cp37
             numpy-version: 1.14.6
           - python-version: 3.8
-            manylinux-version-tag: cp38-cp38
+            manylinux-version-tag: cp38
             numpy-version: 1.17.3
           - python-version: 3.9
-            manylinux-version-tag: cp39-cp39
+            manylinux-version-tag: cp39
             numpy-version: 1.19.3
           - python-version: 3.10
-            manylinux-version-tag: cp310-cp310
+            manylinux-version-tag: cp310
             numpy-version: 1.21.3
       fail-fast: false
     runs-on: ${{ matrix.os }}
@@ -42,8 +41,6 @@ jobs:
         with:
           ref: v0.6.5
           fetch-depth: 0 # Ensure tags are fetched for versioning
-      - name: Fix git ownership for manylinux builds, see https://github.com/pypa/manylinux/issues/1309
-        run: git config --global --add safe.directory "*"
       - name: Setup Python ${{ matrix.python-version }} with Conda
         uses: conda-incubator/setup-miniconda@v2
         with:
@@ -55,6 +52,7 @@ jobs:
       - name: Install llvm on Macos
         if: startsWith(matrix.os, 'macos')
         run: brew install llvm
+
       - name: Build Python wheel
         if: matrix.os != 'ubuntu-latest'
         shell: bash -l {0}
@@ -67,11 +65,13 @@ jobs:
 
       - name: Build manylinux Python wheel
         if: matrix.os == 'ubuntu-latest'
-        uses: RalfG/python-wheels-manylinux-build@v0.3.4-manylinux2010_x86_64
+        uses: pypa/cibuildwheel@v2.8.0
+        env:
+          CIBW_BUILD: ${{ matrix.manylinux-version-tag}}-manylinux*
+          CIBW_BEFORE_BUILD: python -mpip install numpy==${{ matrix.numpy-version }}
+          CIBW_ARCHS: x86_64
         with:
-          python-versions: ${{ matrix.manylinux-version-tag }}
-          build-requirements: numpy==${{ matrix.numpy-version }}
-          pip-wheel-args: '--no-deps -w wheelhouse'
+          output-dir: wheelhouse
 
       - name: Create source distribution
         if: matrix.os == 'windows-latest' && matrix.python-version == '3.10'

--- a/.github/workflows/build_upload_pypi_wheels.yml
+++ b/.github/workflows/build_upload_pypi_wheels.yml
@@ -9,7 +9,7 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [ubuntu-latest]
+        os: [windows-latest, macos-latest, ubuntu-latest]
         python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
         include:
           - os: windows-latest
@@ -85,7 +85,7 @@ jobs:
             name: wheels
             path: wheelhouse/*-${{ matrix.wheelname }}*.whl
       - name: Upload source dist to PyPI
-        if: matrix.os == 'windows-latest' && matrix.python-version == '3.10'
+        if: github.event_name == 'release' && matrix.os == 'windows-latest' && matrix.python-version == '3.10'
         shell: bash -l {0}
         env:
           TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
@@ -93,6 +93,7 @@ jobs:
         run: |
           python -m twine upload dist/*.tar.gz
       - name: Upload wheel to PyPI
+        if: github.event_name == 'release'
         shell: bash -l {0}
         env:
           TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}

--- a/.github/workflows/build_upload_pypi_wheels.yml
+++ b/.github/workflows/build_upload_pypi_wheels.yml
@@ -3,7 +3,7 @@ name: Build and upload PyPI wheels and source dist
 on:
   release:
     types: [published]
-  push:
+  workflow_dispatch:
 
 jobs:
   build:
@@ -39,7 +39,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          ref: v0.6.5
           fetch-depth: 0 # Ensure tags are fetched for versioning
       - name: Setup Python ${{ matrix.python-version }} with Conda
         uses: conda-incubator/setup-miniconda@v2

--- a/.github/workflows/create-landing-page.yml
+++ b/.github/workflows/create-landing-page.yml
@@ -12,7 +12,7 @@ jobs:
   update-landing-page:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           ref: gh-pages
       - uses: actions/setup-python@v1

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -21,7 +21,7 @@ jobs:
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: conda-incubator/setup-miniconda@v2
         with:
           python-version: 3.6

--- a/.github/workflows/test_release.yml
+++ b/.github/workflows/test_release.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           ref: v${{ github.event.inputs.version }}
       - uses: conda-incubator/setup-miniconda@v2

--- a/.github/workflows/test_release.yml
+++ b/.github/workflows/test_release.yml
@@ -15,8 +15,6 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
-        with:
-          ref: v${{ github.event.inputs.version }}
       - uses: conda-incubator/setup-miniconda@v2
         with:
           python-version: 3.6

--- a/.github/workflows/test_release.yml
+++ b/.github/workflows/test_release.yml
@@ -18,6 +18,9 @@ jobs:
       - uses: conda-incubator/setup-miniconda@v2
         with:
           python-version: 3.6
+      - name: Install llvm on Macos
+        if: startsWith(matrix.os, 'macos')
+        run: brew install llvm
       - name: Update pip and install dependencies
         shell: bash -l {0}
         run: |

--- a/release_tox.ini
+++ b/release_tox.ini
@@ -12,7 +12,7 @@ commands =
     python run_tests.py --report
 
 # Test PyPI source distribution
-[testenv:pypisource-py36,py310]
+[testenv:pypisource-{py36,py310}]
 install_command = python -m pip install {opts} {packages}
 deps =
     numpy


### PR DESCRIPTION
Ready for review provided the PyPI builds in https://github.com/pace-neutrons/Euphonic/actions/runs/2630595376 pass (the Conda ones will probably still fail). Summary:

- Move from `RalfG/python-wheels-manylinux-build@v0.3.4-manylinux2010_x86_64` to `pypa/cibuildwheel@v2.8.0` action to create manylinux wheels. Originally the manylinux builds where failing due to the issue described in https://github.com/pypa/manylinux issue 1309, meaning that an unversioned wheel was being created from verisoneer.  `cibuildwheel` is better maintained so has already caught and fixed this issue, and hopefully will do with any future issues.
- Added a workflow dispatch option which wont try and upload the wheels to PyPI, so we can create wheels without having to create a release.
- Switch from the `setup-python` Github action to `setup-miniconda`, as `setup-python` doesn't have Python 3.6
- Use strings for version numbers, otherwise `3.10` is read as `3.1`
- Upgrade to checkout `v3`, might as well?
- Install llvm on Mac for clang compiler to compile Euphonic
- Fix typo in `release_tox`