### PR TITLE
Flatten q-point indices for compatibility with Numpy 2.0

### DIFF
--- a/.github/workflows/build_upload_pypi_wheels.yml
+++ b/.github/workflows/build_upload_pypi_wheels.yml
@@ -14,7 +14,7 @@ jobs:
         include:
           - os: windows-latest
             wheelname: win
-          - os: macos-latest
+          - os: macos-12
             wheelname: macos
           - os: ubuntu-latest
             wheelname: manylinux

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -97,7 +97,7 @@ jobs:
     if: success() || failure()
     steps:
       - name: Download Artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           path: artifacts
       - name: Publish test results

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -17,7 +17,7 @@ jobs:
        (github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'no_ci'))
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest, windows-latest, macos-12]
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:
@@ -30,14 +30,7 @@ jobs:
       - name: Install llvm on Macos
         if: startsWith(matrix.os, 'macos')
         run: |
-          brew install llvm@14
-          echo "CC=gcc-12" >> "$GITHUB_ENV"
-          echo "CXX=g++-12" >> "$GITHUB_ENV"
-      - name: check if CC was set
-        shell: bash -l {0}
-        run: |
-          echo "Value of CC: $CC"
-          echo "Value of CXX: $XX"
+          brew install llvm
       - name: Update pip and install dependencies
         shell: bash -l {0}
         run: |

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -31,8 +31,8 @@ jobs:
         if: startsWith(matrix.os, 'macos')
         run: |
           brew install llvm@14
-          echo "CC=gcc-14" >> "$GITHUB_ENV"
-          echo "CXX=g++-14" >> "$GITHUB_ENV"
+          echo "CC=gcc-12" >> "$GITHUB_ENV"
+          echo "CXX=g++-12" >> "$GITHUB_ENV"
       - name: check if CC was set
         shell: bash -l {0}
         run: |

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -29,7 +29,9 @@ jobs:
           channel-priority: true
       - name: Install llvm on Macos
         if: startsWith(matrix.os, 'macos')
-        run: brew install llvm
+        run: |
+          brew install llvm@14
+          echo "CC=gcc-14" >> $GITHUB_ENV
       - name: Update pip and install dependencies
         shell: bash -l {0}
         run: |

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -32,10 +32,12 @@ jobs:
         run: |
           brew install llvm@14
           echo "CC=gcc-14" >> "$GITHUB_ENV"
+          echo "CXX=g++-14" >> "$GITHUB_ENV"
       - name: check if CC was set
         shell: bash -l {0}
         run: |
           echo "Value of CC: $CC"
+          echo "Value of CXX: $XX"
       - name: Update pip and install dependencies
         shell: bash -l {0}
         run: |

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -31,7 +31,11 @@ jobs:
         if: startsWith(matrix.os, 'macos')
         run: |
           brew install llvm@14
-          echo "CC=gcc-14" >> $GITHUB_ENV
+          echo "CC=gcc-14" >> "$GITHUB_ENV"
+      - name: check if CC was set
+        shell: bash -l {0}
+        run: |
+          echo "Value of CC: $CC"
       - name: Update pip and install dependencies
         shell: bash -l {0}
         run: |

--- a/.github/workflows/test_release.yml
+++ b/.github/workflows/test_release.yml
@@ -10,7 +10,7 @@ jobs:
   test:
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest, windows-latest, macos-12]
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/test_release.yml
+++ b/.github/workflows/test_release.yml
@@ -22,7 +22,9 @@ jobs:
           channel-priority: true
       - name: Install llvm on Macos
         if: startsWith(matrix.os, 'macos')
-        run: brew install llvm
+        run: |
+          brew install llvm@14
+          echo "CC=gcc-14" >> $GITHUB_ENV
       - name: Update pip and install dependencies
         shell: bash -l {0}
         run: |

--- a/.github/workflows/test_release.yml
+++ b/.github/workflows/test_release.yml
@@ -23,8 +23,7 @@ jobs:
       - name: Install llvm on Macos
         if: startsWith(matrix.os, 'macos')
         run: |
-          brew install llvm@14
-          echo "CC=gcc-14" >> $GITHUB_ENV
+          brew install llvm
       - name: Update pip and install dependencies
         shell: bash -l {0}
         run: |

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -25,7 +25,14 @@
   - Compatibility fix for Numpy 2.0 update: avoid some
     broadcasting issues with array shape returned by ``np.unique``
 
-  - Update reference to scipy.integrate.simpson
+  - Update reference to scipy.integrate.simpson (scipy.integrate.simps
+    is deprecated)
+
+  - Mac tests and builds are running against "macos-12" github runner
+    instead of "macos-latest", in order to test properly against
+    Brille. This should be restored to "macos-latest" when Brille
+    build system is updated and gives consistent results with
+    win/linux.
 
 -------------------------------------------------------------------------------
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -25,6 +25,7 @@
   - Compatibility fix for Numpy 2.0 update: avoid some
     broadcasting issues with array shape returned by ``np.unique``
 
