### PR TITLE
Clean up some low-hanging warnings in test suite

### DIFF
--- a/euphonic/brille.py
+++ b/euphonic/brille.py
@@ -1,3 +1,4 @@
+import dataclasses
 from multiprocessing import cpu_count
 from typing import Union, Optional, Dict, Any, Type, TypeVar
 
@@ -185,6 +186,11 @@ class BrilleInterpolator:
         cell = crystal.to_spglib_cell()
 
         dataset = spg.get_symmetry_dataset(cell)
+        # Spglib 2.5 introduced dataclass structures:
+        # convert back to dict for now
+        if dataclasses.is_dataclass(dataset):
+            dataset = dataclasses.asdict(dataset)
+
         rotations = dataset['rotations']  # in fractional
         translations = dataset['translations']  # in fractional
 

--- a/euphonic/cli/utils.py
+++ b/euphonic/cli/utils.py
@@ -312,9 +312,13 @@ def _bands_from_force_constants(data: ForceConstants,
                                                  QpointFrequencies],
                                            XTickLabels, SplitArgs]:
     structure = data.crystal.to_spglib_cell()
-    bandpath = seekpath.get_explicit_k_path(
-        structure,
-        reference_distance=q_distance.to('1 / angstrom').magnitude)
+    with warnings.catch_warnings():
+        # SeeK-path is raising spglib 2.5.0 deprecation warnings, we
+        # don't care to see those for now
+        warnings.simplefilter("ignore", category=DeprecationWarning)
+        bandpath = seekpath.get_explicit_k_path(
+            structure,
+            reference_distance=q_distance.to('1 / angstrom').magnitude)
 
     if insert_gamma:
         _insert_gamma(bandpath)

--- a/tests_and_analysis/test/euphonic_test/test_spectrum2d.py
+++ b/tests_and_analysis/test/euphonic_test/test_spectrum2d.py
@@ -315,7 +315,7 @@ class TestSpectrum2DMethods:
             check_spectrum2d(spectrum, expected_spectrum)
 
     @pytest.mark.parametrize(
-        'args, spectrum2d_file, broadened_spectrum2d_file, expectation', [
+        'args, spectrum2d_file, broadened_spectrum2d_file, context', [
             (({'x_width': 0.1*ureg('1/angstrom'), 'method': 'convolve'}),
              'quartz_bandstructure_sqw.json',
              'quartz_bandstructure_0.1ang_xbroaden_sqw.json',
@@ -369,10 +369,10 @@ class TestSpectrum2DMethods:
               does_not_raise())),
                              ])
     def test_broaden(self, args, spectrum2d_file, broadened_spectrum2d_file,
-                     expectation):
+                     context):
         spec2d = get_spectrum2d(spectrum2d_file)
         expected_broadened_spec2d = get_spectrum2d(broadened_spectrum2d_file)
-        with expectation:
+        with context:
             broadened_spec2d = spec2d.broaden(**args)
         check_spectrum2d(broadened_spec2d, expected_broadened_spec2d)
 

--- a/tests_and_analysis/test/euphonic_test/test_util.py
+++ b/tests_and_analysis/test/euphonic_test/test_util.py
@@ -1,4 +1,5 @@
-from contextlib import ExitStack
+"""Unit tests for euphonic.util"""
+
 import json
 import os
 import sys

