### PR TITLE
Try dropping Conda from test runner

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -22,11 +22,9 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
-      - uses: conda-incubator/setup-miniconda@v3
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.10'
-          channels: conda-forge,defaults
-          channel-priority: true
       - name: Install llvm on Macos
         if: startsWith(matrix.os, 'macos')
         run: |

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -24,7 +24,10 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.10'
+          python-version: |
+              3.10
+              3.11
+              3.12
       - name: Install llvm on Macos
         if: startsWith(matrix.os, 'macos')
         run: |

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,4 @@
 [tox]
-requires = tox-conda
 # The python environments to run the tests in
 envlist = py310,py311,py312,py310-{base,matplotlib,phonopy_reader,brille,all},py310-minrequirements-linux
 # Skip the execution of setup.py as we do it with the correct arg in commands_pre below


### PR DESCRIPTION
It doesn't look like tox.ini/tox-conda is actually using conda to install dependencies (by calling conda_deps) so maybe we don't need this.

(Presumably it was added to manage installation of multiple Python versions, but the setup-python action can handle that now.)