### PR TITLE
Use tox 4 for release testing

### DIFF
--- a/.github/workflows/test_release.yml
+++ b/.github/workflows/test_release.yml
@@ -15,12 +15,15 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
-      - uses: conda-incubator/setup-miniconda@v3
         with:
-          python-version: '3.10'
-          channels: conda-forge,defaults
-          channel-priority: true
-      - name: Install llvm on Macos
+          fetch-depth: 0 # Ensure tags are fetched for versioning
+      - uses: actions/setup-python@v5
+        with:
+          python-version: |
+              3.10
+              3.11
+              3.12
+      - name: Install llvm on MacOS
         if: startsWith(matrix.os, 'macos')
         shell: bash -l {0}
         env:

--- a/build_utils/release_tox.ini
+++ b/build_utils/release_tox.ini
@@ -1,41 +1,41 @@
 [tox]
 # Use conda to set up the python environments to run in
-requires = tox-conda
+requires = tox>=4
 # The python environments to run the tests in
 envlist = pypi-py310-min,conda-py310-old-np,{pypi,conda}-{py310,py311,py312},pypisource-{py310,py312}
-# Skip the execution of setup.py as we do it with the correct version in commands_pre below
-skipsdist = True
+skip_install = True
 
 [testenv]
 changedir = tests_and_analysis/test
 test_command = python {toxinidir}/../tests_and_analysis/test/run_tests.py --report
 requirements_dir = {toxinidir}/../tests_and_analysis
+passenv =
+    EUPHONIC_VERSION
+    CC_LD
+extras =
+    test
+    matplotlib
+    phonopy-reader
+    brille
 
 # Test PyPI source distribution
 [testenv:pypisource-{py310,py312}]
 passenv = CC CC_LD LDFLAGS CPPFLAGS
 install_command = python -m pip install {opts} {packages}
-deps =
-    numpy
-    spglib  # Not interested here in whether source builds of spglib work
-    -r{[testenv]requirements_dir}/tox_requirements.txt
 commands_pre =
     python -m pip install \
     --force-reinstall \
-    'euphonic[matplotlib,phonopy_reader,brille]=={env:EUPHONIC_VERSION}' \
+    'euphonic=={env:EUPHONIC_VERSION}' \
     --no-binary 'euphonic'
 commands = {[testenv]test_command}
 
 
 [testenv:pypi-{py310,py311,py312}]
 install_command = python -m pip install {opts} {packages}
-deps =
-    numpy
-    -r{[testenv]requirements_dir}/tox_requirements.txt
 commands_pre =
     python -m pip install \
     --force-reinstall \
-    'euphonic[matplotlib,phonopy_reader,brille]=={env:EUPHONIC_VERSION}' \
+    'euphonic=={env:EUPHONIC_VERSION}' \
     --only-binary 'euphonic'
 commands = {[testenv]test_command}
 
@@ -45,28 +45,12 @@ platform =
     linux: linux
     windows: win32
 deps =
-    numpy==1.24.0
+    numpy==1.21.3
+extras =
+    test
 commands_pre =
     python -m pip install --force-reinstall \
-        -r{[testenv]requirements_dir}/minimum_euphonic_requirements.txt
-    python -m pip install --force-reinstall \
-        -r{[testenv]requirements_dir}/tox_requirements.txt
-    python -m pip install \
-    'euphonic[matplotlib,phonopy_reader,brille]=={env:EUPHONIC_VERSION}' \
-    --only-binary 'euphonic'
-commands = {[testenv]test_command}
-
-[testenv:pypi-py310-min-mac]
-install_command = python -m pip install --force-reinstall {opts} {packages}
-platform =
-    mac: darwin
-deps =
-    numpy==1.24.0
-commands_pre =
-    python -m pip install --force-reinstall \
-        -r{[testenv]requirements_dir}/minimum_euphonic_requirements_mac.txt
-    python -m pip install --force-reinstall \
-        -r{[testenv]requirements_dir}/tox_requirements.txt
+        -r{toxinidir}/tests_and_analysis/minimum_euphonic_requirements.txt
     python -m pip install \
     'euphonic[matplotlib,phonopy_reader,brille]=={env:EUPHONIC_VERSION}' \
     --only-binary 'euphonic'
