### PR TITLE
Delete MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,8 +1,0 @@
-include euphonic/LICENSE
-include euphonic/CITATION.cff
-include euphonic/data/*
-include euphonic/_version.py
-include euphonic/styles/*.mplstyle
-include versioneer.py
-include c/*.h
-include c/*.c


### PR DESCRIPTION
This file is out of date, and I _think_ it is no longer needed under the python-meson build system. Still, we should build packages without it and check that they look complete.