### PR TITLE
Improve handling of spectral units

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -24,10 +24,22 @@
 
     - Minimum version of threadpoolctl increased from 1.0 to 3.0.
 
-- Big fixes
+- Improvements
+
+  - A "reciprocal_spectroscopy" Pint context is made available in the
+    unit registry for tricky conversions between reciprocal
+    frequency/energy units. It is not active by default but can be
+    enabled with e.g.
+
+      (10 * ureg("1 / meV")).to("cm", "reciprocal_spectroscopy")
+
+- Bug fixes
 
   - Metadata strings from Castep-imported PDOS data are now converted
     from numpy strings to native Python strings.
+
+  - Spectra from CASTEP .phonon_dos files are now imported with units
+    of reciprocal energy (e.g. 1/meV)
 
 
 `v1.3.2 <https://github.com/pace-neutrons/Euphonic/compare/v1.3.1...v1.3.2>`_

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -33,6 +33,9 @@
 
       (10 * ureg("1 / meV")).to("cm", "reciprocal_spectroscopy")
 
+    This can also help to avoid divide-by-zero issues when performing
+    energy <-> wavenumber conversions.
+
 - Bug fixes
 
   - Metadata strings from Castep-imported PDOS data are now converted
@@ -40,6 +43,11 @@
 
   - Spectra from CASTEP .phonon_dos files are now imported with units
     of reciprocal energy (e.g. 1/meV)
+
+- Maintenance
+
+  - Cleared up unit-conversion-related warnings, de-cluttering the
+    expected test suite output.
 
 
 `v1.3.2 <https://github.com/pace-neutrons/Euphonic/compare/v1.3.1...v1.3.2>`_

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -24,6 +24,9 @@
 
     - Minimum version of threadpoolctl increased from 1.0 to 3.0.
 
+  - `toolz <https://toolz.readthedocs.io/en/latest/index.html>`_ is
+    added to the testing (tox) requirements
+
 - Improvements
 
   - A "reciprocal_spectroscopy" Pint context is made available in the

--- a/euphonic/__init__.py
+++ b/euphonic/__init__.py
@@ -1,5 +1,6 @@
 from importlib.resources import files
 
+from . import data
 from . import _version
 __version__ = _version.get_versions()['version']
 
@@ -10,7 +11,6 @@ from pint import UnitRegistry
 ureg = UnitRegistry()
 
 # Add reciprocal_spectroscopy environment used for tricky conversions
-from . import data
 ureg.load_definitions(files(data) / "reciprocal_spectroscopy_definitions.txt")
 
 ureg.enable_contexts('spectroscopy')

--- a/euphonic/__init__.py
+++ b/euphonic/__init__.py
@@ -8,6 +8,11 @@ from pint import UnitRegistry
 
 # Create ureg here so it is only created once
 ureg = UnitRegistry()
+
+# Add reciprocal_spectroscopy environment used for tricky conversions
+from . import data
+ureg.load_definitions(files(data) / "reciprocal_spectroscopy_definitions.txt")
+
 ureg.enable_contexts('spectroscopy')
 Quantity = ureg.Quantity
 