@@ -78,10 +62,13 @@ install_command = conda install {packages}
 conda_channels =
     conda-forge
     default
-conda_deps =
-    --file={[testenv]requirements_dir}/tox_requirements.txt
+extras =
+    test
+    matplotlib
+    phonopy-reader
+
 commands_pre =
-    conda install -c conda-forge euphonic={env:EUPHONIC_VERSION} matplotlib-base pyyaml h5py
+    conda install -c conda-forge euphonic={env:EUPHONIC_VERSION}
 # Brille not available on conda
 commands = {[testenv]test_command} -m "not brille"
 
@@ -93,10 +80,12 @@ install_command = conda install {packages}
 conda_channels =
     conda-forge
     default
-conda_deps =
-    --file={[testenv]requirements_dir}/tox_requirements.txt
+deps = numpy==1.22
+extras =
+    test
+    matplotlib
+    phonopy-reader
 commands_pre =
-    conda install numpy=1.22
-    conda install -c conda-forge euphonic={env:EUPHONIC_VERSION} matplotlib-base pyyaml h5py
+    conda install -c conda-forge euphonic={env:EUPHONIC_VERSION}
 # Brille not available on conda
 commands = {[testenv]test_command} -m "not brille"

--- a/build_utils/release_tox.ini
+++ b/build_utils/release_tox.ini
@@ -11,17 +11,21 @@ test_command = python {toxinidir}/../tests_and_analysis/test/run_tests.py --repo
 requirements_dir = {toxinidir}/../tests_and_analysis
 passenv =
     EUPHONIC_VERSION
-    CC_LD
-setenv =
-    EXTRAS=[test,matplotlib,phonopy-reader,brille]
+# The name "extras" is reserved and has its own format with newlines:
+# we need a token to inject into custom commands_pre, so call it extras_str
+extras_str = [test,matplotlib,phonopy-reader,brille]
 
 # Test PyPI source distribution
 [testenv:pypisource-{py310,py312}]
-passenv = CC, CC_LD, LDFLAGS, CPPFLAGS
+passenv =
+    CC
+    CC_LD
+    LDFLAGS
+    CPPFLAGS
 commands_pre =
     python -m pip install \
     --force-reinstall \
-    'euphonic{env:EXTRAS}=={env:EUPHONIC_VERSION}' \
+    euphonic{[testenv]extras_str}=={env:EUPHONIC_VERSION} \
     --no-binary 'euphonic'
 commands = {[testenv]test_command}
 
@@ -29,7 +33,7 @@ commands = {[testenv]test_command}
 commands_pre =
     python -m pip install \
     --force-reinstall \
-    'euphonic{env:EXTRAS}=={env:EUPHONIC_VERSION}' \
+    euphonic{[testenv]extras_str}=={env:EUPHONIC_VERSION} \
     --only-binary 'euphonic'
 commands = {[testenv]test_command}
 
@@ -42,7 +46,7 @@ commands_pre =
     python -m pip install --force-reinstall \
         -r{toxinidir}/../tests_and_analysis/minimum_euphonic_requirements.txt
     python -m pip install \
-    'euphonic{env:EXTRAS}=={env:EUPHONIC_VERSION}' \
+    euphonic{[testenv]extras_str}=={env:EUPHONIC_VERSION} \
     --only-binary 'euphonic'
 commands = {[testenv]test_command}
 

--- a/build_utils/release_tox.ini
+++ b/build_utils/release_tox.ini
@@ -37,6 +37,7 @@ commands = {[testenv]test_command}
 platform = (linux)|(win32)
 deps =
     numpy==1.24
