### PR TITLE
Expose base Spectrum to euphonic.spectra namespace

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,12 @@
 `Unreleased <https://github.com/pace-neutrons/Euphonic/compare/v1.4.1...HEAD>`_
 -------------------------------------------------------------------------------
 
+- Bug fixes
+
+  - Make Spectrum directly accessible from euphonic.spectra. (This was
+    accidentally lost in a refactor, affecting downstream that uses
+    Spectrum as a type annotation.)
+
 `v1.4.1 <https://github.com/pace-neutrons/Euphonic/compare/v1.4.0.post1...v1.4.1>`_
 -----------------------------------------------------------------------------------
 

--- a/euphonic/spectra/__init__.py
+++ b/euphonic/spectra/__init__.py
@@ -1,4 +1,4 @@
-from .base import Spectrum1D, Spectrum2D, apply_kinematic_constraints
+from .base import Spectrum, Spectrum1D, Spectrum2D, apply_kinematic_constraints
 from .collections import Spectrum1DCollection, Spectrum2DCollection
 
 from .base import CallableQuantity, XTickLabels


### PR DESCRIPTION
Closes #374 

This was a rather subtle API break but it affects some Abins refactoring. Even if we don't inherit from Spectrum it is useful as a type annotation.