--- a/euphonic/broadening.py
+++ b/euphonic/broadening.py
@@ -149,14 +149,13 @@ def width_interpolated_broadening(
         ydata
     """
 
-    conv = 1*ureg('hartree').to(bins.units)
-    return _width_interpolated_broadening(bins.to('hartree').magnitude,
-                                          x.to('hartree').magnitude,
-                                          widths.to('hartree').magnitude,
+    return _width_interpolated_broadening(bins.magnitude,
+                                          x.to(bins.units).magnitude,
+                                          widths.to(bins.units).magnitude,
                                           weights,
                                           adaptive_error,
                                           shape=shape,
-                                          fit=fit) / conv
+                                          fit=fit) / bins.units
 
 
 def _lorentzian(x: np.ndarray, gamma: np.ndarray) -> np.ndarray:
@@ -226,7 +225,7 @@ def _width_interpolated_broadening(
     # bins should be regularly spaced, check that this is the case and
     # raise a warning if not
     bin_widths = np.diff(bins)
-    if not np.all(np.isclose(bin_widths, bin_widths[0])):
+    if not np.all(np.isclose(bin_widths, bin_widths[0], atol=0.)):
         warnings.warn('Not all bin widths are equal, so broadening by '
                       'convolution will give incorrect results.',
                       stacklevel=3)

--- a/euphonic/data/reciprocal_spectroscopy_definitions.txt
+++ b/euphonic/data/reciprocal_spectroscopy_definitions.txt
@@ -1,0 +1,11 @@
+@context reciprocal_spectroscopy = rs
+    1 / [frequency] <-> 1 / [length]: 1 / value / speed_of_light
+    1 / [energy] -> 1 / [frequency]: planck_constant * value
+    1 / [frequency] -> 1 / [energy]: value / planck_constant
+
+    # n index of refraction of the medium.
+    # [length] <-> [frequency]: speed_of_light / value
+    # [frequency] -> [energy]: planck_constant * value
+    # [energy] -> [frequency]: value / planck_constant
+    # [wavenumber] <-> [length]: 1 / value
+@end

--- a/euphonic/data/reciprocal_spectroscopy_definitions.txt
+++ b/euphonic/data/reciprocal_spectroscopy_definitions.txt
@@ -2,10 +2,8 @@
     1 / [frequency] <-> 1 / [length]: 1 / value / speed_of_light
     1 / [energy] -> 1 / [frequency]: planck_constant * value
     1 / [frequency] -> 1 / [energy]: value / planck_constant
-
-    # n index of refraction of the medium.
-    # [length] <-> [frequency]: speed_of_light / value
-    # [frequency] -> [energy]: planck_constant * value
-    # [energy] -> [frequency]: value / planck_constant
-    # [wavenumber] <-> [length]: 1 / value
+    [length] -> 1 / [energy]: value / planck_constant / speed_of_light
+    1 / [energy] -> [length]: value * planck_constant * speed_of_light
+    1 / [length] -> [energy]: value * planck_constant * speed_of_light
+    [energy] -> 1 / [length]: value / planck_constant / speed_of_light
 @end

--- a/euphonic/data/reciprocal_spectroscopy_definitions.txt
+++ b/euphonic/data/reciprocal_spectroscopy_definitions.txt
@@ -2,8 +2,8 @@
     1 / [frequency] <-> 1 / [length]: 1 / value / speed_of_light
     1 / [energy] -> 1 / [frequency]: planck_constant * value
     1 / [frequency] -> 1 / [energy]: value / planck_constant
-    [length] -> 1 / [energy]: value / planck_constant / speed_of_light
-    1 / [energy] -> [length]: value * planck_constant * speed_of_light
-    1 / [length] -> [energy]: value * planck_constant * speed_of_light
-    [energy] -> 1 / [length]: value / planck_constant / speed_of_light
+    [length] -> 1 / [energy]: value / (planck_constant * speed_of_light)
+    1 / [energy] -> [length]: value * (planck_constant * speed_of_light)
+    1 / [length] -> [energy]: value * (planck_constant * speed_of_light)
+    [energy] -> 1 / [length]: value / (planck_constant * speed_of_light)
 @end

--- a/euphonic/readers/castep.py
+++ b/euphonic/readers/castep.py
@@ -103,7 +103,9 @@ def read_phonon_dos_data(
 
     data_dict['dos'] = {}
     data_dict['dos_unit'] = f"1/{frequencies_unit}"
-    dos_conv = ureg('1 / (1/cm)').to(data_dict['dos_unit'], "reciprocal_spectroscopy")
+    dos_conv = ureg('1 / (1/cm)'
+                    ).to(data_dict['dos_unit'], "reciprocal_spectroscopy"
+                         ).magnitude
 
     dos_dict = data_dict['dos']
     dos_dict['Total'] = dos_data[:, 1] * dos_conv

--- a/euphonic/readers/castep.py
+++ b/euphonic/readers/castep.py
@@ -102,16 +102,16 @@ def read_phonon_dos_data(
     data_dict['dos_bins_unit'] = frequencies_unit
 
     data_dict['dos'] = {}
-    data_dict['dos_unit'] = frequencies_unit
-    # Avoid issues in converting DOS, Pint allows
-    # cm^-1 -> meV but not cm -> 1/meV
-    dos_conv = (1*ureg('1/cm').to(frequencies_unit)).magnitude
+    data_dict['dos_unit'] = f"1/{frequencies_unit}"
+    dos_conv = ureg('1 / (1/cm)').to(data_dict['dos_unit'], "reciprocal_spectroscopy")
+
     dos_dict = data_dict['dos']
-    dos_dict['Total'] = dos_data[:, 1]/dos_conv
+    dos_dict['Total'] = dos_data[:, 1] * dos_conv
+
     _, idx = np.unique(atom_type, return_index=True)
     unique_types = atom_type[np.sort(idx)]
     for i, species in enumerate(unique_types):
-        dos_dict[str(species)] = dos_data[:, i + 2]/dos_conv
+        dos_dict[str(species)] = dos_data[:, i + 2] * dos_conv
 
     return data_dict
 

--- a/euphonic/spectra.py
+++ b/euphonic/spectra.py
@@ -42,8 +42,8 @@ class Spectrum(ABC):
 
     @property
     def x_data(self) -> Quantity:
-        return self._x_data*ureg(self._internal_x_data_unit).to(
-            self.x_data_unit)
+        return ureg.Quantity(self._x_data, self._internal_x_data_unit
+                             ).to(self.x_data_unit, "reciprocal_spectroscopy")
 
     @x_data.setter
     def x_data(self, value: Quantity) -> None:
@@ -52,7 +52,7 @@ class Spectrum(ABC):
 
     @property
     def y_data(self) -> Quantity:
-        return self._y_data*ureg(self._internal_y_data_unit).to(
+        return ureg.Quantity(self._y_data, self._internal_y_data_unit).to(
             self.y_data_unit, "reciprocal_spectroscopy")
 
     @y_data.setter
@@ -1319,8 +1319,9 @@ class Spectrum2D(Spectrum):
 
     @property
     def z_data(self) -> Quantity:
-        return self._z_data*ureg(self._internal_z_data_unit).to(
-            self.z_data_unit, "reciprocal_spectroscopy")
+        return ureg.Quantity(
+            self._z_data, self._internal_z_data_unit
+        ).to(self.z_data_unit, "reciprocal_spectroscopy")
 
     @z_data.setter
     def z_data(self, value: Quantity) -> None:

--- a/euphonic/spectra.py
+++ b/euphonic/spectra.py
@@ -1,3 +1,5 @@
+# pylint: disable=no-member
+
 from abc import ABC, abstractmethod
 import collections
 import copy

--- a/euphonic/spectra.py
+++ b/euphonic/spectra.py
@@ -53,7 +53,7 @@ class Spectrum(ABC):
     @property
     def y_data(self) -> Quantity:
         return self._y_data*ureg(self._internal_y_data_unit).to(
-            self.y_data_unit)
+            self.y_data_unit, "reciprocal_spectroscopy")
 
     @y_data.setter
     def y_data(self, value: Quantity) -> None:
@@ -561,6 +561,7 @@ class Spectrum1D(Spectrum):
         else:
             metadata['species'] = element
         metadata['label'] = element
+
         return cls(data['dos_bins']*ureg(data['dos_bins_unit']),
                    data['dos'][element]*ureg(data['dos_unit']),
                    metadata=metadata)
@@ -1319,7 +1320,7 @@ class Spectrum2D(Spectrum):
     @property
     def z_data(self) -> Quantity:
         return self._z_data*ureg(self._internal_z_data_unit).to(
-            self.z_data_unit)
+            self.z_data_unit, "reciprocal_spectroscopy")
 
     @z_data.setter
     def z_data(self, value: Quantity) -> None:

--- a/euphonic/validate.py
+++ b/euphonic/validate.py
@@ -82,7 +82,8 @@ def _check_unit_conversion(obj: object, attr_name: str, attr_value: Any,
     if hasattr(obj, attr_name):
         if attr_name in unit_attrs:
             try:
-                _ = ureg(getattr(obj, attr_name)).to(attr_value)
+                _ = ureg(getattr(obj, attr_name)).to(attr_value,
+                                                     "reciprocal_spectroscopy")
             except DimensionalityError:
                 raise ValueError((
                     f'"{attr_value}" is not a known dimensionally-consistent '

--- a/euphonic/validate.py
+++ b/euphonic/validate.py
@@ -82,8 +82,8 @@ def _check_unit_conversion(obj: object, attr_name: str, attr_value: Any,
     if hasattr(obj, attr_name):
         if attr_name in unit_attrs:
             try:
-                _ = ureg(getattr(obj, attr_name)).to(attr_value,
-                                                     "reciprocal_spectroscopy")
+                ureg(getattr(obj, attr_name)).ito(attr_value,
+                                                  "reciprocal_spectroscopy")
             except DimensionalityError:
                 raise ValueError((
                     f'"{attr_value}" is not a known dimensionally-consistent '

--- a/tests_and_analysis/test/data/spectrum1dcollection/lzo_222_full_castep_adaptive_dos.json
+++ b/tests_and_analysis/test/data/spectrum1dcollection/lzo_222_full_castep_adaptive_dos.json
@@ -50038,5 +50038,5 @@
             0.0
         ]
     ],
-    "y_data_unit": "millielectron_volt"
+    "y_data_unit": "1 / millielectron_volt"
 }

--- a/tests_and_analysis/test/data/spectrum1dcollection/quartz_554_full_castep_adaptive_dos.json
+++ b/tests_and_analysis/test/data/spectrum1dcollection/quartz_554_full_castep_adaptive_dos.json
@@ -12031,5 +12031,5 @@
             0.0
         ]
     ],
-    "y_data_unit": "millielectron_volt"
+    "y_data_unit": "1 / millielectron_volt"
 }

--- a/tests_and_analysis/test/euphonic_test/test_castep_reader.py
+++ b/tests_and_analysis/test/euphonic_test/test_castep_reader.py
@@ -4,6 +4,7 @@ import json
 import pytest
 import numpy as np
 import numpy.testing as npt
+from toolz.dicttoolz import valmap
 
 from euphonic.io import _from_json_dict
 from euphonic.util import direction_changed, mp_grid, get_qpoint_labels
@@ -43,14 +44,15 @@ class TestReadPhononDosData:
                     assert dct[exp_key] == exp_val
 
         # Convert ref data from cm to 1/meV to match current behaviour
-
         expected_dos_data['dos_unit'] = '1/meV'
 
-        for key, value in expected_dos_data['dos'].items():
-            expected_dos_data['dos'][key] = (ureg.Quantity(value, "cm")
-                                             .to("1 / meV", "reciprocal_spectroscopy")
-                                             .magnitude
-                                             .tolist())
+        def transform(dos: list[float]) -> list[float]:
+            return (ureg.Quantity(dos, "cm")
+                    .to("1 / meV", "reciprocal_spectroscopy")
+                    .magnitude
+                    .tolist())
+
+        expected_dos_data["dos"] = valmap(transform, expected_dos_data["dos"])
 
         check_dict(dos_data, expected_dos_data)
 

--- a/tests_and_analysis/test/euphonic_test/test_castep_reader.py
+++ b/tests_and_analysis/test/euphonic_test/test_castep_reader.py
@@ -41,12 +41,17 @@ class TestReadPhononDosData:
                     check_dict(dct[exp_key], exp_val)
                 else:
                     assert dct[exp_key] == exp_val
-        # Temporary solution until test data has been regenerated
-        # units have changed
-        expected_dos_data['dos_unit'] = 'meV'
-        dos_conv = (1*ureg('1/cm').to('meV')).magnitude
+
+        # Convert ref data from cm to 1/meV to match current behaviour
+
+        expected_dos_data['dos_unit'] = '1/meV'
+
         for key, value in expected_dos_data['dos'].items():
-            expected_dos_data['dos'][key] = [x/dos_conv for x in value]
+            expected_dos_data['dos'][key] = (ureg.Quantity(value, "cm")
+                                             .to("1 / meV", "reciprocal_spectroscopy")
+                                             .magnitude
+                                             .tolist())
+
         check_dict(dos_data, expected_dos_data)
 
 

--- a/tests_and_analysis/test/euphonic_test/test_spectrum1d.py
+++ b/tests_and_analysis/test/euphonic_test/test_spectrum1d.py
@@ -182,7 +182,8 @@ class TestSpectrum1DCreation:
         pytest.lazy_fixture('create_from_constructor'),
         pytest.lazy_fixture('create_from_json'),
         pytest.lazy_fixture('create_from_dict'),
-        pytest.lazy_fixture('create_from_castep_phonon_dos')])
+        pytest.lazy_fixture('create_from_castep_phonon_dos'),
+    ])
     def test_correct_object_creation(self, spec1d_creator):
         spec1d, expected_spec1d = spec1d_creator
         check_spectrum1d(spec1d, expected_spec1d)

--- a/tests_and_analysis/test/utils.py
+++ b/tests_and_analysis/test/utils.py
@@ -195,7 +195,9 @@ def check_unit_conversion(obj: object, attr: str, unit: str) -> None:
     else:
         assert getattr(obj, attr).units == ureg(unit)
     npt.assert_allclose(getattr(obj, attr).magnitude,
-                        original_attr_value.to(unit).magnitude)
+                        (original_attr_value
+                         .to(unit, "reciprocal_spectroscopy")
+                         .magnitude))
 
 
 def check_property_setters(obj: object, attr: str, unit: str,

--- a/tests_and_analysis/tox_requirements.txt
+++ b/tests_and_analysis/tox_requirements.txt
@@ -5,3 +5,4 @@ pytest-mock
 pytest-lazy-fixture
 pytest-xvfb
 python-slugify
+toolz


### PR DESCRIPTION
It looks like spectral intensities are sometimes handled in energy units (such as when imported from CASTEP DOS). If these are converted to/from their proper (reciprocal energy) units, this can cause divide-by-zero errors as pint performs a wavenumber <-> wavelength conversion and takes the reciprocal of the spectral intensities, including empty bins.

Here we introduce another mechanism for dealing with spectral units: a few extra unit conversions in a special "reciprocal_spectroscopy" context (which comes an "rs" alias for convenience). This stops Pint from choking on the `1/(1/cm) <-> 1/meV` conversions.

The broadening system is made a bit more robust; previously the variable-width broadening assumed that things can always be converted to energy units.

Perhaps the most serious issue addressed here is the way the Spectrum data "getters" (hidden behind a `@property` interface) work.

The current spectrum getters create a unit conversion factor and then
multiply the raw array by it. There are two problems with this:

- Multiplying any iterator by a Quantity or Unit leads to Pint
  checking through all the data for consistency. This can be quite
  expensive, and is unnecessary for these trusted array objects. When
  iterating over spectra yielded from a Spectrum1DCollection, the cost
  can become quite noticeable.

- Some unit conversions in the spectroscopy context involve taking
  a reciprocal, e.g. conversion from cm -> 1/cm is allowed. But if
  this is done to a _factor_ the data itself will not be inverted. If
  we start with a Spectrum1D with x_data in wavenumber (1/cm) then

    ```python
    spectrum.x_data.to("cm")
    ```

  and

    ```python
    spectrum.x_data_unit = "cm"
    spectrum.x_data
    ```

  will not give the same result; the second method leaves the actual
  values untouched (as cm / (1/cm) = 1).

To further improve these conversions I included some technically-redundant energy-wavenumber conversions in the "reciprocal_spectroscopy" context. With these available, `.to(..., "rs")` conversions can avoid needlessly taking reciprocals of the data and raising divide-by-zero errors. That _should_ be more efficient, too, but it's not clear if that works in practice.