### PR TITLE
Fix Py_None increment bug #270

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -73,7 +73,8 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install -r tests_and_analysis/ci_requirements.txt
-          python -m pip install -r doc/requirements.txt numpy .[matplotlib,phonopy_reader,brille]
+          python -m pip install -r doc/requirements.txt
+          python -m pip install .[matplotlib,phonopy_reader,brille]
       - name: Run Sphinx doctests
         working-directory: ./doc
         shell: bash -l {0}

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -14,10 +14,10 @@ sphinx:
 python:
    version: 3.7
    install:
+      - requirements: doc/requirements.txt
       - method: pip
         path: .
         extra_requirements:
            - matplotlib
            - phonopy_reader
            - brille
-      - requirements: doc/requirements.txt

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,8 @@
 
   - Allow ``color`` to be passed as an extra kwarg to ``plot_1d`` and
     ``plot_1d_to_axis``. Previously this caused a ``TypeError``.
+  - Fix bug where ``Py_None`` was not incremented before returning from
+    ``calculate_phonons()`` in the C-extension causing a deallocation crash
 
 `v1.2.0 <https://github.com/pace-neutrons/Euphonic/compare/v1.1.0...v1.2.0>`_
 ------

--- a/c/_euphonic.c
+++ b/c/_euphonic.c
@@ -300,7 +300,7 @@ static PyObject *calculate_phonons(PyObject *self, PyObject *args) {
         Py_DECREF(py_dipole_init_data);
     }
 
-    return Py_None;
+    Py_RETURN_NONE;
 }
 
 static PyMethodDef _euphonic_methods[] = {

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,3 +1,4 @@
+numpy>=1.14.5
 sphinx==5.3.0
 sphinx-argparse==0.3.2
 sphinx-autodoc-typehints==1.19.5


### PR DESCRIPTION
Change code to use the `Py_RETURN_NONE` macro to correctly increment the reference count to the `Py_None` object returned by the `calculate_phonons` C-extension.