+    -r{toxinidir}/../tests_and_analysis/tox_requirements.txt
 commands_pre =
     python -m pip install --force-reinstall \
         -r{toxinidir}/../tests_and_analysis/minimum_euphonic_requirements.txt

--- a/build_utils/release_tox.ini
+++ b/build_utils/release_tox.ini
@@ -12,47 +12,38 @@ requirements_dir = {toxinidir}/../tests_and_analysis
 passenv =
     EUPHONIC_VERSION
     CC_LD
-extras =
-    test
-    matplotlib
-    phonopy-reader
-    brille
+setenv =
+    EXTRAS=[test,matplotlib,phonopy-reader,brille]
 
 # Test PyPI source distribution
 [testenv:pypisource-{py310,py312}]
 passenv = CC CC_LD LDFLAGS CPPFLAGS
-install_command = python -m pip install {opts} {packages}
 commands_pre =
     python -m pip install \
     --force-reinstall \
-    'euphonic=={env:EUPHONIC_VERSION}' \
+    'euphonic{env:EXTRAS}=={env:EUPHONIC_VERSION}' \
     --no-binary 'euphonic'
 commands = {[testenv]test_command}
 
-
 [testenv:pypi-{py310,py311,py312}]
-install_command = python -m pip install {opts} {packages}
 commands_pre =
     python -m pip install \
     --force-reinstall \
-    'euphonic=={env:EUPHONIC_VERSION}' \
+    'euphonic{env:EXTRAS}=={env:EUPHONIC_VERSION}' \
     --only-binary 'euphonic'
 commands = {[testenv]test_command}
 
 [testenv:pypi-py310-min-win-linux]
-install_command = python -m pip install --force-reinstall {opts} {packages}
 platform =
     linux: linux
     windows: win32
 deps =
     numpy==1.21.3
-extras =
-    test
 commands_pre =
     python -m pip install --force-reinstall \
         -r{toxinidir}/tests_and_analysis/minimum_euphonic_requirements.txt
     python -m pip install \
-    'euphonic[matplotlib,phonopy_reader,brille]=={env:EUPHONIC_VERSION}' \
+    'euphonic{env:EXTRAS}=={env:EUPHONIC_VERSION}' \
     --only-binary 'euphonic'
 commands = {[testenv]test_command}
 

--- a/build_utils/release_tox.ini
+++ b/build_utils/release_tox.ini
@@ -17,7 +17,7 @@ setenv =
 
 # Test PyPI source distribution
 [testenv:pypisource-{py310,py312}]
-passenv = CC CC_LD LDFLAGS CPPFLAGS
+passenv = CC, CC_LD, LDFLAGS, CPPFLAGS
 commands_pre =
     python -m pip install \
     --force-reinstall \

--- a/build_utils/release_tox.ini
+++ b/build_utils/release_tox.ini
@@ -33,15 +33,13 @@ commands_pre =
     --only-binary 'euphonic'
 commands = {[testenv]test_command}
 
-[testenv:pypi-py310-min-win-linux]
-platform =
-    linux: linux
-    windows: win32
+[testenv:pypi-py310-min]
+platform = (linux)|(win32)
 deps =
-    numpy==1.21.3
+    numpy==1.24
 commands_pre =
     python -m pip install --force-reinstall \
-        -r{toxinidir}/tests_and_analysis/minimum_euphonic_requirements.txt
+        -r{toxinidir}/../tests_and_analysis/minimum_euphonic_requirements.txt
     python -m pip install \
     'euphonic{env:EXTRAS}=={env:EUPHONIC_VERSION}' \
     --only-binary 'euphonic'
@@ -71,7 +69,7 @@ install_command = conda install {packages}
 conda_channels =
     conda-forge
     default
-deps = numpy==1.22
+deps = numpy==1.24
 extras =
     test
     matplotlib


### PR DESCRIPTION
Not backwards compatible with prior releases, requires #324 release.

Cannot test without #324 release.