### PR TITLE
Allow "unsafe" (faster) Spectrum1DCollection.from_spectra()

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -47,6 +47,12 @@
       one needs to iterate over the collection metadata without
       copying the spectral data to new objects.
 
+  - Both Spectrum1DCollection and Spectrum2DCollection have a
+    ``.from_spectra()`` constructor with an "unsafe" option which
+    bypasses some consistency checks on the component data. This
+    should only be used when confident that these will be consistent,
+    such as when iterating over an existing collection.
+
   - A ``euphonic.writers.phonon_website`` module has been added with a
     function to export QpointPhononModes to appropriate JSON for use
     with the phonon visualisation website

--- a/euphonic/spectra.py
+++ b/euphonic/spectra.py
@@ -1957,7 +1957,7 @@ class Spectrum2DCollection(SpectrumCollectionMixin,
             x_tick_labels, spectrum_i_x_tick_labels
     ) -> None:
         """Check spectrum data units and x_tick_labels are consistent"""
-        if (spectrum_0_data_units != spectrum_i_data_units):
+        if spectrum_0_data_units != spectrum_i_data_units:
             raise ValueError("Spectrum units in sequence are inconsistent")
         if x_tick_labels != spectrum_i_x_tick_labels:
             raise ValueError("x_tick_labels in sequence are inconsistent")

