### PR TITLE
Spglib 2.4 compatibility: handle TypeError when passing empty cell

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,12 @@
   - Fixed an error loading QpointPhononModes from JSON when there is a
     single q-point in the data
 
+- Maintenance
+
+  - Compatibility fix for spglib 2.4 update: a new sanity-check in
+    spglib raises TypeError when using empty unit cell and this needs
+    handling when looking for high-symmetry labels
+
 
 -------------------------------------------------------------------------------
 

--- a/euphonic/util.py
+++ b/euphonic/util.py
@@ -568,7 +568,9 @@ def _recip_space_labels(qpts: np.ndarray,
     else:
         try:
             sym_label_to_coords = seekpath.get_path(cell)["point_coords"]
-        except SymmetryDetectionError:
+        except (SymmetryDetectionError, TypeError) as err:
+            if isinstance(err, TypeError):
+                assert "positions has to be" in str(err)
             warnings.warn(('Could not determine cell symmetry, using generic '
                            'q-point labels'), stacklevel=2)
             sym_label_to_coords = _generic_qpt_labels()

--- a/euphonic/util.py
+++ b/euphonic/util.py
@@ -570,7 +570,10 @@ def _recip_space_labels(qpts: np.ndarray,
             sym_label_to_coords = seekpath.get_path(cell)["point_coords"]
         except (SymmetryDetectionError, TypeError) as err:
             if isinstance(err, TypeError):
+                # There is a particular TypeError we expect to see when the
+                # unit cell is empty; make sure we do not have some other error
                 assert "positions has to be" in str(err)
+                assert len(cell[1]) == 0
             warnings.warn(('Could not determine cell symmetry, using generic '
                            'q-point labels'), stacklevel=2)
             sym_label_to_coords = _generic_qpt_labels()


### PR DESCRIPTION
Some sanity-checking has been added to spglib and now this scenario leads to a TypeError before the SymmetryDetectionError is reached.

This has been causing test failures on unrelated branches as the CI is using the new version of spglib

closes #297 