### PR TITLE
Add paper citation to docs

### DIFF
--- a/doc/source/cite.rst
+++ b/doc/source/cite.rst
@@ -19,3 +19,10 @@ or it can be read programatically as follows:
 
 The latest version of the citation file can also be found in Euphonic's code
 repository `here <https://github.com/pace-neutrons/Euphonic/blob/master/CITATION.cff>`_.
+
+Please also cite the following publication:
+
+* Fair R.L., Jackson A.J., Voneshen D.J., Jochym D.B., Le M.D., Refson K., Perring T.G.
+  *Euphonic: inelastic neutron scattering simulations from force constants and visualization tools for phonon properties*.
+  Journal of Applied Crystallography **55** 1689-1703 (2022).
+  DOI: https://doi.org/10.1107/S1600576722009256.


### PR DESCRIPTION
I wasn't sure what citation style to use for this, so I've just made sure all the information is there. Alternatively, rather than adding to the citation docs page, we could update the CITATION.cff file so instead of having an overall DOI, we have multiple `identifiers`, one for the software itself, and one for the paper, as done here: https://github.com/citation-file-format/citation-file-format/blob/main/README.md#structure.