--- a/tests_and_analysis/test/script_tests/test_intensity_map.py
+++ b/tests_and_analysis/test/script_tests/test_intensity_map.py
@@ -38,9 +38,6 @@ intensity_map_params = [
     [graphite_fc_file, '--e-min=-100', '--e-max=1000', '--ebins=100',
      '--energy-unit=cm^-1'],
     [graphite_fc_file, '--energy-broadening=2e-3', '-u=eV'],
-    [graphite_fc_file, '--q-spacing=0.05', '--length-unit=bohr',
-     '--q-broadening=0.1'],
-    [graphite_fc_file, '--qb=0.01', '--eb=1.5', '--shape=lorentz'],
     [graphite_fc_file, '--asr'],
     [graphite_fc_file, '--asr=realspace'],
     [quartz_json_file],
@@ -49,6 +46,11 @@ intensity_map_params = [
     [quartz_no_evec_json_file],
     [graphite_fc_file, '--weighting=coherent', '--cmap=bone'],
     [graphite_fc_file, '--weighting=coherent', '--temperature=800']]
+broadening_warning_expected_params = [
+    [graphite_fc_file, '--q-spacing=0.05', '--length-unit=bohr',
+     '--q-broadening=0.1'],
+    [graphite_fc_file, '--qb=0.01', '--eb=1.5', '--shape=lorentz'],
+]
 
 
 class TestRegression:
@@ -93,6 +95,13 @@ class TestRegression:
     def test_intensity_map_image_data(
             self, inject_mocks, intensity_map_args):
         self.run_intensity_map_and_test_result(intensity_map_args)
+
+    @pytest.mark.parametrize('intensity_map_args',
+                             broadening_warning_expected_params)
+    def test_intensity_map_image_data_width_warning(
+            self, inject_mocks, intensity_map_args):
+        with pytest.warns(UserWarning, match="x_data bin widths are not equal"):
+            self.run_intensity_map_and_test_result(intensity_map_args)
 
     @pytest.mark.parametrize('intensity_map_args', [
         [quartz_json_file, '--save-to'],
@@ -169,7 +178,7 @@ def test_regenerate_intensity_map_data(_):
     except FileNotFoundError:
         json_data = {}
 
-    for intensity_map_param in intensity_map_params:
+    for intensity_map_param in intensity_map_params + broadening_warning_expected_params:
         # Generate current figure for us to retrieve with gcf
         euphonic.cli.intensity_map.main(intensity_map_param)
 

--- a/tests_and_analysis/test/script_tests/test_optimise_dipole_parameter.py
+++ b/tests_and_analysis/test/script_tests/test_optimise_dipole_parameter.py
@@ -1,3 +1,4 @@
+from contextlib import ExitStack
 import os
 import math
 # Required for mocking
@@ -26,8 +27,6 @@ class TestRegression:
     @staticmethod
     def call_cli(fc_file: str, args: list[Any], warning: Optional[str]) -> None:
         """Call optimise-dipole-parameter, checking for warning if appropriate"""
-        from contextlib import ExitStack
-
         with ExitStack() as stack:
             if warning is not None:
                 stack.enter_context(pytest.warns(UserWarning, match=warning))

--- a/tests_and_analysis/test/script_tests/test_optimise_dipole_parameter.py
+++ b/tests_and_analysis/test/script_tests/test_optimise_dipole_parameter.py
@@ -3,6 +3,7 @@ import math
 # Required for mocking
 from random import random
 import time
+from typing import Any, Optional
 from unittest.mock import Mock
 
 import pytest
@@ -22,29 +23,43 @@ quick_calc_params = ['-n=10', '--min=0.5', '--max=0.5']
 
 
 class TestRegression:
+    @staticmethod
+    def call_cli(fc_file: str, args: list[Any], warning: Optional[str]) -> None:
+        """Call optimise-dipole-parameter, checking for warning if appropriate"""
+        from contextlib import ExitStack
+
+        with ExitStack() as stack:
+            if warning is not None:
+                stack.enter_context(pytest.warns(UserWarning, match=warning))
+
+            return euphonic.cli.optimise_dipole_parameter.main([fc_file, *args])
 
     @pytest.mark.parametrize(
         'fc_file, opt_dipole_par_args, expected_n_qpts, '
-        'expected_dipole_pars, expected_calc_qpt_ph_modes_kwargs', [
-            (quartz_castep_bin, ['-n=5'], 5, np.linspace(0.25, 1.5, 6), {}),
+        'expected_dipole_pars, expected_calc_qpt_ph_modes_kwargs, '
+        'warning', [
+            (quartz_castep_bin, ['-n=5'], 5, np.linspace(0.25, 1.5, 6), {}, None),
             (quartz_castep_bin,
              ['-n=10', '--n-threads=2', '--dipole-parameter-min=0.5',
               '--dipole-parameter-max=1.0'], 10, np.linspace(0.5, 1.0, 3),
-             {'n_threads': 2}),
+             {'n_threads': 2}, None),
             (lzo_castep_bin,
              ['-n=15', '--asr=reciprocal', '--disable-c',
               '--dipole-parameter-min=0.1', '--dipole-parameter-max=0.4',
               '--dipole-parameter-step=0.1'], 15, np.linspace(0.1, 0.4, 4),
-             {'asr': 'reciprocal', 'use_c': False})
+             {'asr': 'reciprocal', 'use_c': False},
+             "Born charges not found for this material")
         ])
     def test_calc_qpt_phonon_modes_called_with_correct_args(
             self, mocker, fc_file, opt_dipole_par_args, expected_n_qpts,
-            expected_dipole_pars, expected_calc_qpt_ph_modes_kwargs):
+            expected_dipole_pars, expected_calc_qpt_ph_modes_kwargs,
+            warning):
         fc = ForceConstants.from_castep(fc_file)
         mock = mocker.patch.object(ForceConstants, 'calculate_qpoint_phonon_modes',
             wraps=fc.calculate_qpoint_phonon_modes)
-        euphonic.cli.optimise_dipole_parameter.main(
-            [fc_file, *opt_dipole_par_args])
+
+        self.call_cli(fc_file, opt_dipole_par_args, warning=warning)
+
         default_kwargs = {'asr': None, 'n_threads': None, 'use_c': None}
 
         # Called twice for each dipole_parameter value - once to measure
@@ -83,11 +98,6 @@ class TestRegression:
         euphonic.cli.optimise_dipole_parameter.main([
            nacl_default_yaml, *quick_calc_params])
         assert len(recwarn) == 0
-
-    def test_fc_with_no_born_emits_user_warning(self):
-        with pytest.warns(UserWarning):
-            euphonic.cli.optimise_dipole_parameter.main([
-                lzo_castep_bin, *quick_calc_params])
 
     def test_qpoint_modes_raises_type_error(self):
         with pytest.raises(TypeError):

--- a/tests_and_analysis/test/script_tests/test_powder_map.py
+++ b/tests_and_analysis/test/script_tests/test_powder_map.py
@@ -88,7 +88,6 @@ class TestRegression:
             self, powder_map_args, keys_to_omit=['x_ticklabels']):
         euphonic.cli.powder_map.main(powder_map_args)
 
