### PR TITLE
Reduce source distribution size

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,3 @@
-# Added by versioneer
-euphonic/_version.py export-subst
+.github/** export-ignore
+tests_and_analysis/** export-ignore
+tox.ini export-ignore

--- a/.github/workflows/build_upload_pypi_wheels.yml
+++ b/.github/workflows/build_upload_pypi_wheels.yml
@@ -6,29 +6,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  build-sdist:
-    name: Build sdist
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0 # Ensure tags are fetched for versioning
-
-      - name: Create source distribution
-        shell: bash -l {0}
-        run: |
-          pipx run build --sdist .
-
-      - name: Upload source dist as build artifact
-        uses: actions/upload-artifact@v4
-        with:
-            name: python-source-distribution
-            path: dist/
-            if-no-files-found: error
-
   build-wheels:
-    needs: build-sdist
     strategy:
       matrix:
         os: [windows-latest, macos-13, macos-latest, ubuntu-latest]
@@ -57,23 +35,6 @@ jobs:
     steps:
       - name: Checkout project (for test files)
         uses: actions/checkout@v4
-        with:
-          path: euphonic_from_git
-
-      - name: Delete source (to ensure we are using sdist only)
-        shell: bash -l {0}
-        run: rm -rf euphonic_from_git/euphonic
-
-      - name: Download sdist
-        uses: actions/download-artifact@v4
-        with:
-          name: python-source-distribution
-          path: dist/
-
-      - name: Get sdist filename
-        shell: bash -l {0}
-        run: |
-          echo EUPHONIC_SDIST="$(find dist/ -name 'euphonic*.tar.gz')" >> $GITHUB_ENV
 
       - name: Setup Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
@@ -115,7 +76,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip build wheel twine
 
-      - name: Build wheels from sdist
+      - name: Build wheels from git checkout
         uses: pypa/cibuildwheel@v2.21.3
         env:
           CIBW_BUILD_FRONTEND: build
@@ -126,17 +87,37 @@ jobs:
           CIBW_REPAIR_WHEEL_COMMAND_MACOS: ""
 
           CIBW_TEST_EXTRAS: "test,brille,phonopy_reader,matplotlib"
-          CIBW_TEST_COMMAND: "python {package}../../euphonic_from_git/tests_and_analysis/test/run_tests.py"
+          CIBW_TEST_COMMAND: "python {package}/tests_and_analysis/test/run_tests.py"
 
         with:
           output-dir: wheelhouse
-          package-dir: ${{ env.EUPHONIC_SDIST }}
 
       - name: Upload wheels as build artifacts
         uses: actions/upload-artifact@v4
         with:
             name: wheel-${{ matrix.wheelname }}-${{ matrix.python-version }}-${{ matrix.cibw_archs }}
             path: wheelhouse/*-${{ matrix.wheelname }}*_${{ matrix.cibw_archs }}.whl
+            if-no-files-found: error
+
+  build-sdist:
+    name: Build sdist
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # Ensure tags are fetched for versioning
+
+      - name: Create source distribution
+        shell: bash -l {0}
+        run: |
+          pipx run build --sdist .
+
+      - name: Upload source dist as build artifact
+        uses: actions/upload-artifact@v4
+        with:
+            name: python-source-distribution
+            path: dist/
             if-no-files-found: error
 
   test-sdist:
@@ -195,7 +176,6 @@ jobs:
       - name: run tests
         shell: bash -l {0}
         run: python tests_and_analysis/test/run_tests.py --report
-
 
   publish:
     if: github.event_name == 'release'

--- a/.github/workflows/build_upload_pypi_wheels.yml
+++ b/.github/workflows/build_upload_pypi_wheels.yml
@@ -115,10 +115,6 @@ jobs:
         run: |
           python -m pip install --upgrade pip build wheel twine
 
-      - name: List contents of GITHUB_WORKSPACE
-        shell: bash -l {0}
-        run: ls -R ${GITHUB_WORKSPACE}
-
       - name: Build wheels from sdist
         uses: pypa/cibuildwheel@v2.21.3
         env:
@@ -130,7 +126,7 @@ jobs:
           CIBW_REPAIR_WHEEL_COMMAND_MACOS: ""
 
           CIBW_TEST_EXTRAS: "test,brille,phonopy_reader,matplotlib"
-          CIBW_TEST_COMMAND: python ${{ github.workspace }}/euphonic_from_git/tests_and_analysis/test/run_tests.py
+          CIBW_TEST_COMMAND: python {project}/euphonic_from_git/tests_and_analysis/test/run_tests.py
 
         with:
           output-dir: wheelhouse

--- a/.github/workflows/build_upload_pypi_wheels.yml
+++ b/.github/workflows/build_upload_pypi_wheels.yml
@@ -124,7 +124,7 @@ jobs:
           CIBW_REPAIR_WHEEL_COMMAND_MACOS: ""
 
           CIBW_TEST_EXTRAS: "test,brille,phonopy_reader,matplotlib"
-          CIBW_TEST_COMMAND: python {package}/tests_and_analysis/test/run_tests.py
+          CIBW_TEST_COMMAND: python ${{ github.workspace }}/tests_and_analysis/test/run_tests.py
 
         with:
           output-dir: wheelhouse

--- a/.github/workflows/build_upload_pypi_wheels.yml
+++ b/.github/workflows/build_upload_pypi_wheels.yml
@@ -126,7 +126,7 @@ jobs:
           CIBW_REPAIR_WHEEL_COMMAND_MACOS: ""
 
           CIBW_TEST_EXTRAS: "test,brille,phonopy_reader,matplotlib"
-          CIBW_TEST_COMMAND: python {project}/euphonic_from_git/tests_and_analysis/test/run_tests.py
+          CIBW_TEST_COMMAND: "python {package}../../euphonic_from_git/tests_and_analysis/test/run_tests.py"
 
         with:
           output-dir: wheelhouse

--- a/.github/workflows/build_upload_pypi_wheels.yml
+++ b/.github/workflows/build_upload_pypi_wheels.yml
@@ -57,10 +57,12 @@ jobs:
     steps:
       - name: Checkout project (for test files)
         uses: actions/checkout@v4
+        with:
+          path: euphonic_from_git
 
       - name: Delete source (to ensure we are using sdist only)
         shell: bash -l {0}
-        run: rm -rf euphonic
+        run: rm -rf euphonic_from_git/euphonic
 
       - name: Download sdist
         uses: actions/download-artifact@v4
@@ -113,6 +115,10 @@ jobs:
         run: |
           python -m pip install --upgrade pip build wheel twine
 
+      - name: List contents of GITHUB_WORKSPACE
+        shell: bash -l {0}
+        run: ls -R ${GITHUB_WORKSPACE}
+
       - name: Build wheels from sdist
         uses: pypa/cibuildwheel@v2.21.3
         env:
@@ -124,7 +130,7 @@ jobs:
           CIBW_REPAIR_WHEEL_COMMAND_MACOS: ""
 
           CIBW_TEST_EXTRAS: "test,brille,phonopy_reader,matplotlib"
-          CIBW_TEST_COMMAND: python ${{ github.workspace }}/tests_and_analysis/test/run_tests.py
+          CIBW_TEST_COMMAND: python ${{ github.workspace }}/euphonic_from_git/tests_and_analysis/test/run_tests.py
 
         with:
           output-dir: wheelhouse


### PR DESCRIPTION
Depends on #337 

meson-python uses git-archive to create the sdist. Some of euphonic's test files are on the large side and we don't need to include them with every copy of the source.

This does have the downside that git-archive can no longer be used to produce a copy of the source with tests, but we weren't using that anyway.