### PR TITLE
Use pytest-xdist for all tests within tox

### DIFF
--- a/tests_and_analysis/tox_requirements.txt
+++ b/tests_and_analysis/tox_requirements.txt
@@ -1,6 +1,6 @@
 mock
 pytest~=7.0
-coverage
+pytest-cov
 pytest-mock
 pytest-lazy-fixture
 pytest-xdist

--- a/tests_and_analysis/tox_requirements.txt
+++ b/tests_and_analysis/tox_requirements.txt
@@ -3,6 +3,7 @@ pytest~=7.0
 coverage
 pytest-mock
 pytest-lazy-fixture
+pytest-xdist
 pytest-xvfb
 python-slugify
 toolz

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,7 @@ skipsdist = True
 
 [testenv]
 changedir = tests_and_analysis/test
-test_command = python run_tests.py --report
+test_command = python run_tests.py --report --parallel
 
 [testenv:{py310,py311,py312}]
 install_command =

--- a/tox.ini
+++ b/tox.ini
@@ -8,6 +8,11 @@ skipsdist = True
 [testenv]
 changedir = tests_and_analysis/test
 test_command = python run_tests.py --report --parallel
+setenv =
+  COVERAGE_PROCESS_START = {toxinidir}/tests_and_analysis/test/.coveragerc
+  COV_CORE_CONFIG = {toxinidir}/tests_and_analysis/test/.coveragerc
+  COV_CORE_DATAFILE = {toxinidir}/tests_and_analysis/test/.coverage
+  COV_CORE_SOURCE =
 
 [testenv:{py310,py311,py312}]
 install_command =

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,7 @@ skipsdist = True
 
 [testenv]
 changedir = tests_and_analysis/test
-test_command = python run_tests.py --report --parallel
+test_command = python run_tests.py --report
 setenv =
   COVERAGE_PROCESS_START = {toxinidir}/tests_and_analysis/test/.coveragerc
   COV_CORE_CONFIG = {toxinidir}/tests_and_analysis/test/.coveragerc
@@ -31,7 +31,7 @@ commands_pre =
     --upgrade-strategy eager \
     '{toxinidir}[matplotlib,phonopy_reader,brille]'
 commands =
-    {[testenv]test_command} --cov
+    {[testenv]test_command} --cov --parallel
 
 # Test with no extras
 [testenv:py310-base]
@@ -42,7 +42,7 @@ commands_pre =
         --upgrade \
         --upgrade-strategy eager \
         '{toxinidir}'
-commands = {[testenv]test_command} --cov -m "not (phonopy_reader or matplotlib or brille)"
+commands = {[testenv]test_command} --cov --parallel -m "not (phonopy_reader or matplotlib or brille)"
 
 # Test with matplotlib extra only
 [testenv:py310-matplotlib]
@@ -53,7 +53,7 @@ commands_pre =
         --upgrade \
         --upgrade-strategy eager \
         '{toxinidir}[matplotlib]'
-commands = {[testenv]test_command} --cov -m "matplotlib and not multiple_extras"
+commands = {[testenv]test_command} --cov --parallel -m "matplotlib and not multiple_extras"
 
 # Test with phonopy_reader extra only
 [testenv:py310-phonopy_reader]
@@ -64,9 +64,10 @@ commands_pre =
         --upgrade \
         --upgrade-strategy eager \
         '{toxinidir}[phonopy_reader]'
-commands = {[testenv]test_command} --cov -m "phonopy_reader and not multiple_extras"
+commands = {[testenv]test_command} --cov --parallel -m "phonopy_reader and not multiple_extras"
 
 # Test with brille extra only
+# -- this one is actually faster without --parallel
 [testenv:py310-brille]
 install_command = {[testenv:py310]install_command}
 deps = {[testenv:py310]deps}
@@ -87,7 +88,7 @@ commands_pre =
         --upgrade-strategy eager \
         '{toxinidir}[phonopy_reader,matplotlib,brille]'
 commands =
-    {[testenv]test_command} --cov -m multiple_extras
+    {[testenv]test_command} --cov --parallel -m multiple_extras
 
 [testenv:py310-minrequirements-linux]
 whitelist_externals = rm


### PR DESCRIPTION
The pytest-xdist plugin allows pytest to distribute the tests to "workers". Here we have quite an aggressive configuration:

- use as many workers as there are available CPUs.

  - This should be beneficial as we have quite a large number of short/fast tests to spread over workers.

- when a worker has run out of jobs, allow it to "steal" remaining jobs from other workers

  - This should be beneficial as there are a few tests which are much slower, and we don't want them to run in series on the same worker while others sit idle.

We might need to do some funny business and let certain tests run independently... But so far this works pretty well on my laptop.