### PR TITLE
Bump numpy requirement to 1.24, matching Mantid

### DIFF
--- a/.github/workflows/build_upload_pypi_wheels.yml
+++ b/.github/workflows/build_upload_pypi_wheels.yml
@@ -9,22 +9,23 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [windows-latest, macos-13, ubuntu-latest]
-        python-version: ['3.10', '3.11']
+        os: [windows-latest, macos-13, macos-latest, ubuntu-latest]
+        python-version: ['3.10', '3.11', '3.12']
         include:
           - os: windows-latest
             wheelname: win
           - os: macos-13
-            wheelname: macos
+            wheelname: macos-intel
+          - os: macos-latest
+            wheelname: macos-arm
           - os: ubuntu-latest
             wheelname: manylinux
-          # Build wheels against the lowest compatible Numpy version
           - python-version: '3.10'
             manylinux-version-tag: cp310
-            numpy-version: 1.21.3
           - python-version: '3.11'
             manylinux-version-tag: cp311
-            numpy-version: 1.23.2
+          - python-version: '3.11'
+            manylinux-version-tag: cp311
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:
@@ -50,7 +51,7 @@ jobs:
         if: matrix.os != 'ubuntu-latest'
         shell: bash -l {0}
         env:
-          NUMPY_VERSION: ${{ matrix.numpy-version }}
+          NUMPY_VERSION: 2.0
         run: |
           # Build against lowest required Numpy version
           python -m pip install numpy==${NUMPY_VERSION}
@@ -61,7 +62,7 @@ jobs:
         uses: pypa/cibuildwheel@v2.12.0
         env:
           CIBW_BUILD: ${{ matrix.manylinux-version-tag}}-manylinux*
-          CIBW_BEFORE_BUILD: python -mpip install numpy==${{ matrix.numpy-version }}
+          CIBW_BEFORE_BUILD: python -mpip install numpy==2.0
           CIBW_ARCHS: x86_64
         with:
           output-dir: wheelhouse

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -17,8 +17,7 @@ jobs:
        (github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'no_ci'))
     strategy:
       matrix:
-        # os: [ubuntu-latest, windows-latest, macos-latest]
-        os: [ubuntu-latest]
+        os: [ubuntu-latest, windows-latest, macos-latest]
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -17,7 +17,8 @@ jobs:
        (github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'no_ci'))
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        # os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest]
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,12 +7,12 @@
 
   - Python 3.12 is supported
 
-  - Python 3.10+ requires numpy >= 1.21.3
-
   - importlib_resources backport is no longer required
 
-  - Some other dependency requirements have been increased because
-    older versions are difficult to test against Python 3.10:
+  - Some other dependency requirements have been increased in order
+    to simplify maintenance and testing:
+
+    - Minimum version of numpy increased from 1.19.3 to 1.24.0
 
     - Minimum version of matplotlib increased from 3.2 to 3.8
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -20,7 +20,9 @@
 
     - Minimum version of PyYAML increased from 3.13 to 6.0
 
-    - Minimum version of h5py increaased form 2.10 to 3.6
+    - Minimum version of h5py increaased from 2.10 to 3.6
+
+    - Minimum version of threadpoolctl increased from 1.0 to 3.0.
 
 - Big fixes
 

--- a/setup.py
+++ b/setup.py
@@ -144,7 +144,7 @@ def run_setup():
             'seekpath>=1.1.0',
             'spglib>=1.9.4',
             'pint>=0.22',
