### PR TITLE
Faster indexing/iteration for spectrum collections

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -53,6 +53,11 @@
     should only be used when confident that these will be consistent,
     such as when iterating over an existing collection.
 
+  - Performance optimisations have been made to the "item getter" for
+    Spectrum1DCollection (and Spectrum2DCollection); it should now be
+    significantly faster to access and iterate over the contained
+    spectra.
+
   - A ``euphonic.writers.phonon_website`` module has been added with a
     function to export QpointPhononModes to appropriate JSON for use
     with the phonon visualisation website

--- a/euphonic/spectra.py
+++ b/euphonic/spectra.py
@@ -718,20 +718,20 @@ class SpectrumCollectionMixin(ABC):
         return f"{cls._spectrum_axis}_data"
 
     @classmethod
-    def _spectrum_raw_data_name(cls) -> str:
+    def _raw_spectrum_data_name(cls) -> str:
         return f"_{cls._spectrum_axis}_data"
 
     def _get_spectrum_data(self) -> Quantity:
         return getattr(self, self._spectrum_data_name())
 
     def _get_raw_spectrum_data(self) -> np.ndarray:
-        return getattr(self, self._spectrum_raw_data_name())
+        return getattr(self, self._raw_spectrum_data_name())
 
     def _set_spectrum_data(self, data: Quantity) -> None:
         setattr(self, self._spectrum_data_name(), data)
 
     def _set_raw_spectrum_data(self, data: np.ndarray) -> None:
-        setattr(self, self._spectrum_raw_data_name(), data)
+        setattr(self, self._raw_spectrum_data_name(), data)
 
     def _get_spectrum_data_unit(self) -> str:
         return getattr(self, f"{self._spectrum_data_name()}_unit")
@@ -849,8 +849,9 @@ class SpectrumCollectionMixin(ABC):
                 name = prop.format(axis)
                 setattr(spectrum, name, copy.copy(getattr(self, name)))
 
