### PR TITLE
Don't test Py 3.7 release for Conda

### DIFF
--- a/release_tox.ini
+++ b/release_tox.ini
@@ -2,7 +2,7 @@
 # Use conda to set up the python environments to run in
 requires = tox-conda
 # The python environments to run the tests in
-envlist = pypi-py37-min,conda-py37-old-np,{pypi,conda}-{py37,py38,py39,py310},pypisource-{py37,py310}
+envlist = pypi-py37-min,pypi-py37,conda-py38-old-np,{pypi,conda}-{py38,py39,py310},pypisource-{py37,py310}
 # Skip the execution of setup.py as we do it with the correct version in commands_pre below
 skipsdist = True
 
@@ -48,7 +48,7 @@ commands_pre =
     'euphonic[matplotlib,phonopy_reader]=={env:EUPHONIC_VERSION}' \
     --only-binary 'euphonic'
 
-[testenv:conda-{py37,py38,py39,py310}]
+[testenv:conda-{py38,py39,py310}]
 whitelist_externals = conda
 install_command = conda install {packages}
 conda_channels =
@@ -61,7 +61,7 @@ commands_pre =
 
 # Test against a version of Numpy less than the latest for Conda
 # See https://github.com/conda-forge/euphonic-feedstock/pull/20
-[testenv:conda-py37-old-np]
+[testenv:conda-py38-old-np]
 whitelist_externals = conda
 install_command = conda install {packages}
 conda_channels =


### PR DESCRIPTION
Python 3.7 conda support was dropped when 3.11 was added.

See https://github.com/conda-forge/conda-forge.github.io issue 1815.