-            'threadpoolctl>=1.0.0'
+            'threadpoolctl>=3.0.0'
         ],
         extras_require={
             'matplotlib': ['matplotlib>=3.8.0'],

--- a/setup.py
+++ b/setup.py
@@ -139,7 +139,8 @@ def run_setup():
         include_package_data=True,
         install_requires=[
             'packaging',
-            'scipy>=1.10',  # requires numpy >= 1.19.5; py3.10 requires 1.21.3
+            'numpy>=1.24.0',
+            'scipy>=1.10',
             'seekpath>=1.1.0',
             'spglib>=1.9.4',
             'pint>=0.22',

--- a/tests_and_analysis/minimum_euphonic_requirements.txt
+++ b/tests_and_analysis/minimum_euphonic_requirements.txt
@@ -1,4 +1,4 @@
-numpy==1.24.0
+numpy==1.24.4
 scipy==1.10.0
 spglib==1.9.4.2
 seekpath==1.1.0

--- a/tests_and_analysis/minimum_euphonic_requirements.txt
+++ b/tests_and_analysis/minimum_euphonic_requirements.txt
@@ -1,4 +1,4 @@
-numpy==1.24.4
+numpy==1.24.0
 scipy==1.10.0
 spglib==1.9.4.2
 seekpath==1.1.0
@@ -6,5 +6,4 @@ pint==0.22
 matplotlib==3.8
 h5py==3.6
 PyYAML==6.0
-#threadpoolctl==1.0.0
-threadpoolctl==2.0
+threadpoolctl==3.0.0

--- a/tests_and_analysis/minimum_euphonic_requirements.txt
+++ b/tests_and_analysis/minimum_euphonic_requirements.txt
@@ -1,4 +1,4 @@
-numpy==1.21.3
+numpy==1.24.0
 scipy==1.10.0
 spglib==1.9.4.2
 seekpath==1.1.0

--- a/tests_and_analysis/minimum_euphonic_requirements.txt
+++ b/tests_and_analysis/minimum_euphonic_requirements.txt
@@ -1,5 +1,5 @@
 numpy==1.24.4
-# scipy==1.10.0
+scipy==1.10.0
 # spglib==1.9.4.2
 # seekpath==1.1.0
 # pint==0.22

--- a/tests_and_analysis/minimum_euphonic_requirements.txt
+++ b/tests_and_analysis/minimum_euphonic_requirements.txt
@@ -1,5 +1,5 @@
 numpy==1.24.4
-scipy==1.10.0
+scipy
 spglib==1.9.4.2
 seekpath==1.1.0
 pint==0.22

--- a/tests_and_analysis/minimum_euphonic_requirements.txt
+++ b/tests_and_analysis/minimum_euphonic_requirements.txt
@@ -7,4 +7,4 @@ matplotlib==3.8
 h5py==3.6
 PyYAML==6.0
 #threadpoolctl==1.0.0
-threadpoolctl==3.0
+threadpoolctl==2.0

--- a/tests_and_analysis/minimum_euphonic_requirements.txt
+++ b/tests_and_analysis/minimum_euphonic_requirements.txt
@@ -1,9 +1,9 @@
 numpy==1.24.4
 scipy==1.10.0
-# spglib==1.9.4.2
-# seekpath==1.1.0
-# pint==0.22
-# matplotlib==3.8
+spglib==1.9.4.2
+seekpath==1.1.0
+pint==0.22
+matplotlib==3.8
 # h5py==3.6
 # PyYAML==6.0
 # threadpoolctl==1.0.0

--- a/tests_and_analysis/minimum_euphonic_requirements.txt
+++ b/tests_and_analysis/minimum_euphonic_requirements.txt
@@ -6,4 +6,5 @@ pint==0.22
 matplotlib==3.8
 h5py==3.6
 PyYAML==6.0
-threadpoolctl==1.0.0
+#threadpoolctl==1.0.0
+threadpoolctl==3.0

--- a/tests_and_analysis/minimum_euphonic_requirements.txt
+++ b/tests_and_analysis/minimum_euphonic_requirements.txt
@@ -6,4 +6,4 @@ pint==0.22
 matplotlib==3.8
 h5py==3.6
 PyYAML==6.0
-# threadpoolctl==1.0.0
+threadpoolctl==1.0.0

--- a/tests_and_analysis/minimum_euphonic_requirements.txt
+++ b/tests_and_analysis/minimum_euphonic_requirements.txt
@@ -4,6 +4,6 @@ spglib==1.9.4.2
 seekpath==1.1.0
 pint==0.22
 matplotlib==3.8
-# h5py==3.6
-# PyYAML==6.0
+h5py==3.6
+PyYAML==6.0
 # threadpoolctl==1.0.0

--- a/tests_and_analysis/minimum_euphonic_requirements.txt
+++ b/tests_and_analysis/minimum_euphonic_requirements.txt
@@ -1,9 +1,9 @@
 numpy==1.24.4
-scipy
-spglib==1.9.4.2
-seekpath==1.1.0
-pint==0.22
-matplotlib==3.8
-h5py==3.6
-PyYAML==6.0
-threadpoolctl==1.0.0
+# scipy==1.10.0
+# spglib==1.9.4.2
+# seekpath==1.1.0
+# pint==0.22
+# matplotlib==3.8
+# h5py==3.6
+# PyYAML==6.0
+# threadpoolctl==1.0.0

--- a/tox.ini
+++ b/tox.ini
@@ -18,7 +18,6 @@ install_command =
         {opts} \
         {packages}
 deps =
-    numpy
     -r{toxinidir}/tests_and_analysis/tox_requirements.txt
 commands_pre =
     python -m pip install \
@@ -90,8 +89,7 @@ install_command =
     python -m pip install --force-reinstall {opts} {packages}
 platform =
     linux: linux
-deps =
-    numpy==1.21.3
+deps = {[testenv:py310]deps}
 commands_pre =
     python -m pip install --force-reinstall \
         -r{toxinidir}/tests_and_analysis/minimum_euphonic_requirements.txt

--- a/tox.ini
+++ b/tox.ini
@@ -91,7 +91,7 @@ install_command =
 platform =
     linux: linux
 deps =
-    numpy==1.24.0
+    numpy==1.24.4
     {[testenv:py310]deps}
 commands_pre =
     python -m pip install --force-reinstall \

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,8 @@
 [tox]
 requires = tox-conda
 # The python environments to run the tests in
-envlist = py310,py311,py312,py310-{base,matplotlib,phonopy_reader,brille,all},py310-minrequirements-linux
+#envlist = py310,py311,py312,py310-{base,matplotlib,phonopy_reader,brille,all},py310-minrequirements-linux
+envlist = py310,py312,py310-minrequirements-linux
 # Skip the execution of setup.py as we do it with the correct arg in commands_pre below
 skipsdist = True
 

--- a/tox.ini
+++ b/tox.ini
@@ -18,6 +18,7 @@ install_command =
         {opts} \
         {packages}
 deps =
+    numpy
     -r{toxinidir}/tests_and_analysis/tox_requirements.txt
 commands_pre =
     python -m pip install \

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,7 @@
 [tox]
 requires = tox-conda
 # The python environments to run the tests in
-#envlist = py310,py311,py312,py310-{base,matplotlib,phonopy_reader,brille,all},py310-minrequirements-linux
-envlist = py310,py312,py310-minrequirements-linux
+envlist = py310,py311,py312,py310-{base,matplotlib,phonopy_reader,brille,all},py310-minrequirements-linux
 # Skip the execution of setup.py as we do it with the correct arg in commands_pre below
 skipsdist = True
 
@@ -92,7 +91,7 @@ install_command =
 platform =
     linux: linux
 deps =
-    numpy==1.24.4
+    numpy==1.24.0
     {[testenv:py310]deps}
 commands_pre =
     python -m pip install --force-reinstall \

--- a/tox.ini
+++ b/tox.ini
@@ -90,7 +90,9 @@ install_command =
     python -m pip install --force-reinstall {opts} {packages}
 platform =
     linux: linux
-deps = {[testenv:py310]deps}
+deps =
+    numpy==1.24.0
+    {[testenv:py310]deps}
 commands_pre =
     python -m pip install --force-reinstall \
         -r{toxinidir}/tests_and_analysis/minimum_euphonic_requirements.txt


### PR DESCRIPTION
While transitioning to Numpy 2.0 it is helpful to reduce the range of versions being used and tested. As we are changing other requirements in this release, it is a good time to bump Numpy.

Here we also update the build/release workflow to add Python 3.12 and build with Numpy 2.0; these builds _should_ also work with all the supported numpy 1.x.

- [ ] Add a note to changelog that binary wheels are now built against 2.0