### PR TITLE
Avoid redundant coverage checks in CI

### DIFF
--- a/.github/workflows/test_checkout_one_os.yml
+++ b/.github/workflows/test_checkout_one_os.yml
@@ -84,7 +84,7 @@ jobs:
 
       - name: Run tests
         shell: bash -l {0}
-        run: python -m tox run-parallel
+        run: python -m tox run-parallel -- ${{ inputs.coverage && '--cov' || '' }}
 
       - name: Upload test results
         if: always()

--- a/tox.ini
+++ b/tox.ini
@@ -25,33 +25,33 @@ extras =
     matplotlib
     phonopy-reader
     brille
-commands = {[testenv]test_command} --cov
+commands = {[testenv]test_command} {posargs}
 
 # Test with no extras
 [testenv:py310-base]
 extras = {[testenv]extras}
-commands = {[testenv]test_command} --cov -m "not (phonopy_reader or matplotlib or brille)"
+commands = {[testenv]test_command} -m "not (phonopy_reader or matplotlib or brille)"
 
 # Test with matplotlib extra only
 [testenv:py310-matplotlib]
 extras =
     {[testenv]extras}
     matplotlib
-commands = {[testenv]test_command} --cov -m "matplotlib and not multiple_extras"
+commands = {[testenv]test_command} -m "matplotlib and not multiple_extras"
 
 # Test with phonopy-reader extra only
 [testenv:py310-phonopy-reader]
 extras =
     {[testenv]extras}
     phonopy-reader
-commands = {[testenv]test_command} --cov -m "phonopy_reader and not multiple_extras"
+commands = {[testenv]test_command} -m "phonopy_reader and not multiple_extras"
 
 # Test with brille extra only
 [testenv:py310-brille]
 extras =
     {[testenv]extras}
     brille
-commands = {[testenv]test_command} --cov -m "brille and not multiple_extras"
+commands = {[testenv]test_command} -m "brille and not multiple_extras"
 
 # Run remaining tests that require multiple extras
 [testenv:py310-all]
@@ -61,7 +61,7 @@ extras =
     phonopy-reader
     brille
 commands =
-    {[testenv]test_command} --cov -m "multiple_extras"
+    {[testenv]test_command} -m "multiple_extras"
 
 [testenv:py310-no-c]
 install_command = {[testenv]install_command} -Csetup-args="-Dpython_only=true"


### PR DESCRIPTION
Closes #352 

We only really need to use coverage for one pass over the test suite, and only on the ubuntu runner (as this is the one that uploads the coverage results.)