### PR TITLE
Drop python 3.7 support, bump Scipy, Pint, h5py requirements

### DIFF
--- a/.github/workflows/build_upload_pypi_wheels.yml
+++ b/.github/workflows/build_upload_pypi_wheels.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest, macos-latest, ubuntu-latest]
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.8', '3.9', '3.10', '3.11']
         include:
           - os: windows-latest
             wheelname: win
@@ -19,15 +19,12 @@ jobs:
           - os: ubuntu-latest
             wheelname: manylinux
           # Build wheels against the lowest compatible Numpy version
-          - python-version: 3.7
-            manylinux-version-tag: cp37
-            numpy-version: 1.14.5
           - python-version: 3.8
             manylinux-version-tag: cp38
-            numpy-version: 1.17.3
+            numpy-version: 1.19.5
           - python-version: 3.9
             manylinux-version-tag: cp39
-            numpy-version: 1.19.3
+            numpy-version: 1.19.5
           - python-version: 3.10
             manylinux-version-tag: cp310
             numpy-version: 1.21.3

--- a/.github/workflows/create-landing-page.yml
+++ b/.github/workflows/create-landing-page.yml
@@ -17,7 +17,7 @@ jobs:
           ref: gh-pages
       - uses: actions/setup-python@v4
         with:
-          python-version: 3.7
+          python-version: 3.8
       - name: Update pip and install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -67,7 +67,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: conda-incubator/setup-miniconda@v2
         with:
-          python-version: 3.7
+          python-version: 3.8
       - name: Update pip and install dependencies
         shell: bash -l {0}
         run: |

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: conda-incubator/setup-miniconda@v2
         with:
-          python-version: 3.8
+          python-version: 3.7
       - name: Install llvm on Macos
         if: startsWith(matrix.os, 'macos')
         run: brew install llvm
@@ -67,7 +67,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: conda-incubator/setup-miniconda@v2
         with:
-          python-version: 3.8
+          python-version: 3.7
       - name: Update pip and install dependencies
         shell: bash -l {0}
         run: |

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: conda-incubator/setup-miniconda@v2
         with:
-          python-version: 3.7
+          python-version: 3.8
       - name: Install llvm on Macos
         if: startsWith(matrix.os, 'macos')
         run: brew install llvm
@@ -33,10 +33,10 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install -r tests_and_analysis/ci_requirements.txt
-      - name: Run tests, skip Python 3.8, 3.9, 3.10 unless workflow dispatch
+      - name: Run tests, skip Python 3.9, 3.10 unless workflow dispatch
         if: github.event_name != 'workflow_dispatch'
         env:
-          TOX_SKIP_ENV: '.*?(py38|py39|py310).*?'
+          TOX_SKIP_ENV: '.*?(py39|py310).*?'
         shell: bash -l {0}
         run: python -m tox
       - name: Run tests, workflow dispatch so test all Python versions
@@ -67,7 +67,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: conda-incubator/setup-miniconda@v2
         with:
-          python-version: 3.7
+          python-version: 3.8
       - name: Update pip and install dependencies
         shell: bash -l {0}
         run: |

--- a/.github/workflows/test_release.yml
+++ b/.github/workflows/test_release.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: conda-incubator/setup-miniconda@v2
         with:
-          python-version: 3.7
+          python-version: 3.8
       - name: Install llvm on Macos
         if: startsWith(matrix.os, 'macos')
         run: brew install llvm

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -12,7 +12,7 @@ sphinx:
 
 # Optionally set the version of Python and requirements required to build your docs
 python:
-   version: 3.7
+   version: 3.8
    install:
       - requirements: doc/requirements.txt
       - method: pip

--- a/doc/source/installation.rst
+++ b/doc/source/installation.rst
@@ -5,7 +5,7 @@ Installation
 
 .. contents:: :local:
 
-Euphonic has been tested on Python 3.7 - 3.10.
+Euphonic has been tested on Python 3.8 - 3.10.
 
 Pip
 ===

--- a/release_tox.ini
+++ b/release_tox.ini
@@ -2,7 +2,7 @@
 # Use conda to set up the python environments to run in
 requires = tox-conda
 # The python environments to run the tests in
-envlist = pypi-py37-min,pypi-py37,conda-py38-old-np,{pypi,conda}-{py38,py39,py310,py311},pypisource-{py37,py311}
+envlist = pypi-py38-min,conda-py38-old-np,{pypi,conda}-{py38,py39,py310,py311},pypisource-{py38,py311}
 # Skip the execution of setup.py as we do it with the correct version in commands_pre below
 skipsdist = True
 
@@ -11,7 +11,7 @@ changedir = tests_and_analysis/test
 test_command = python run_tests.py --report
 
 # Test PyPI source distribution
-[testenv:pypisource-{py37,py311}]
+[testenv:pypisource-{py38,py311}]
 install_command = python -m pip install {opts} {packages}
 deps =
     numpy
@@ -24,7 +24,7 @@ commands_pre =
 commands = {[testenv]test_command}
 
 
-[testenv:pypi-{py37,py38,py39,py310,py311}]
+[testenv:pypi-{py38,py39,py310,py311}]
 install_command = python -m pip install {opts} {packages}
 deps =
     numpy
@@ -36,10 +36,10 @@ commands_pre =
     --only-binary 'euphonic'
 commands = {[testenv]test_command}
 
-[testenv:pypi-py37-min]
+[testenv:pypi-py38-min]
 install_command = python -m pip install --force-reinstall {opts} {packages}
 deps =
