### PR TITLE
Add error for old castep_bin files

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,9 +1,20 @@
 `Unreleased <https://github.com/pace-neutrons/Euphonic/compare/v1.3.1...HEAD>`_
 
+- Requirements
+
+  - ``packaging`` library added to dependencies.
+
 - Bug fixes
 
   - Fixed an error loading QpointPhononModes from JSON when there is a
     single q-point in the data
+
+- Improvements
+
+  - When loading ``.castep_bin`` files, explicitly check the CASTEP
+    version number and give a useful error message if this is < 17.1.
+    (These files are missing information about the unit cell origins,
+    and would previously cause an error with an unhelpful message.)
 
 - Maintenance
 

--- a/euphonic/readers/castep.py
+++ b/euphonic/readers/castep.py
@@ -469,8 +469,17 @@ def read_interpolation_data(
                     np.reshape(_read_entry(f, float_type),
                                (n_cells_in_sc, 3*n_atoms, 3*n_atoms)),
                     axes=[0, 2, 1]))
-                cell_origins = np.reshape(
-                    _read_entry(f, int_type), (n_cells_in_sc, 3))
+                try:
+                    cell_origins = np.reshape(
+                        _read_entry(f, int_type), (n_cells_in_sc, 3))
+                except ValueError:
+                    raise ValueError('Old castep file detected: '
+                        'Euphonic only supports post-Castep 17.1 files. '
+                        'Please rerun the calculation with a newer version '
+                        'of Castep with the original .cell file and a '
+                        '.castep file with a single line with the '
+                        '"continuation: <old.castep_bin>" keyword and '
+                        'use the new output .castep_bin file in Euphonic.')
                 _ = _read_entry(f, int_type)  # FC row not used
             elif header == b'BORN_CHGS':
                 born = np.reshape(

--- a/euphonic/readers/castep.py
+++ b/euphonic/readers/castep.py
@@ -469,10 +469,9 @@ def read_interpolation_data(
                     np.reshape(_read_entry(f, float_type),
                                (n_cells_in_sc, 3*n_atoms, 3*n_atoms)),
                     axes=[0, 2, 1]))
-                try:
-                    cell_origins = np.reshape(
-                        _read_entry(f, int_type), (n_cells_in_sc, 3))
-                except ValueError:
+
+                cell_origins = _read_entry(f, int_type)
+                if isinstance(cell_origins, int):
                     raise ValueError('Old castep file detected: '
                         'Euphonic only supports post-Castep 17.1 files. '
                         'Please rerun the calculation with a newer version '
@@ -480,6 +479,9 @@ def read_interpolation_data(
                         '.castep file with a single line with the '
                         '"continuation: <old.castep_bin>" keyword and '
                         'use the new output .castep_bin file in Euphonic.')
+
+                cell_origins = np.reshape(cell_origins, (n_cells_in_sc, 3))
+
                 _ = _read_entry(f, int_type)  # FC row not used
             elif header == b'BORN_CHGS':
                 born = np.reshape(

--- a/setup.py
+++ b/setup.py
@@ -138,6 +138,7 @@ def run_setup():
         packages=packages,
         include_package_data=True,
         install_requires=[
+            'packaging',
             'scipy>=1.10',  # requires numpy >= 1.19.5
             'seekpath>=1.1.0',
             'spglib>=1.9.4',


### PR DESCRIPTION
Adds a more helpful error message if users try to use old castep_bin file (pre Castep-17.1).

An alternative fix would involve calculating the `supercell_origins` field. Some [code](https://github.com/pace-neutrons/Euphonic/blob/7608b14f7024ebb240c079ab336805e6a190b8f1/euphonic/readers/phonopy.py#L765-L768) used in the phonopy reader could possibly be re-used for this.

Fixes #295