### PR TITLE
Update release tests for new framework

### DIFF
--- a/.github/workflows/test_release.yml
+++ b/.github/workflows/test_release.yml
@@ -22,13 +22,40 @@ jobs:
           channel-priority: true
       - name: Install llvm on Macos
         if: startsWith(matrix.os, 'macos')
+        shell: bash -l {0}
+        env:
+          # Homebrew location is different on Intel Mac
+          LLVM_DIR: ${{ (matrix.os == 'macos-13') && '/usr/local/opt/llvm' || '/opt/homebrew/opt/llvm' }}
         run: |
           brew install llvm
+          echo CC="${LLVM_DIR}/bin/clang" >> $GITHUB_ENV
+          echo LDFLAGS="-L${LLVM_DIR}/lib $LDFLAGS" >> $GITHUB_ENV
+          echo CPPFLAGS="-I${LLVM_DIR}/include $CPPFLAGS" >> $GITHUB_ENV
+
+      - name: Windows - find MSVC and set environment variables
+        if: startsWith(matrix.os, 'windows')
+        shell: bash -l {0}
+        env:
+          MSVC_PREFIX: 'C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC'
+        run: |
+          echo "Available MSVC installations:"
+          ls "$MSVC_PREFIX"
+
+          MSVC_BIN=$(ls "$MSVC_PREFIX" | tail -n 1)\\bin\\HostX64\\x64
+          CC="$MSVC_PREFIX\\$MSVC_BIN\\cl.exe"
+          echo "CC: $CC"
+          echo "CC=$CC" >> $GITHUB_ENV
+
+          CC_LD="$MSVC_PREFIX\\$MSVC_BIN\\link.exe"
+          echo "CC_LD: $CC_LD"
+          echo "CC_LD=$CC_LD" >> $GITHUB_ENV
+
       - name: Update pip and install dependencies
         shell: bash -l {0}
         run: |
           python -m pip install --upgrade pip
           python -m pip install -r tests_and_analysis/ci_requirements.txt
+
       - name: Run tests
         shell: bash -l {0}
         env:

--- a/build_utils/release_tox.ini
+++ b/build_utils/release_tox.ini
@@ -8,14 +8,15 @@ skipsdist = True
 
 [testenv]
 changedir = tests_and_analysis/test
-test_command = python run_tests.py --report
+test_command = python {toxinidir}/../tests_and_analysis/run_tests.py --report
+requirements_dir = {toxinidir}/../tests_and_analysis
 
 # Test PyPI source distribution
 [testenv:pypisource-{py310,py312}]
 install_command = python -m pip install {opts} {packages}
 deps =
     numpy
-    -r{toxinidir}/tests_and_analysis/tox_requirements.txt
+    -r{[testenv]requirements_dir}/tox_requirements.txt
 commands_pre =
     python -m pip install \
     --force-reinstall \
@@ -28,7 +29,7 @@ commands = {[testenv]test_command}
 install_command = python -m pip install {opts} {packages}
 deps =
     numpy
-    -r{toxinidir}/tests_and_analysis/tox_requirements.txt
+    -r{[testenv]requirements_dir}/tox_requirements.txt
 commands_pre =
     python -m pip install \
     --force-reinstall \
@@ -42,9 +43,9 @@ deps =
     numpy==1.21.3
 commands_pre =
     python -m pip install --force-reinstall \
-        -r{toxinidir}/tests_and_analysis/minimum_euphonic_requirements.txt
+        -r{[testenv]requirements_dir}/minimum_euphonic_requirements.txt
     python -m pip install --force-reinstall \
-        -r{toxinidir}/tests_and_analysis/tox_requirements.txt
+        -r{[testenv]requirements_dir}/tox_requirements.txt
     python -m pip install \
     'euphonic[matplotlib,phonopy_reader,brille]=={env:EUPHONIC_VERSION}' \
     --only-binary 'euphonic'
