### PR TITLE
Update actions versions (Node.js 12 deprecation)

### DIFF
--- a/.github/workflows/build_upload_pypi_wheels.yml
+++ b/.github/workflows/build_upload_pypi_wheels.yml
@@ -76,7 +76,7 @@ jobs:
           python setup.py sdist
 
       - name: Upload as build artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
             name: wheels
             path: wheelhouse/*-${{ matrix.wheelname }}*.whl

--- a/.github/workflows/create-landing-page.yml
+++ b/.github/workflows/create-landing-page.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           ref: gh-pages
-      - uses: actions/setup-python@v1
+      - uses: actions/setup-python@v4
         with:
           python-version: 3.7
       - name: Update pip and install dependencies

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -45,7 +45,7 @@ jobs:
         run: python -m tox
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: Unit test results ${{ matrix.os }}
           path: tests_and_analysis/test/reports/junit_report*.xml
@@ -55,7 +55,7 @@ jobs:
         with:
           project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
           coverage-reports: tests_and_analysis/test/reports/coverage*.xml
-      - uses: codecov/codecov-action@v2
+      - uses: codecov/codecov-action@v3
         if: startsWith(matrix.os, 'ubuntu')
         with:
           files: tests_and_analysis/test/reports/coverage*.xml
@@ -66,7 +66,7 @@ jobs:
     if: success() || failure()
     steps:
       - name: Download Artifacts
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           path: artifacts
       - name: Publish test results

--- a/.github/workflows/test_release.yml
+++ b/.github/workflows/test_release.yml
@@ -33,7 +33,7 @@ jobs:
         run: python -m tox -c release_tox.ini
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: Unit test results ${{ matrix.os }}
           path: tests_and_analysis/test/reports/junit_report*.xml


### PR DESCRIPTION
Currently am getting the following warning on Github Actions runners:
```
Node.js 12 actions are deprecated.
For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.
Please update the following actions to use Node.js 16: conda-incubator/setup-miniconda, actions/upload-artifact, codecov/codecov-action, conda-incubator/setup-miniconda
```
setup-miniconda doesn't seem to have an update for that yet, but there is an issue to do this https://github.com/conda-incubator/setup-miniconda/issues issue 248. Opening this PR as a reminder for now and will merge once a new version of setup-miniconda has been released.