### PR TITLE
Remove packaging imports

### DIFF
--- a/euphonic/__init__.py
+++ b/euphonic/__init__.py
@@ -5,7 +5,6 @@ del get_versions
 import pint
 from pint import UnitRegistry
 from importlib_resources import files
-from packaging.version import parse as parse_version
 
 # Create ureg here so it is only created once
 ureg = UnitRegistry()

--- a/tests_and_analysis/test/script_tests/test_dispersion.py
+++ b/tests_and_analysis/test/script_tests/test_dispersion.py
@@ -5,7 +5,6 @@ from unittest.mock import patch
 
 import pytest
 import numpy.testing as npt
-from packaging import version
 
 from euphonic import Spectrum1DCollection
 from tests_and_analysis.test.utils import (


### PR DESCRIPTION
After installing Euphonic on an empty Python 3.9 conda environment I was getting an `ImportError` because packaging wasn't installed. I found that these imports in Euphonic are actually no longer used and are the last remaining references to the packaging library. Packaging is not in the Python standard library so we must remember to add it to dependencies if we're to use it again, it was omitted before. How we didn't notice this earlier I don't know, I guess we got lucky and other dependencies needed packaging so it was installed anyway.