### PR TITLE
Test/release on Python 3.11

### DIFF
--- a/.github/workflows/build_upload_pypi_wheels.yml
+++ b/.github/workflows/build_upload_pypi_wheels.yml
@@ -64,7 +64,7 @@ jobs:
 
       - name: Build manylinux Python wheel
         if: matrix.os == 'ubuntu-latest'
-        uses: pypa/cibuildwheel@v2.8.0
+        uses: pypa/cibuildwheel@v2.12.0
         env:
           CIBW_BUILD: ${{ matrix.manylinux-version-tag}}-manylinux*
           CIBW_BEFORE_BUILD: python -mpip install numpy==${{ matrix.numpy-version }}

--- a/.github/workflows/build_upload_pypi_wheels.yml
+++ b/.github/workflows/build_upload_pypi_wheels.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest, macos-latest, ubuntu-latest]
-        python-version: ['3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
         include:
           - os: windows-latest
             wheelname: win
@@ -31,6 +31,9 @@ jobs:
           - python-version: 3.10
             manylinux-version-tag: cp310
             numpy-version: 1.21.3
+          - python-version: 3.11
+            manylinux-version-tag: cp311
+            numpy-version: 1.23.2
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:
@@ -70,7 +73,7 @@ jobs:
           output-dir: wheelhouse
 
       - name: Create source distribution
-        if: matrix.os == 'windows-latest' && matrix.python-version == '3.10'
+        if: matrix.os == 'windows-latest' && matrix.python-version == '3.11'
         shell: bash -l {0}
         run: |
           python setup.py sdist
@@ -81,7 +84,7 @@ jobs:
             name: wheels
             path: wheelhouse/*-${{ matrix.wheelname }}*.whl
       - name: Upload source dist to PyPI
-        if: github.event_name == 'release' && matrix.os == 'windows-latest' && matrix.python-version == '3.10'
+        if: github.event_name == 'release' && matrix.os == 'windows-latest' && matrix.python-version == '3.11'
         shell: bash -l {0}
         env:
           TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -33,10 +33,10 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install -r tests_and_analysis/ci_requirements.txt
-      - name: Run tests, skip Python 3.8, 3.9 unless workflow dispatch
+      - name: Run tests, skip Python 3.8, 3.9, 3.10 unless workflow dispatch
         if: github.event_name != 'workflow_dispatch'
         env:
-          TOX_SKIP_ENV: '.*?(py38|py39).*?'
+          TOX_SKIP_ENV: '.*?(py38|py39|py310).*?'
         shell: bash -l {0}
         run: python -m tox
       - name: Run tests, workflow dispatch so test all Python versions

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,11 @@
 `Unreleased <https://github.com/pace-neutrons/Euphonic/compare/v1.1.0...HEAD>`_
 ----------
 
+- Improvements:
+
+  - Euphonic now tests on Python 3.11
+  - Euphonic now provides PyPI wheels for Python 3.11
+
 - New features:
 
   - You can now perform linear interpolation of phonon frequencies and

--- a/release_tox.ini
+++ b/release_tox.ini
@@ -2,7 +2,7 @@
 # Use conda to set up the python environments to run in
 requires = tox-conda
 # The python environments to run the tests in
-envlist = pypi-py37-min,pypi-py37,conda-py38-old-np,{pypi,conda}-{py38,py39,py310},pypisource-{py37,py310}
+envlist = pypi-py37-min,pypi-py37,conda-py38-old-np,{pypi,conda}-{py38,py39,py310,py311},pypisource-{py37,py311}
 # Skip the execution of setup.py as we do it with the correct version in commands_pre below
 skipsdist = True
 
@@ -11,7 +11,7 @@ changedir = tests_and_analysis/test
 test_command = python run_tests.py --report
 
 # Test PyPI source distribution
-[testenv:pypisource-{py37,py310}]
+[testenv:pypisource-{py37,py311}]
 install_command = python -m pip install {opts} {packages}
 deps =
     numpy
@@ -24,7 +24,7 @@ commands_pre =
 commands = {[testenv]test_command}
 
 
-[testenv:pypi-{py37,py38,py39,py310}]
+[testenv:pypi-{py37,py38,py39,py310,py311}]
 install_command = python -m pip install {opts} {packages}
 deps =
     numpy
@@ -50,7 +50,7 @@ commands_pre =
     --only-binary 'euphonic'
 commands = {[testenv]test_command}
 
-[testenv:conda-{py38,py39,py310}]
+[testenv:conda-{py38,py39,py310,py311}]
 whitelist_externals = conda
 install_command = conda install {packages}
 conda_channels =

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 requires = tox-conda
 # The python environments to run the tests in
-envlist = py38,py39,py310,py37-{base,matplotlib,phonopy_reader,brille,all},py37-minrequirements-linux
+envlist = py38,py39,py310,py311,py37-{base,matplotlib,phonopy_reader,brille,all},py37-minrequirements-linux
 # Skip the execution of setup.py as we do it with the correct arg in commands_pre below
 skipsdist = True
 
@@ -9,7 +9,7 @@ skipsdist = True
 changedir = tests_and_analysis/test
 test_command = python run_tests.py --report
 
-[testenv:{py38,py39,py310}]
+[testenv:{py38,py39,py310,py311}]
 install_command =
     python -m pip install \
         --force-reinstall \


### PR DESCRIPTION
#248 

Currently getting the error:
```
PackagesNotFoundError: The following packages are not available from current channels:

  - python=3.11

Current channels:

  - https://repo.anaconda.com/pkgs/main/linux-64
  - https://repo.anaconda.com/pkgs/main/noarch
  - https://repo.anaconda.com/pkgs/r/linux-64
  - https://repo.anaconda.com/pkgs/r/noarch
```

Looks like Python 3.11 isn't available yet, but there is an issue https://github.com/ContinuumIO/anaconda-issues/issues/ issue 13082. Opening this PR as a reminder for now and will merge once Python 3.11 is available.

Tasks:
- [x] Rerun once Python 3.11 is available in the Anaconda repo
- [x] Also check 'Build and upload PyPI wheels' workflow dispatch