+  - Update reference to scipy.integrate.simpson
 
 -------------------------------------------------------------------------------
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -22,6 +22,9 @@
     spglib raises TypeError when using empty unit cell and this needs
     handling when looking for high-symmetry labels
 
+  - Compatibility fix for Numpy 2.0 update: avoid some
+    broadcasting issues with array shape returned by ``np.unique``
+
 
 -------------------------------------------------------------------------------
 

--- a/euphonic/force_constants.py
+++ b/euphonic/force_constants.py
@@ -508,6 +508,8 @@ class ForceConstants:
             norm_qpts[gamma_i] = 0.
             reduced_qpts, qpts_i = np.unique(norm_qpts, return_inverse=True,
                                              axis=0)
+            qpts_i = qpts_i.flatten()
+            
             n_rqpts = len(reduced_qpts)
             # Special handling of gamma points - don't reduce gamma
             # points if LO-TO splitting

--- a/setup.py
+++ b/setup.py
@@ -56,6 +56,8 @@ def get_c_extension():
         except FileNotFoundError:
             brew_prefix = None
 
+        raise Exception("AAAAAAAAAAAA Darwin build, CC=", os.environ.get("CC"))
+
         if brew_prefix and not os.environ.get('CC'):
             os.environ['CC'] = '{}/opt/llvm/bin/clang'.format(brew_prefix)
             link_args = ['-L{}/opt/llvm/lib'.format(brew_prefix), '-fopenmp']

--- a/setup.py
+++ b/setup.py
@@ -56,15 +56,13 @@ def get_c_extension():
         except FileNotFoundError:
             brew_prefix = None
 
-        raise Exception("AAAAAAAAAAAA Darwin build, CC=", os.environ.get("CC"))
-
         if brew_prefix and not os.environ.get('CC'):
             os.environ['CC'] = '{}/opt/llvm/bin/clang'.format(brew_prefix)
             link_args = ['-L{}/opt/llvm/lib'.format(brew_prefix), '-fopenmp']
         else:
             link_args = ['-fopenmp']
 
-        compile_args = ['-fopenmp']            
+        compile_args = ['-fopenmp']
 
     else:
         # Linux - assume gcc if CC not set

--- a/tests_and_analysis/test/euphonic_test/test_broadening.py
+++ b/tests_and_analysis/test/euphonic_test/test_broadening.py
@@ -3,7 +3,7 @@ import numpy as np
 from numpy.polynomial import Polynomial
 from numpy.random import RandomState
 import numpy.testing as npt
-from scipy.integrate import simps
+from scipy.integrate import simpson
 from scipy.ndimage import gaussian_filter
 
 from euphonic.broadening import (find_coeffs,
@@ -74,10 +74,10 @@ def test_area_unchanged_for_broadened_dos(material, qpt_freqs_json,
                                 fit='cheby-log')
     ebins_centres = ebins.magnitude[:-1] + 0.5*np.diff(ebins.magnitude)
     assert dos.y_data.units == 1/ebins.units
-    dos_area = simps(dos.y_data.magnitude, ebins_centres)
+    dos_area = simpson(dos.y_data.magnitude, x=ebins_centres)
     assert variable_width_broaden.units == 1/ebins.units
-    adaptively_broadened_dos_area = simps(variable_width_broaden.magnitude,
-                                          ebins_centres)
+    adaptively_broadened_dos_area = simpson(
+        variable_width_broaden.magnitude, x=ebins_centres)
     assert adaptively_broadened_dos_area == pytest.approx(dos_area, rel=0.01)
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -8,9 +8,6 @@ skipsdist = True
 [testenv]
 changedir = tests_and_analysis/test
 test_command = python run_tests.py --report
-passenv =
-    CC
-    CXX
 
 [testenv:{py38,py39,py310,py311}]
 install_command =

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,9 @@ skipsdist = True
 [testenv]
 changedir = tests_and_analysis/test
 test_command = python run_tests.py --report
-passenv = CC
+passenv =
+    CC
+    CXX
 
 [testenv:{py38,py39,py310,py311}]
 install_command =

--- a/tox.ini
+++ b/tox.ini
@@ -8,6 +8,7 @@ skipsdist = True
 [testenv]
 changedir = tests_and_analysis/test
 test_command = python run_tests.py --report
+passenv = CC
 
 [testenv:{py38,py39,py310,py311}]
 install_command =


### PR DESCRIPTION
With Numpy 2.0, np.unique returns a 2-D array when applied to q-points. This in turn gets broadcast and adds an extra dimension to the frequency/mode arrays, causing all kinds of chaos.

Flattening the array here should be a no-op for Numpy <2 and fix the issue.