-    numpy==1.14.5
+    numpy==1.19.5
 commands_pre =
     python -m pip install --force-reinstall \
         -r{toxinidir}/tests_and_analysis/minimum_euphonic_requirements.txt

--- a/setup.py
+++ b/setup.py
@@ -138,17 +138,16 @@ def run_setup():
         packages=packages,
         include_package_data=True,
         install_requires=[
-            'numpy>=1.14.5',
-            'scipy>=1.1.0',
+            'scipy>=1.10',  # requires numpy >= 1.19.5
             'seekpath>=1.1.0',
             'spglib>=1.9.4',
-            'pint>=0.10.1',
-            'importlib_resources>=1.3.0',
+            'pint>=0.19',
+            'importlib_resources>=1.3.0',  # equivalent to Python 3.9
             'threadpoolctl>=1.0.0'
         ],
         extras_require={
             'matplotlib': ['matplotlib>=2.2.2'],
-            'phonopy_reader': ['h5py>=2.8.0', 'PyYAML>=3.13'],
+            'phonopy_reader': ['h5py>=2.10.0', 'PyYAML>=3.13'],
             'brille': ['brille>=0.7.0']
         },
         entry_points={'console_scripts': [

--- a/tests_and_analysis/minimum_euphonic_requirements.txt
+++ b/tests_and_analysis/minimum_euphonic_requirements.txt
@@ -1,10 +1,10 @@
-numpy==1.14.5
-scipy==1.1.0
+numpy==1.19.5
+scipy==1.10.0
 spglib==1.9.4.2
 seekpath==1.1.0
-pint==0.10.1
+pint==0.19.0
 importlib_resources==1.3.0
 matplotlib==2.2.2
-h5py==2.8.0
+h5py==2.10.0
 PyYAML==3.13
 threadpoolctl==1.0.0

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 requires = tox-conda
 # The python environments to run the tests in
-envlist = py38,py39,py310,py311,py37-{base,matplotlib,phonopy_reader,brille,all},py37-minrequirements-linux
+envlist = py38,py39,py310,py311,py38-{base,matplotlib,phonopy_reader,brille,all},py38-minrequirements-linux
 # Skip the execution of setup.py as we do it with the correct arg in commands_pre below
 skipsdist = True
 
@@ -29,7 +29,7 @@ commands =
     {[testenv]test_command} --cov
 
 # Test with no extras
-[testenv:py37-base]
+[testenv:py38-base]
 install_command = {[testenv:py310]install_command}
 deps = {[testenv:py310]deps}
 commands_pre =
@@ -40,7 +40,7 @@ commands_pre =
 commands = {[testenv]test_command} --cov -m "not (phonopy_reader or matplotlib or brille)"
 
 # Test with matplotlib extra only
-[testenv:py37-matplotlib]
+[testenv:py38-matplotlib]
 install_command = {[testenv:py310]install_command}
 deps = {[testenv:py310]deps}
 commands_pre =
@@ -51,7 +51,7 @@ commands_pre =
 commands = {[testenv]test_command} --cov -m "matplotlib and not multiple_extras"
 
 # Test with phonopy_reader extra only
-[testenv:py37-phonopy_reader]
+[testenv:py38-phonopy_reader]
 install_command = {[testenv:py310]install_command}
 deps = {[testenv:py310]deps}
 commands_pre =
@@ -62,7 +62,7 @@ commands_pre =
 commands = {[testenv]test_command} --cov -m "phonopy_reader and not multiple_extras"
 
 # Test with brille extra only
-[testenv:py37-brille]
+[testenv:py38-brille]
 install_command = {[testenv:py310]install_command}
 deps = {[testenv:py310]deps}
 commands_pre =
@@ -73,7 +73,7 @@ commands_pre =
 commands = {[testenv]test_command} --cov -m "brille and not multiple_extras"
 
 # Run remaining tests that require multiple extras
-[testenv:py37-all]
+[testenv:py38-all]
 install_command = {[testenv:py310]install_command}
 deps = {[testenv:py310]deps}
 commands_pre =
@@ -84,21 +84,18 @@ commands_pre =
 commands =
     {[testenv]test_command} --cov -m multiple_extras
 
-[testenv:py37-minrequirements-linux]
+[testenv:py38-minrequirements-linux]
 whitelist_externals = rm
 install_command =
     python -m pip install --force-reinstall {opts} {packages}
 platform =
     linux: linux
 deps =
-    numpy==1.14.5
+    numpy==1.19.5
 commands_pre =
     python -m pip install --force-reinstall \
         -r{toxinidir}/tests_and_analysis/minimum_euphonic_requirements.txt
     python -m pip install --force-reinstall \
         -r{toxinidir}/tests_and_analysis/tox_requirements.txt
-# Force rebuild of euphonic extension to avoid Numpy clash
-# (it still exists from py37 env)
-    rm -rf {toxinidir}/build
     python -m pip install '{toxinidir}[matplotlib,phonopy_reader,brille]'
 commands = {[testenv]test_command}

--- a/tox.ini
+++ b/tox.ini
@@ -97,5 +97,7 @@ commands_pre =
         -r{toxinidir}/tests_and_analysis/minimum_euphonic_requirements.txt
     python -m pip install --force-reinstall \
         -r{toxinidir}/tests_and_analysis/tox_requirements.txt
+    # Force rebuild of euphonic extension to avoid Numpy clash
+    rm -rf {toxinidir}/build
     python -m pip install '{toxinidir}[matplotlib,phonopy_reader,brille]'
 commands = {[testenv]test_command}


### PR DESCRIPTION
Closes #278 

This PR should focus on mechanics of version bump; subsequent PRs can introduce new goodies.