-        matplotlib.pyplot.gcf().tight_layout()  # Force tick labels to be set
         image_data = get_current_plot_image_data()
 
         with open(powder_map_output_file, 'r') as expected_data_file:

--- a/tests_and_analysis/test/script_tests/utils.py
+++ b/tests_and_analysis/test/script_tests/utils.py
@@ -148,7 +148,7 @@ def get_ax_image_data(ax: 'matplotlib.axes.Axes'
     data['cmap'] = im.cmap.name
     data['extent'] = [float(x) for x in im.get_extent()]
     data['size'] = [int(x) for x in im.get_size()]
-    data['data_1'] = list(map(float, data_slice_1))
-    data['data_2'] = list(map(float, data_slice_2))
+    data['data_1'] = list(map(float, data_slice_1.filled(np.nan)))
+    data['data_2'] = list(map(float, data_slice_2.filled(np.nan)))
 
     return data

--- a/tests_and_analysis/test/utils.py
+++ b/tests_and_analysis/test/utils.py
@@ -1,3 +1,4 @@
+from contextlib import contextmanager
 import os
 import json
 from typing import Optional, Tuple
@@ -348,3 +349,16 @@ def check_spectrum_text_header(text_filename):
             if idx > 0 and line[0] != '#':  # Ensure at least 1 y_data line
                 break
             assert f'# Column {idx + 2}: y_data[{idx}] {{' in line
+
+
+@contextmanager
+def does_not_raise():
+    """Dummy context manager
+
+    Use this instead of pytest.raises() or pytest.warns() as part of an
+    "expectation" parameter for tests that sometimes raise a warning/exception.
+
+    See https://docs.pytest.org/en/4.6.x/example/parametrize.html#parametrizing-conditional-raising
+
+    """
+    yield


### PR DESCRIPTION
- Spglib 2.5 deprecation warnings; when caused by Euphonic, we can solve the compatibility issue by converting to a dict. When caused by a dependency, suppress the warning.
- Filter out expected warnings from certain tests in a more systematic way
- Avoid a Matplotlib warning when calling tight_layout() on a plot with a colourbar... by not doing that.
- Replace noisy implicit filling of masked values with NaN with explicit filling

There is a divide-by-zero warning which I think has its roots in nasty pint/spectroscopy units hackery. That is not just an artifact and should be dealt with in a separate PR.