### PR TITLE
Release workflow tuning: 1.4.1rc2 release

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -33,7 +33,7 @@ authors:
     given-names: "Jacob S."
 title: "Euphonic"
 doi: 10.5286/SOFTWARE/EUPHONIC
-version: 1.4.1rc1
+version: 1.4.1rc2
 date-released: 2025-02-12
 license: GPL-3.0-only
 repository-code: https://github.com/pace-neutrons/Euphonic

--- a/euphonic/version.py
+++ b/euphonic/version.py
@@ -1,1 +1,1 @@
-__version__ = "v1.4.1rc1"
+__version__ = "v1.4.1rc2"


### PR DESCRIPTION
It looks like everything worked:

https://github.com/pace-neutrons/Euphonic/releases/tag/v1.4.1rc2
https://pace-neutrons.github.io/Euphonic/versions/v1.4.1rc2.html
https://pypi.org/project/Euphonic/1.4.1rc2/

CHANGELOG still shows as Unreleased, that should change on full release.