@@ -57,7 +58,7 @@ conda_channels =
     conda-forge
     default
 conda_deps =
-    --file={toxinidir}/tests_and_analysis/tox_requirements.txt
+    --file={[testenv]requirements_dir}/tox_requirements.txt
 commands_pre =
     conda install -c conda-forge euphonic={env:EUPHONIC_VERSION} matplotlib-base pyyaml h5py
 # Brille not available on conda
@@ -72,7 +73,7 @@ conda_channels =
     conda-forge
     default
 conda_deps =
-    --file={toxinidir}/tests_and_analysis/tox_requirements.txt
+    --file={[testenv]requirements_dir}/tox_requirements.txt
 commands_pre =
     conda install numpy=1.22
     conda install -c conda-forge euphonic={env:EUPHONIC_VERSION} matplotlib-base pyyaml h5py

--- a/build_utils/release_tox.ini
+++ b/build_utils/release_tox.ini
@@ -8,7 +8,7 @@ skipsdist = True
 
 [testenv]
 changedir = tests_and_analysis/test
-test_command = python {toxinidir}/../tests_and_analysis/test/run_tests.py --report
+test_command = python run_tests.py --report
 requirements_dir = {toxinidir}/../tests_and_analysis
 
 # Test PyPI source distribution

--- a/build_utils/release_tox.ini
+++ b/build_utils/release_tox.ini
@@ -8,7 +8,7 @@ skipsdist = True
 
 [testenv]
 changedir = tests_and_analysis/test
-test_command = python {toxinidir}/../tests_and_analysis/run_tests.py --report
+test_command = python {toxinidir}/../tests_and_analysis/test/run_tests.py --report
 requirements_dir = {toxinidir}/../tests_and_analysis
 
 # Test PyPI source distribution

--- a/build_utils/release_tox.ini
+++ b/build_utils/release_tox.ini
@@ -13,9 +13,11 @@ requirements_dir = {toxinidir}/../tests_and_analysis
 
 # Test PyPI source distribution
 [testenv:pypisource-{py310,py312}]
+passenv = CC CC_LD LDFLAGS CPPFLAGS
 install_command = python -m pip install {opts} {packages}
 deps =
     numpy
+    spglib  # Not interested here in whether source builds of spglib work
     -r{[testenv]requirements_dir}/tox_requirements.txt
 commands_pre =
     python -m pip install \

--- a/build_utils/release_tox.ini
+++ b/build_utils/release_tox.ini
@@ -40,7 +40,7 @@ commands = {[testenv]test_command}
 [testenv:pypi-py310-min]
 install_command = python -m pip install --force-reinstall {opts} {packages}
 deps =
-    numpy==1.21.3
+    numpy==1.24.0
 commands_pre =
     python -m pip install --force-reinstall \
         -r{[testenv]requirements_dir}/minimum_euphonic_requirements.txt

--- a/build_utils/release_tox.ini
+++ b/build_utils/release_tox.ini
@@ -39,13 +39,32 @@ commands_pre =
     --only-binary 'euphonic'
 commands = {[testenv]test_command}
 
-[testenv:pypi-py310-min]
+[testenv:pypi-py310-min-win-linux]
 install_command = python -m pip install --force-reinstall {opts} {packages}
+platform =
+    linux: linux
+    windows: win32
 deps =
     numpy==1.24.0
 commands_pre =
     python -m pip install --force-reinstall \
         -r{[testenv]requirements_dir}/minimum_euphonic_requirements.txt
+    python -m pip install --force-reinstall \
+        -r{[testenv]requirements_dir}/tox_requirements.txt
+    python -m pip install \
+    'euphonic[matplotlib,phonopy_reader,brille]=={env:EUPHONIC_VERSION}' \
+    --only-binary 'euphonic'
+commands = {[testenv]test_command}
+
+[testenv:pypi-py310-min-mac]
+install_command = python -m pip install --force-reinstall {opts} {packages}
+platform =
+    mac: darwin
+deps =
+    numpy==1.24.0
+commands_pre =
+    python -m pip install --force-reinstall \
+        -r{[testenv]requirements_dir}/minimum_euphonic_requirements_mac.txt
     python -m pip install --force-reinstall \
         -r{[testenv]requirements_dir}/tox_requirements.txt
     python -m pip install \

