### PR TITLE
Drop deprecated pkg_resources

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,13 +5,15 @@
 
   - Python 3.7 is no longer supported
 
-    - Minimum version of scipy increased from 1.1 to 1.10
+  - Minimum version of scipy increased from 1.1 to 1.10
 
-      - This requires numpy >= 1.19.5
+    - This requires numpy >= 1.19.5
 
-    - Minimum version of pint increased from 0.10.1 to 0.19
+  - Minium version of matplotlib increased from 2.2.2 to 3.2.0
 
-    - Minimum version of h5py increaased form 2.8 to 2.10
+  - Minimum version of pint increased from 0.10.1 to 0.19
+
+  - Minimum version of h5py increaased form 2.8 to 2.10
 
 - Improvements
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,7 +9,7 @@
 
     - This requires numpy >= 1.19.5
 
-  - Minium version of matplotlib increased from 2.2.2 to 3.2.0
+  - Minimum version of matplotlib increased from 2.2.2 to 3.2.0
 
   - Minimum version of pint increased from 0.10.1 to 0.19
 

--- a/euphonic/styles/__init__.py
+++ b/euphonic/styles/__init__.py
@@ -1,6 +1,5 @@
 """Matplotlib stylesheets for plot styling"""
-from pkg_resources import resource_filename
+from importlib_resources import files
 
-base_style = resource_filename("euphonic.styles", "base.mplstyle")
-intensity_widget_style = resource_filename("euphonic.styles",
-                                           "intensity_widget.mplstyle")
+base_style = files(__package__) / "base.mplstyle"
+intensity_widget_style = files(__package__) / "intensity_widget.mplstyle"

--- a/setup.py
+++ b/setup.py
@@ -146,7 +146,7 @@ def run_setup():
             'threadpoolctl>=1.0.0'
         ],
         extras_require={
-            'matplotlib': ['matplotlib>=2.2.2'],
+            'matplotlib': ['matplotlib>=3.2.0'],
             'phonopy_reader': ['h5py>=2.10.0', 'PyYAML>=3.13'],
             'brille': ['brille>=0.7.0']
         },

--- a/tests_and_analysis/minimum_euphonic_requirements.txt
+++ b/tests_and_analysis/minimum_euphonic_requirements.txt
@@ -4,7 +4,7 @@ spglib==1.9.4.2
 seekpath==1.1.0
 pint==0.19.0
 importlib_resources==1.3.0
-matplotlib==2.2.2
+matplotlib==3.2.0
 h5py==2.10.0
 PyYAML==3.13
 threadpoolctl==1.0.0


### PR DESCRIPTION
This line was causing some deprecation warnings. I think this is the right way to modernise it?