### PR TITLE
Fix incompatible-pointer-types

### DIFF
--- a/.github/workflows/test_gcc14.yml
+++ b/.github/workflows/test_gcc14.yml
@@ -1,7 +1,14 @@
-name: Run tests from source with GCC-14
+name: run-tests-gcc-14
+run-name: Run tests from source with GCC-14
 on:
   pull_request:
     types: [opened, reopened, labeled, synchronize]
+
+# Most euphonic tests/builds use Clang, but users might have GCC.
+# New GCC versions often promote bad practices from warnings to errors,
+# so a GCC update can unexpectedly break things.
+# It would be neat to somehow ensure automatically that we are using a
+# very recent GCC. Otherwise, this workflow will need updating occasionally.
 
 jobs:
   test:
@@ -32,14 +39,14 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install -r tests_and_analysis/ci_requirements.txt
 
-      - name: Try installing Euphonic
+      - name: Install Euphonic (verbosely)
         shell: bash -l {0}
         run: |
           python -m pip install -v .
 
       - name: Run tests
         shell: bash -l {0}
-        run: python -m tox run-parallel
+        run: python -m tox -e py312
 
       - name: Upload test results
         if: always()

--- a/.github/workflows/test_gcc14.yml
+++ b/.github/workflows/test_gcc14.yml
@@ -1,0 +1,49 @@
+name: Run tests from source with GCC-14
+on:
+  pull_request:
+    types: [opened, reopened, labeled, synchronize]
+
+jobs:
+  test:
+    runs-on: ubuntu-24.04
+    env:
+      PYTHON_VERSION: |
+        3.12
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # Ensure tags are fetched for versioning
+          fetch-tags: true
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Check gcc-14 exists and set as C compiler
+        shell: bash -l {0}
+        run: |
+          which gcc-14 || exit
+          echo CC="gcc-14" >> $GITHUB_ENV
+
+      - name: Update pip and install dependencies
+        shell: bash -l {0}
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -r tests_and_analysis/ci_requirements.txt
+
+      - name: Try installing Euphonic
+        shell: bash -l {0}
+        run: |
+          python -m pip install -v .
+
+      - name: Run tests
+        shell: bash -l {0}
+        run: python -m tox run-parallel
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: Unit test results Ubuntu + GCC-14
+          path: tests_and_analysis/test/reports/junit_report*.xml

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,16 @@
 `Unreleased <https://github.com/pace-neutrons/Euphonic/compare/v1.4.2...HEAD>`_
 -------------------------------------------------------------------------------
 
+- Bug fixes
+
+  - Fix tox version number in Pyproject.toml; installation with [ci]
+    "extra" was broken.
+
+- Maintenance
+
+  - Avoid incompatible-pointer-types in C compilation; this is an
+    error in GCC14 and warning in older versions.
+
 `v1.4.2 <https://github.com/pace-neutrons/Euphonic/compare/v1.4.1...v1.4.2>`_
 -----------------------------------------------------------------------------
 

