### PR TITLE
Update github action versions in test_release

### DIFF
--- a/.github/workflows/test_release.yml
+++ b/.github/workflows/test_release.yml
@@ -36,7 +36,7 @@ jobs:
         run: python -m tox -c release_tox.ini
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Unit test results ${{ matrix.os }}
           path: tests_and_analysis/test/reports/junit_report*.xml
@@ -47,7 +47,7 @@ jobs:
     if: success() || failure()
     steps:
       - name: Download Artifacts
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           path: artifacts
       - name: Publish test results

--- a/.github/workflows/test_release.yml
+++ b/.github/workflows/test_release.yml
@@ -14,8 +14,8 @@ jobs:
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v3
-      - uses: conda-incubator/setup-miniconda@v2
+      - uses: actions/checkout@v4
+      - uses: conda-incubator/setup-miniconda@v3
         with:
           python-version: '3.10'
           channels: conda-forge,defaults


### PR DESCRIPTION
The latest version of download-artifact v4 includes an important security fix.

Version numbers of upload- and download- artifact are supposed to match.

Other actions are already using these versions but this one was overlooked.