### PR TITLE
Release 1.4.0.post1

### DIFF
--- a/.github/workflows/set_version.yml
+++ b/.github/workflows/set_version.yml
@@ -23,11 +23,13 @@ jobs:
           import os
           from packaging.version import Version
 
-          version_string = 'v' + str(Version("${{ inputs.version }}"))
+          version_number = str(Version("${{ inputs.version }}"))
+          version_string = 'v' + version_number
 
           print(f"Normalised version string: {version_string}")
 
           with open(os.environ["GITHUB_ENV"], "a") as github_env:
+              print(f"VERSION_NUMBER={version_number}", file=github_env)
               print(f"VERSION_STRING={version_string}", file=github_env)
 
       - uses: actions/checkout@v4
@@ -45,7 +47,7 @@ jobs:
       - name: "Update CITATION.cff"
         shell: bash -l {0}
         run: |
-          sed -i "s/^version:\ .*/version: ${VERSION_STRING}/" CITATION.cff
+          sed -i "s/^version:\ .*/version: ${VERSION_NUMBER}/" CITATION.cff
           sed -i "s/^date-released:\ .*/date-released: $(date -I)/" CITATION.cff
 
       - name: "Create commit"

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,5 +1,15 @@
-`Unreleased <https://github.com/pace-neutrons/Euphonic/compare/v1.4.0...HEAD>`_
--------------------------------------------------------------------------------
+`Unreleased <https://github.com/pace-neutrons/Euphonic/compare/v1.4.0.post1...HEAD>`_
+-------------------------------------------------------------------------------------
+
+
+`v1.4.0.post1 <https://github.com/pace-neutrons/Euphonic/compare/v1.4.0...v1.4.0.post1>`_
+-----------------------------------------------------------------------------------------
+
+This post-release makes some changes to the source-distribution build process:
+- A bug is fixed in the version-numbering script; this particularly affected Windows
+- A copies of the unit tests and documentation were mistakenly included
+  in tarballs, making them excessively large. This is no longer present.
+
 
 - Bug fixes
 

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -33,7 +33,7 @@ authors:
     given-names: "Jacob S."
 title: "Euphonic"
 doi: 10.5286/SOFTWARE/EUPHONIC
-version: v1.4.0.post1
+version: 1.4.0.post1
 date-released: 2024-12-12
 license: GPL-3.0-only
 repository-code: https://github.com/pace-neutrons/Euphonic


### PR DESCRIPTION
This post-release makes some changes to the source-distribution build process:
- A bug is fixed in the version-numbering script; this particularly affected Windows
- A copies of the unit tests and documentation were mistakenly included
  in tarballs, making them excessively large. This is no longer present.