-        setattr(spectrum, self._spectrum_raw_data_name(),
+        setattr(spectrum, self._raw_spectrum_data_name(),
                 self._get_raw_spectrum_data()[item, :].copy())
+
         setattr(spectrum, f"_internal_{self._spectrum_data_name()}_unit",
                 self._get_internal_spectrum_data_unit())
         setattr(spectrum, f"{self._spectrum_data_name()}_unit",

--- a/euphonic/spectra.py
+++ b/euphonic/spectra.py
@@ -837,7 +837,11 @@ class SpectrumCollectionMixin(ABC):
             spectrum: Spectrum,
             item: Union[Integral, slice, Sequence[Integral], np.ndarray]
     ) -> None:
-        """Write axis and spectrum data to a new Spectrum"""
+        """Write axis and spectrum data from self to Spectrum
+
+        This is intended to set attributes on a 'bare' Spectrum created with
+        __new__() from the parent SpectrumCollection.
+        """
 
         for axis in self._bin_axes:
             setattr(spectrum, f"_{axis}_data",

--- a/euphonic/spectra.py
+++ b/euphonic/spectra.py
@@ -823,7 +823,8 @@ class SpectrumCollectionMixin(ABC):
         if isinstance(item, Integral):
             spectrum = self._item_type.__new__(self._item_type)
         else:
-            spectrum = type(self).__new__(type(self))
+            # Pylint miscounts arguments when we call this staticmethod
+            spectrum = self.__new__(type(self))  # pylint: disable=E1120
 
         self._set_item_data(spectrum, item)
 

--- a/euphonic/spectra.py
+++ b/euphonic/spectra.py
@@ -1212,7 +1212,7 @@ class Spectrum1DCollection(SpectrumCollectionMixin,
             self, item: Integral
     ):
         """Index a new spectrum item without any safety checks"""
-        spectrum = self.__new__(type(self))
+        spectrum = self._item_type.__new__(self._item_type)
 
         for axis in self._bin_axes:
             setattr(spectrum, f"_{axis}_data",

--- a/euphonic/spectra.py
+++ b/euphonic/spectra.py
@@ -845,12 +845,9 @@ class SpectrumCollectionMixin(ABC):
         """
 
         for axis in self._bin_axes:
-            setattr(spectrum, f"_{axis}_data",
-                    getattr(self, f"_{axis}_data").copy())
-            setattr(spectrum, f"_internal_{axis}_data_unit",
-                    getattr(self, f"_internal_{axis}_data_unit"))
-            setattr(spectrum, f"{axis}_data_unit",
-                    getattr(self, f"{axis}_data_unit"))
+            for prop in ("_{}_data", "_internal_{}_data_unit", "{}_data_unit"):
+                name = prop.format(axis)
+                setattr(spectrum, name, copy.copy(getattr(self, name)))
 
         setattr(spectrum, self._spectrum_raw_data_name(),
                 self._get_raw_spectrum_data()[item, :].copy())

--- a/euphonic/spectra.py
+++ b/euphonic/spectra.py
@@ -761,6 +761,7 @@ class SpectrumCollectionMixin(ABC):
     def _get_item_data_unit(cls, item: Spectrum) -> str:
         return getattr(item, f"{cls._spectrum_axis}_data_unit")
 
+
     def sum(self) -> Spectrum:
         """
         Sum collection to a single spectrum
@@ -1206,6 +1207,32 @@ class Spectrum1DCollection(SpectrumCollectionMixin,
 
         self.metadata = metadata if metadata is not None else {}
         self._check_metadata()
+
+    def _get_item_unsafe(
+            self, item: Integral
+    ):
+        """Index a new spectrum item without any safety checks"""
+        spectrum = self.__new__(type(self))
+
+        for axis in self._bin_axes:
+            setattr(spectrum, f"_{axis}_data",
+                    getattr(self, f"_{axis}_data").copy())
+            setattr(spectrum, f"_internal_{axis}_data_unit",
+                    getattr(self,f"_internal_{axis}_data_unit"))
+            setattr(spectrum, f"{axis}_data_unit",
+                    getattr(self, f"{axis}_data_unit"))
+
+        setattr(spectrum, self._spectrum_raw_data_name(),
+                self._get_raw_spectrum_data()[item].copy())
+        setattr(spectrum, f"_internal_{self._spectrum_data_name()}_unit",
+                self._get_internal_spectrum_data_unit())
+        setattr(spectrum, f"{self._spectrum_data_name()}_unit",
+                self._get_spectrum_data_unit())
+
+        spectrum.x_tick_labels = self.x_tick_labels
+        spectrum.metadata = self._get_item_metadata(item)
+
+        return spectrum
 
     def _split_by_indices(self,
                           indices: Union[Sequence[int], np.ndarray]

--- a/euphonic/spectra.py
+++ b/euphonic/spectra.py
@@ -822,16 +822,31 @@ class SpectrumCollectionMixin(ABC):
             self, item: Union[Integral, slice, Sequence[Integral], np.ndarray]
     ):  # noqa: F811
         self._validate_item(item)
-        init_kwargs = {
-            self._spectrum_data_name(): self._get_spectrum_data()[item, :],
-            "x_tick_labels": self.x_tick_labels,
-            "metadata": self._get_item_metadata(item)
-                       } | self._get_bin_kwargs()
 
         if isinstance(item, Integral):
-            return self._item_type(**init_kwargs)
+            spectrum = self._item_type.__new__(self._item_type)
+        else:
+            spectrum = self.__new__(type(self))
 
-        return type(self)(**init_kwargs)
+        for axis in self._bin_axes:
+            setattr(spectrum, f"_{axis}_data",
+                    getattr(self, f"_{axis}_data").copy())
+            setattr(spectrum, f"_internal_{axis}_data_unit",
+                    getattr(self,f"_internal_{axis}_data_unit"))
+            setattr(spectrum, f"{axis}_data_unit",
+                    getattr(self, f"{axis}_data_unit"))
+
+        setattr(spectrum, self._spectrum_raw_data_name(),
+                self._get_raw_spectrum_data()[item, :].copy())
+        setattr(spectrum, f"_internal_{self._spectrum_data_name()}_unit",
+                self._get_internal_spectrum_data_unit())
+        setattr(spectrum, f"{self._spectrum_data_name()}_unit",
+                self._get_spectrum_data_unit())
+
+        spectrum.x_tick_labels = self.x_tick_labels
+        spectrum.metadata = self._get_item_metadata(item)
+
+        return spectrum
 
     def _validate_item(self, item: Integral | slice | Sequence[Integral] | np.ndarray
                        ) -> None:
@@ -1207,32 +1222,6 @@ class Spectrum1DCollection(SpectrumCollectionMixin,
 
         self.metadata = metadata if metadata is not None else {}
         self._check_metadata()
-
-    def _get_item_unsafe(
-            self, item: Integral
-    ):
-        """Index a new spectrum item without any safety checks"""
-        spectrum = self._item_type.__new__(self._item_type)
-
-        for axis in self._bin_axes:
-            setattr(spectrum, f"_{axis}_data",
-                    getattr(self, f"_{axis}_data").copy())
-            setattr(spectrum, f"_internal_{axis}_data_unit",
-                    getattr(self,f"_internal_{axis}_data_unit"))
-            setattr(spectrum, f"{axis}_data_unit",
-                    getattr(self, f"{axis}_data_unit"))
-
-        setattr(spectrum, self._spectrum_raw_data_name(),
-                self._get_raw_spectrum_data()[item].copy())
-        setattr(spectrum, f"_internal_{self._spectrum_data_name()}_unit",
-                self._get_internal_spectrum_data_unit())
-        setattr(spectrum, f"{self._spectrum_data_name()}_unit",
-                self._get_spectrum_data_unit())
-
-        spectrum.x_tick_labels = self.x_tick_labels
-        spectrum.metadata = self._get_item_metadata(item)
-
-        return spectrum
 
     def _split_by_indices(self,
                           indices: Union[Sequence[int], np.ndarray]

--- a/euphonic/spectra.py
+++ b/euphonic/spectra.py
@@ -823,7 +823,7 @@ class SpectrumCollectionMixin(ABC):
         if isinstance(item, Integral):
             spectrum = self._item_type.__new__(self._item_type)
         else:
-            spectrum = self.__new__(type(self))
+            spectrum = type(self).__new__(type(self))
 
         self._set_item_data(spectrum, item)
 

--- a/euphonic/spectra.py
+++ b/euphonic/spectra.py
@@ -755,7 +755,6 @@ class SpectrumCollectionMixin(ABC):
     def _get_item_data_unit(cls, item: Spectrum) -> str:
         return getattr(item, f"{cls._spectrum_axis}_data_unit")
 
-
     def sum(self) -> Spectrum:
         """
         Sum collection to a single spectrum
@@ -844,7 +843,7 @@ class SpectrumCollectionMixin(ABC):
             setattr(spectrum, f"_{axis}_data",
                     getattr(self, f"_{axis}_data").copy())
             setattr(spectrum, f"_internal_{axis}_data_unit",
-                    getattr(self,f"_internal_{axis}_data_unit"))
+                    getattr(self, f"_internal_{axis}_data_unit"))
             setattr(spectrum, f"{axis}_data_unit",
                     getattr(self, f"{axis}_data_unit"))
 
@@ -854,8 +853,6 @@ class SpectrumCollectionMixin(ABC):
                 self._get_internal_spectrum_data_unit())
         setattr(spectrum, f"{self._spectrum_data_name()}_unit",
                 self._get_spectrum_data_unit())
-
-
 
     def _validate_item(self, item: Integral | slice | Sequence[Integral] | np.ndarray
                        ) -> None:
@@ -927,7 +924,6 @@ class SpectrumCollectionMixin(ABC):
         common_metadata = {key: value for key, value in self.metadata.items()
                            if key != "line_data"}
 
-
         line_data = self.metadata.get("line_data")
         if line_data is None:
             line_data = itertools.repeat({}, len(self._get_raw_spectrum_data()))
@@ -994,7 +990,6 @@ class SpectrumCollectionMixin(ABC):
             return (value,) if isinstance(value, (int, str)) else value
 
         select_key_values = valmap(ensure_sequence, select_key_values)
-
 
         # Collect indices that match each combination of values
         selected_indices = []
@@ -1475,6 +1470,7 @@ class Spectrum1DCollection(SpectrumCollectionMixin,
         spectrum_collection
         """
         return super().from_dict(d)
+
 
 class Spectrum2D(Spectrum):
     """


### PR DESCRIPTION
Iterating on SpectrumCollection objects is currently quite expensive, which limits the feasibility of processing them with functional-programming-style filters, pipelines etc. Currently in Abins prototypes I am using workarounds that access or construct raw numpy arrays. It would be nice if that wasn't necessary!

So far we just have a proof of concept: instead of constructing with the relatively slow `__init__()` method, we can use `__new__()` and bypass the safety checks. As we are constructing from known-good data this _should_ be ok...