### PR TITLE
Address Numpy 1.25 deprecation warning

### DIFF
--- a/euphonic/util.py
+++ b/euphonic/util.py
@@ -395,16 +395,19 @@ def convert_fc_phases(force_constants: np.ndarray, atom_r: np.ndarray,
     for i in range(n_atoms_sc):
         co_idx = np.where(
             (cell_origins_per_atom[i] == cell_origins).all(axis=1))[0]
-        if len(co_idx) != 1:
+
+        if len(co_idx) == 1:
+            co_idx = co_idx[0]
+        else:
             # Get equivalent cell origin in surrounding supercells
             origin_in_scs = cell_origins_per_atom[i] - sc_origins_pcell
-            co_idx = -1
+
             # Find which of the 'unique' cell origins is equivalent
             for j, cell_origin in enumerate(cell_origins):
                 if np.any((origin_in_scs == cell_origin).all(axis=1)):
                     co_idx = j
                     break
-            if co_idx == -1:
+            else:
                 raise Exception((
                     'Couldn\'t determine cell origins for '
                     'force constants matrix'))


### PR DESCRIPTION
This logic was passing a size-1 vector of indices to a scalar index, which is no longer allowed as of version 1.25

The result was a hard-to-debug test failure because one of the script tests is checking that no warnings are raised: https://github.com/pace-neutrons/Euphonic/blob/48cbb0e06ec9c81016466c472bd57c9ea50e4442/tests_and_analysis/test/script_tests/test_optimise_dipole_parameter.py#L79

That testing approach could be improved to give better information, but this is less urgent than addressing a test failure that currently affects `master`.

(I did also clarify some control logic, as I that code block is being edited anyway...)