--- a/c/_euphonic.c
+++ b/c/_euphonic.c
@@ -126,27 +126,27 @@ static PyObject *calculate_phonons(PyObject *self, PyObject *args) {
 
     // Get rest of vars from ForceConstants object
     if (attr_from_pyobj(py_idata, "crystal", &py_crystal) ||
-        attr_from_pyobj(py_idata, "_n_sc_images", &py_n_sc_ims) ||
-        attr_from_pyobj(py_idata, "_sc_image_i", &py_sc_im_idx) ||
-        attr_from_pyobj(py_idata, "cell_origins", &py_cell_ogs)) {
+        attr_from_pyobj(py_idata, "_n_sc_images", (PyObject**)&py_n_sc_ims) ||
+        attr_from_pyobj(py_idata, "_sc_image_i", (PyObject**)&py_sc_im_idx) ||
+        attr_from_pyobj(py_idata, "cell_origins", (PyObject**)&py_cell_ogs)) {
             PyErr_Format(PyExc_RuntimeError,
                          "Failed to read attributes from object\n");
             return NULL;
     }
     if (dipole) {
-        if (attr_from_pyobj(py_idata, "_dipole_init_data", &py_dipole_init_data)) {
+      if (attr_from_pyobj(py_idata, "_dipole_init_data", (PyObject**)&py_dipole_init_data)) {
                 PyErr_Format(PyExc_RuntimeError,
                              "Failed to read dipole init data from object\n");
                 return NULL;
         }
-        if (attr_from_pyobj(py_idata, "_born", &py_born) ||
-            attr_from_pyobj(py_idata, "_dielectric", &py_dielectric) ||
+      if (attr_from_pyobj(py_idata, "_born", (PyObject**)&py_born) ||
+          attr_from_pyobj(py_idata, "_dielectric", (PyObject**)&py_dielectric) ||
             double_from_pydict(py_dipole_init_data, "lambda", &lambda) ||
-            val_from_pydict(py_dipole_init_data, "H_ab", &py_H_ab) ||
-            val_from_pydict(py_dipole_init_data, "cells", &py_dipole_cells) ||
-            val_from_pydict(py_dipole_init_data, "gvec_phases", &py_gvec_phases) ||
-            val_from_pydict(py_dipole_init_data, "gvecs_cart", &py_gvecs_cart) ||
-            val_from_pydict(py_dipole_init_data, "dipole_q0", &py_dipole_q0)) {
+          val_from_pydict(py_dipole_init_data, "H_ab", (PyObject**)&py_H_ab) ||
+          val_from_pydict(py_dipole_init_data, "cells", (PyObject**)&py_dipole_cells) ||
+          val_from_pydict(py_dipole_init_data, "gvec_phases", (PyObject**)&py_gvec_phases) ||
+          val_from_pydict(py_dipole_init_data, "gvecs_cart", (PyObject**)&py_gvecs_cart) ||
+          val_from_pydict(py_dipole_init_data, "dipole_q0", (PyObject**)&py_dipole_q0)) {
                 PyErr_Format(PyExc_RuntimeError,
                              "Failed to read dipole attributes from object\n");
                 return NULL;
@@ -154,7 +154,7 @@ static PyObject *calculate_phonons(PyObject *self, PyObject *args) {
     }
     // Get vars from Crystal object
     if (int_from_pyobj(py_crystal, "n_atoms", &n_atoms) ||
-        attr_from_pyobj(py_crystal, "atom_r", &py_atom_r)) {
+        attr_from_pyobj(py_crystal, "atom_r", (PyObject**)&py_atom_r)) {
             PyErr_Format(PyExc_RuntimeError,
                          "Failed to read attributes from Crystal object\n");
             return NULL;

--- a/c/py_util.c
+++ b/c/py_util.c
@@ -8,7 +8,7 @@ int val_from_pydict(PyDictObject *dict, const char *key, PyObject **result) {
 /* Given a PyDictObject and key, retrieve get the address of the value associated
  * with that key, and alter the pointer pointed to by result to point to that
  * address */
-    PyObject *tmp = PyDict_GetItemString(dict, key);
+    PyObject *tmp = PyDict_GetItemString((PyObject*)dict, key);
     if (!tmp) {
         printf("Couldn't retrieve %s from dict\n", key);
         return 1;

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,7 @@ phonopy_reader = ["h5py>=3.6.0", "PyYAML>=6.0"]  # Deprecated, will be removed i
 phonopy-reader = ["h5py>=3.6.0", "PyYAML>=6.0"]
 brille = ["brille>=0.7.0"]
 test = ["mock", "pytest~=7.0", "coverage", "pytest-mock", "pytest-lazy-fixture", "pytest-xvfb", "python-slugify"]
-ci = ["tox==4.32.2"]
+ci = ["tox==4.23.2"]
 
 [project.scripts]
 euphonic-brille-convergence = "euphonic.cli.brille_convergence:main"


### PR DESCRIPTION
Closes #351 

[PyObject](https://docs.python.org/3/c-api/structures.html#c.PyObject)s are clever: although C doesn't really have "inheritance", their pointers work as a common interface to more specific Python object types as all these structures have a PyObject as the first component. This way the pointer always goes to something that looks like a PyObject!

Compilers are understandably twitchy about the ensuing signature mismatch when we take a function with signature
`Pyobject *PyDict_GetItemString(PyObject *p, const char *key)`
and pass it a `*PyDictObject` as the first argument. Since GCC14 this has become a hard error; the solution is to explicitly cast pointers from their specialised class to *PyObject.