--- a/build_utils/release_tox.ini
+++ b/build_utils/release_tox.ini
@@ -8,7 +8,7 @@ skipsdist = True
 
 [testenv]
 changedir = tests_and_analysis/test
-test_command = python run_tests.py --report
+test_command = python {toxinidir}/../tests_and_analysis/test/run_tests.py --report
 requirements_dir = {toxinidir}/../tests_and_analysis
 
 # Test PyPI source distribution

--- a/tests_and_analysis/minimum_euphonic_requirements_mac.txt
+++ b/tests_and_analysis/minimum_euphonic_requirements_mac.txt
@@ -1,0 +1,10 @@
+numpy==1.24.0
+scipy==1.10.0
+spglib==2.0.0
+seekpath==1.1.0
+pint==0.22
+matplotlib==3.8
+h5py==3.7
+PyYAML==6.0
+threadpoolctl==3.0.0
+toolz==0.12.1

--- a/tests_and_analysis/minimum_euphonic_requirements_mac.txt
+++ b/tests_and_analysis/minimum_euphonic_requirements_mac.txt
@@ -1,6 +1,6 @@
 numpy==1.24.0
 scipy==1.10.0
-spglib==2.0.0
+spglib==1.9.4.2
 seekpath==1.1.0
 pint==0.22
 matplotlib==3.8

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 # The python environments to run the tests in
-envlist = py310,py311,py312,py310-{base,matplotlib,phonopy_reader,brille,all},py310-minrequirements-linux
+envlist = py310,py311,py312,py310-{base,matplotlib,phonopy_reader,brille,all},py310-minrequirements-{mac,linux}
 # Skip the execution of setup.py as we do it with the correct arg in commands_pre below
 skipsdist = True
 whitelist_externals = git
@@ -97,6 +97,25 @@ deps =
 commands_pre =
     python -m pip install --force-reinstall \
         -r{toxinidir}/tests_and_analysis/minimum_euphonic_requirements.txt
+    python -m pip install --force-reinstall \
+        -r{toxinidir}/tests_and_analysis/tox_requirements.txt
+    # Force rebuild of euphonic extension to avoid Numpy clash
+    rm -rf {toxinidir}/build
+    python -m pip install '{toxinidir}[matplotlib,phonopy_reader,brille]'
+commands = {[testenv]test_command}
+
+[testenv:py310-minrequirements-mac]
+whitelist_externals = rm
+install_command =
+    python -m pip install --force-reinstall {opts} {packages}
+platform =
+    macos: darwin
+deps =
+    numpy==1.24.0
+    {[testenv:py310]deps}
+commands_pre =
+    python -m pip install --force-reinstall \
+        -r{toxinidir}/tests_and_analysis/minimum_euphonic_requirements_mac.txt
     python -m pip install --force-reinstall \
         -r{toxinidir}/tests_and_analysis/tox_requirements.txt
     # Force rebuild of euphonic extension to avoid Numpy clash


### PR DESCRIPTION
Current status:
- All conda tests failing (this is fine, the conda-forge package is not done yet)
- Ubuntu pypi-py310-min fails because it can't build spglib. The `ModuleNotFoundError: No module named 'distutils.msvccompiler'` error seems to be related to numpy/distutils versions.
- Windows pypisource-py310 and pypisource-py312 fail to build the Euphonic package, probably an environment/Meson issue
- macos-latest pypi-py310-min fails because it can't build spglib or h5py. I think there are no ARM wheels for the old versions and we haven't set up an appropriate environment to build them (e.g. with libhdf5 an old C compiler)
- macos-13 pypi-py310-min fails because it can't build spglib