### PR TITLE
run_tests workflow: use parallel tox

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -72,12 +72,16 @@ jobs:
         if: github.event_name != 'workflow_dispatch'
         env:
           TOX_SKIP_ENV: '.*?(py311).*?'
+          TOX_PARALLEL_NO_SPINNER: 1
         shell: bash -l {0}
-        run: python -m tox
+        run: python -m tox --parallel
+
       - name: Run tests, workflow dispatch so test all Python versions
         if: github.event_name == 'workflow_dispatch'
+        env:
+          TOX_PARALLEL_NO_SPINNER: 1
         shell: bash -l {0}
-        run: python -m tox
+        run: python -m tox --parallel
 
       - name: Upload test results
         if: always()


### PR DESCRIPTION
Alternative to #321 : parallelism at the `tox` level

Let's see if we get a more impressive speedup by distributing the tox environments over separate processors.

Depends on #324