--- a/euphonic/spectra.py
+++ b/euphonic/spectra.py
@@ -1261,7 +1261,7 @@ class Spectrum1DCollection(SpectrumCollectionMixin,
             y_data_magnitude[i + 1, :] = spectrum.y_data.magnitude
 
         metadata = cls._combine_metadata([spec.metadata for spec in spectra])
-        y_data = Quantity(y_data_magnitude, y_data_units)
+        y_data = ureg.Quantity(y_data_magnitude, y_data_units)
         return cls(x_data, y_data, x_tick_labels=x_tick_labels,
                    metadata=metadata)
 
@@ -2021,7 +2021,8 @@ class Spectrum2DCollection(SpectrumCollectionMixin,
             spectrum_data_magnitude[i + 1, :, :] = spectrum_i_raw_data
 
         metadata = cls._combine_metadata([spec.metadata for spec in spectra])
-        spectrum_data = Quantity(spectrum_data_magnitude, spectrum_data_units)
+        spectrum_data = ureg.Quantity(spectrum_data_magnitude,
+                                      spectrum_data_units)
         return cls(**bins_data,
                    **{f"{cls._spectrum_axis}_data": spectrum_data},
                    x_tick_labels=x_tick_labels,

--- a/euphonic/spectra.py
+++ b/euphonic/spectra.py
@@ -1981,7 +1981,7 @@ class Spectrum2DCollection(SpectrumCollectionMixin,
 
     @classmethod
     def from_spectra(
-            cls, spectra: Sequence[Spectrum2D], unsafe: bool = False
+            cls, spectra: Sequence[Spectrum2D], *, unsafe: bool = False
     ) -> Self:
         """Combine Spectrum2D to produce a new collection
 

--- a/euphonic/spectra.py
+++ b/euphonic/spectra.py
@@ -2007,7 +2007,7 @@ class Spectrum2DCollection(SpectrumCollectionMixin,
         spectrum_data_magnitude[0, :, :] = spectrum_0_data.magnitude
         spectrum_data_units = spectrum_0_data.units
 
-        for i, spectrum in enumerate(spectra[1:]):
+        for i, spectrum in enumerate(spectra[1:], start=1):
             spectrum_i_raw_data = cls._get_item_raw_data(spectrum)
             spectrum_i_data_units = cls._get_item_data_unit(spectrum)
 
@@ -2018,7 +2018,7 @@ class Spectrum2DCollection(SpectrumCollectionMixin,
                     x_tick_labels, spectrum.x_tick_labels)
                 cls._from_spectra_bins_check(bins_data, spectrum)
 
-            spectrum_data_magnitude[i + 1, :, :] = spectrum_i_raw_data
+            spectrum_data_magnitude[i, :, :] = spectrum_i_raw_data
 
         metadata = cls._combine_metadata([spec.metadata for spec in spectra])
         spectrum_data = ureg.Quantity(spectrum_data_magnitude,

--- a/euphonic/spectra.py
+++ b/euphonic/spectra.py
@@ -790,7 +790,7 @@ class SpectrumCollectionMixin(ABC):
     @classmethod
     @abstractmethod
     def from_spectra(
-            cls, spectra: Sequence[Spectrum], unsafe: bool = False
+            cls, spectra: Sequence[Spectrum], *, unsafe: bool = False
     ) -> Self:
         """Construct spectrum collection from a sequence of components
 
@@ -1233,7 +1233,7 @@ class Spectrum1DCollection(SpectrumCollectionMixin,
 
     @classmethod
     def from_spectra(
-            cls: Self, spectra: Sequence[Spectrum1D], unsafe: bool = False
+            cls: Self, spectra: Sequence[Spectrum1D], *, unsafe: bool = False
     ) -> Self:
         """Combine Spectrum1D to produce a new collection
 

--- a/tests_and_analysis/test/euphonic_test/test_spectrum1dcollection.py
+++ b/tests_and_analysis/test/euphonic_test/test_spectrum1dcollection.py
@@ -225,6 +225,36 @@ class TestSpectrum1DCollectionCreation:
         check_spectrum1dcollection(spectrum, expected_spectrum)
 
     @pytest.mark.parametrize(
+        'input_spectra, expected_error',
+        [
+            (['NotASpectrum', get_spectrum1d(f'gan_bands_index_2.json')],
+             TypeError),
+            ([get_spectrum1d(f'gan_bands_index_2.json'), 'NotASpectrum'],
+             TypeError),
+            ([get_spectrum1d(f'gan_bands_index_2.json'),
+              get_spectrum1d(f'methane_pdos_index_1.json')],
+             ValueError)
+        ]
+    )
+    def test_create_from_bad_sequence(self, input_spectra, expected_error):
+        with pytest.raises(expected_error):
+            Spectrum1DCollection.from_spectra(input_spectra)
+
+    def test_unsafe_from_sequence(self):
+        """Ensure that unsafe from_spectra doesn't check units"""
+
+        spec1 = get_spectrum1d(f'gan_bands_index_2.json')
+        spec2 = get_spectrum1d(f'gan_bands_index_3.json')
+
+        spec1.x_data_unit = '1/angstrom'
+        spec2.x_data_unit = '1/mm'
+
+        with pytest.raises(ValueError):
+            Spectrum1DCollection.from_spectra([spec1, spec2])
+
+        Spectrum1DCollection.from_spectra([spec1, spec2], unsafe=True)
+
+    @pytest.mark.parametrize(
         'input_metadata, expected_metadata',
         [([{},
            {'label': 'H3'},

--- a/tests_and_analysis/test/euphonic_test/test_spectrum2dcollection.py
+++ b/tests_and_analysis/test/euphonic_test/test_spectrum2dcollection.py
@@ -148,12 +148,12 @@ class TestSpectrum2DCollectionCreation:
             inconsistent_y_item):
         """Spectrum2DCollection.from_spectra with inconsistent input"""
 
-        with pytest.raises(AssertionError):
+        with pytest.raises(ValueError):
             Spectrum2DCollection.from_spectra(
                 quartz_fuzzy_items + [inconsistent_x_item]
             )
 
-        with pytest.raises(AssertionError):
+        with pytest.raises(ValueError):
             Spectrum2DCollection.from_spectra(
                 quartz_fuzzy_items + [inconsistent_x_units_item]
             )
@@ -163,7 +163,7 @@ class TestSpectrum2DCollectionCreation:
                 quartz_fuzzy_items + [inconsistent_x_length_item]
             )
 
-        with pytest.raises(AssertionError):
+        with pytest.raises(ValueError):
             Spectrum2DCollection.from_spectra(
                 quartz_fuzzy_items + [inconsistent_y_item]
             )

--- a/tests_and_analysis/test/euphonic_test/test_spectrum2dcollection.py
+++ b/tests_and_analysis/test/euphonic_test/test_spectrum2dcollection.py
@@ -168,6 +168,40 @@ class TestSpectrum2DCollectionCreation:
                 quartz_fuzzy_items + [inconsistent_y_item]
             )
 
+    # pylint: disable=R0913  #  These fixtures are "too many arguments"
+    def test_from_bad_spectra_usafe(
+            self,
+            quartz_fuzzy_items,
+            inconsistent_x_item,
+            inconsistent_x_length_item,
+            inconsistent_x_units_item,
+            inconsistent_y_item):
+        """Spectrum2DCollection.from_spectra, unsafe with inconsistent input"""
+
+        Spectrum2DCollection.from_spectra(
+            quartz_fuzzy_items + [inconsistent_x_item],
+            unsafe=True
+        )
+
+        Spectrum2DCollection.from_spectra(
+            quartz_fuzzy_items + [inconsistent_x_units_item],
+            unsafe=True
+        )
+
+        # Inconsistent length will still cause trouble but should fall to numpy
+        with pytest.raises(ValueError, match="could not broadcast input"):
+            Spectrum2DCollection.from_spectra(
+                quartz_fuzzy_items + [inconsistent_x_length_item],
+                unsafe=True
+            )
+
+
+        Spectrum2DCollection.from_spectra(
+            quartz_fuzzy_items + [inconsistent_y_item],
+            unsafe=True
+        )
+
+
 class TestSpectrum2DCollectionFunctionality:
     """Unit test indexing and methods of Spectrum2DCollection"""
 


### PR DESCRIPTION
When filtering or otherwise manipulating spectra from an existing collection, we can be confident the axes remain consistent. The safety checks are quite expensive so this should be a useful optimisation.