### PR TITLE
Pre release 1.4.1 rc

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -20,18 +20,18 @@ jobs:
         config:
         - os: ubuntu-latest
           skip: false
-          all-python-versions: ${{(github.event_name == 'workflow_dispatch')}}
+          all-python-versions: ${{(github.event_name != 'pull_request')}}
           coverage: true
         - os: windows-latest
           skip: false
-          all-python-versions: ${{(github.event_name == 'workflow_dispatch')}}
+          all-python-versions: ${{(github.event_name != 'pull_request')}}
           coverage: false
         - os: macos-latest
           skip: false
-          all-python-versions: ${{(github.event_name == 'workflow_dispatch')}}
+          all-python-versions: ${{(github.event_name != 'pull_request')}}
           coverage: false
         - os: macos-13
-          skip: ${{ github.event_name != 'workflow_dispatch' }}
+          skip: ${{ github.event_name == 'pull_request' }}
           all-python-versions: true
           coverage: false
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,5 +1,8 @@
-`Unreleased <https://github.com/pace-neutrons/Euphonic/compare/v1.4.0.post1...HEAD>`_
--------------------------------------------------------------------------------------
+`Unreleased <https://github.com/pace-neutrons/Euphonic/compare/v1.4.1rc1...HEAD>`_
+----------------------------------------------------------------------------------
+
+`v1.4.1rc1 <https://github.com/pace-neutrons/Euphonic/compare/v1.4.0.post1...v1.4.1rc1>`_
+-----------------------------------------------------------------------------------------
 
 - Bug fixes
 

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -33,8 +33,8 @@ authors:
     given-names: "Jacob S."
 title: "Euphonic"
 doi: 10.5286/SOFTWARE/EUPHONIC
-version: 1.4.0.post1
-date-released: 2024-12-12
+version: 1.4.1rc1
+date-released: 2025-02-12
 license: GPL-3.0-only
 repository-code: https://github.com/pace-neutrons/Euphonic
 url: https://euphonic.readthedocs.io

--- a/euphonic/version.py
+++ b/euphonic/version.py
@@ -1,1 +1,1 @@
-__version__ = "v1.4.0.post1"
+__version__ = "v1.4.1rc1"


### PR DESCRIPTION
Pre-release to test release tool updates

- Need to merge into master to bring the tweaks to run_tests
- CHANGELOG was messed up: pre-release shouldn't appear in changelog. Incoming PR to fix that.
- Push to PyPI failed because release.yml didn't have permission from the PyPI side. That has now been fixed.

I intend to do a 1.4.1rc2 release the checks everything is working before the "real" 1.4.1 release.