### PR TITLE
Linting: whitespace, negation, type comparison, mutable defaults, staticmethods

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -10,7 +10,14 @@ on:
   workflow_dispatch:
 
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/ruff-action@v3
+
   test:
+    needs: lint
     if: |
        github.event_name != 'pull_request' ||
        (github.event.action == 'labeled' && github.event.label.name == 'run_ci') ||
@@ -46,6 +53,7 @@ jobs:
     secrets: inherit
 
   test-docs:
+    needs: lint
     runs-on: ubuntu-latest
     if: success() || failure()
     steps:

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -52,6 +52,10 @@ jobs:
       coverage: ${{ matrix.config.coverage }}
     secrets: inherit
 
+  test-gcc14:
+    needs: lint
+    uses: ./.github/workflows/test_gcc14.yml
+
   test-docs:
     needs: lint
     runs-on: ubuntu-latest

--- a/.github/workflows/test_gcc14.yml
+++ b/.github/workflows/test_gcc14.yml
@@ -1,8 +1,7 @@
 name: run-tests-gcc-14
 run-name: Run tests from source with GCC-14
 on:
-  pull_request:
-    types: [opened, reopened, labeled, synchronize]
+  workflow_call:
 
 # Most euphonic tests/builds use Clang, but users might have GCC.
 # New GCC versions often promote bad practices from warnings to errors,

--- a/euphonic/cli/dispersion.py
+++ b/euphonic/cli/dispersion.py
@@ -6,7 +6,7 @@ import matplotlib.style
 from euphonic.plot import plot_1d
 from euphonic.styles import base_style
 from euphonic.writers.phonon_website import write_phonon_website_json
-from euphonic import Spectrum1D, ForceConstants, QpointFrequencies
+from euphonic import Spectrum1D, ForceConstants, QpointPhononModes
 from .utils import (load_data_from_file, get_args, _bands_from_force_constants,
                     _compose_style,
                     _get_q_distance, matplotlib_save_or_show, _get_cli_parser,
@@ -22,7 +22,8 @@ def main(params: Optional[List[str]] = None) -> None:
 
     data = load_data_from_file(args.filename, verbose=True,
                                frequencies_only=frequencies_only)
-    if not frequencies_only and isinstance(data, QpointFrequencies):
+    if not frequencies_only and not isinstance(
+            data, (ForceConstants, QpointPhononModes)):
         raise TypeError(
             'Eigenvectors are required to use "--reorder" option')
 

--- a/euphonic/cli/dispersion.py
+++ b/euphonic/cli/dispersion.py
@@ -22,7 +22,7 @@ def main(params: Optional[List[str]] = None) -> None:
 
     data = load_data_from_file(args.filename, verbose=True,
                                frequencies_only=frequencies_only)
-    if not frequencies_only and type(data) is QpointFrequencies:
+    if not frequencies_only and isinstance(data, QpointFrequencies):
         raise TypeError(
             'Eigenvectors are required to use "--reorder" option')
 

--- a/euphonic/cli/dos.py
+++ b/euphonic/cli/dos.py
@@ -5,7 +5,7 @@ import matplotlib.style
 from numpy import sqrt
 from numpy.polynomial import Polynomial
 
-from euphonic import ureg, ForceConstants, QpointFrequencies
+from euphonic import ureg, ForceConstants, QpointPhononModes
 from euphonic.util import mp_grid, mode_gradients_to_widths
 from euphonic.plot import plot_1d
 from euphonic.styles import base_style
@@ -24,7 +24,8 @@ def main(params: Optional[List[str]] = None) -> None:
     data = load_data_from_file(args.filename, verbose=True,
                                frequencies_only=frequencies_only)
 
-    if not frequencies_only and isinstance(data, QpointFrequencies):
+    if not frequencies_only and not isinstance(
+            data, (QpointPhononModes, ForceConstants)):
         raise TypeError('Eigenvectors are required to use "--pdos" or '
                         'any "--weighting" option other than plain DOS')
     if args.adaptive:

--- a/euphonic/cli/dos.py
+++ b/euphonic/cli/dos.py
@@ -24,7 +24,7 @@ def main(params: Optional[List[str]] = None) -> None:
     data = load_data_from_file(args.filename, verbose=True,
                                frequencies_only=frequencies_only)
 
-    if not frequencies_only and type(data) is QpointFrequencies:
+    if not frequencies_only and isinstance(data, QpointFrequencies):
         raise TypeError('Eigenvectors are required to use "--pdos" or '
                         'any "--weighting" option other than plain DOS')
     if args.adaptive:

--- a/euphonic/cli/intensity_map.py
+++ b/euphonic/cli/intensity_map.py
@@ -24,7 +24,7 @@ def main(params: Optional[List[str]] = None) -> None:
     frequencies_only = (args.weighting != 'coherent')
     data = load_data_from_file(args.filename, verbose=True,
                                frequencies_only=frequencies_only)
-    if not frequencies_only and type(data) is QpointFrequencies:
+    if not frequencies_only and isinstance(data, QpointFrequencies):
         raise TypeError('Eigenvectors are required to use '
                         '"--weighting coherent" option')
     if args.weighting.lower() == 'coherent' and args.temperature is not None:

--- a/euphonic/cli/utils.py
+++ b/euphonic/cli/utils.py
@@ -544,7 +544,7 @@ def _get_cli_parser(features: Collection[str] = {},
                   'data: "realspace" applies the correction to the force '
                   'constant matrix in real space. "reciprocal" applies '
                   'the correction to the dynamical matrix at each q-point.'))
-        if not 'dipole-parameter-optimisation' in features:
+        if 'dipole-parameter-optimisation' not in features:
             sections['interpolation'].add_argument(
                 '--dipole-parameter', type=float, default=1.0,
                 dest='dipole_parameter',
@@ -574,7 +574,7 @@ def _get_cli_parser(features: Collection[str] = {},
     ins_desc = ('coherent inelastic neutron scattering')
     if 'pdos-weighting' in features:
         # Currently do not support multiple PDOS for 2D plots
-        if not 'q-e' in features:
+        if 'q-e' not in features:
             sections['property'].add_argument(
                 '--pdos', type=str, action='store', nargs='*',
                 help=('Plot PDOS. With --pdos, per-species PDOS will be plotted '
@@ -697,7 +697,7 @@ def _get_cli_parser(features: Collection[str] = {},
                              default='cm', dest='figsize_unit',
                              help='Unit of length for --figsize')
 
-    if ('plotting' in features) and not ('map' in features):
+    if ('plotting' in features) and 'map' not in features:
         section = sections['plotting']
         section.add_argument('--line-width', '--linewidth', type=float,
                              default=None, dest='linewidth',

--- a/euphonic/crystal.py
+++ b/euphonic/crystal.py
@@ -77,7 +77,7 @@ class Crystal:
 
         self.cell_vectors_unit = str(cell_vectors.units)
         self.atom_mass_unit = str(atom_mass.units)
-                
+
     @property
     def cell_vectors(self) -> Quantity:
         return self._cell_vectors*ureg('bohr').to(

--- a/euphonic/force_constants.py
+++ b/euphonic/force_constants.py
@@ -509,7 +509,7 @@ class ForceConstants:
             reduced_qpts, qpts_i = np.unique(norm_qpts, return_inverse=True,
                                              axis=0)
             qpts_i = qpts_i.flatten()
-            
+
             n_rqpts = len(reduced_qpts)
             # Special handling of gamma points - don't reduce gamma
             # points if LO-TO splitting

--- a/euphonic/io.py
+++ b/euphonic/io.py
@@ -26,7 +26,7 @@ def _to_json_dict(dictionary: Dict[str, Any]) -> Dict[str, Any]:
 
 
 def _from_json_dict(dictionary: Dict[str, Any],
-                    type_dict: Dict[str, Type[Any]]|None = None) -> Dict[str, Any]:
+                    type_dict: Dict[str, Type[Any]] | None = None) -> Dict[str, Any]:
     """
     For a dictionary read from a JSON file, convert all list key values
     to that specified in type_dict. If not specified in type_dict, just

--- a/euphonic/io.py
+++ b/euphonic/io.py
@@ -26,12 +26,14 @@ def _to_json_dict(dictionary: Dict[str, Any]) -> Dict[str, Any]:
 
 
 def _from_json_dict(dictionary: Dict[str, Any],
-                    type_dict: Dict[str, Type[Any]] = {}) -> Dict[str, Any]:
+                    type_dict: Dict[str, Type[Any]]|None = None) -> Dict[str, Any]:
     """
     For a dictionary read from a JSON file, convert all list key values
     to that specified in type_dict. If not specified in type_dict, just
     uses the default conversion provided by np.array(list)
     """
+    type_dict = {} if type_dict is None else type_dict
+
     for key, val in dictionary.items():
         if isinstance(val, list):
             if key in type_dict and type_dict[key] == tuple:
@@ -76,13 +78,17 @@ def _obj_to_dict(obj: T, attrs: Sequence[str]) -> Dict[str, Any]:
     return dout
 
 
-def _process_dict(dictionary: Dict[str, Any], quantities: Sequence[str] = [],
-                  optional: Sequence[str] = []) -> Dict[str, Any]:
+def _process_dict(dictionary: Dict[str, Any],
+                  quantities: Sequence[str]|None = None,
+                  optional: Sequence[str]|None = None) -> Dict[str, Any]:
     """
     Process an input dictionary for creating objects. Convert keys in
     'quantities' to Quantity objects, and if any 'optional' keys are
     missing, set them to None
     """
+    quantities = [] if quantities is None else quantities
+    optional = [] if optional is None else optional
+
     dictionary = copy.deepcopy(dictionary)
     for okey in optional:
         if not okey in dictionary.keys():
@@ -109,10 +115,12 @@ def _obj_to_json_file(obj: T, filename: str) -> None:
 
 
 def _obj_from_json_file(cls: Type[T], filename: str,
-                        type_dict: Dict[str, Type[Any]] = {}) -> T:
+                        type_dict: Dict[str, Type[Any]]|None = None) -> T:
     """
     Generic function for reading from a JSON file to a Euphonic object
     """
+    type_dict = {} if type_dict is None else type_dict
+
     with open(filename, 'r') as f:
         obj_dict = json.loads(f.read())
     obj_dict = _from_json_dict(obj_dict, type_dict)

--- a/euphonic/io.py
+++ b/euphonic/io.py
@@ -86,8 +86,6 @@ def _process_dict(dictionary: Dict[str, Any],
     'quantities' to Quantity objects, and if any 'optional' keys are
     missing, set them to None
     """
-    quantities = [] if quantities is None else quantities
-    optional = [] if optional is None else optional
 
     dictionary = copy.deepcopy(dictionary)
     for okey in optional:

--- a/euphonic/io.py
+++ b/euphonic/io.py
@@ -79,8 +79,8 @@ def _obj_to_dict(obj: T, attrs: Sequence[str]) -> Dict[str, Any]:
 
 
 def _process_dict(dictionary: Dict[str, Any],
-                  quantities: Sequence[str]|None = None,
-                  optional: Sequence[str]|None = None) -> Dict[str, Any]:
+                  quantities: Sequence[str] = (),
+                  optional: Sequence[str] = ()) -> Dict[str, Any]:
     """
     Process an input dictionary for creating objects. Convert keys in
     'quantities' to Quantity objects, and if any 'optional' keys are

--- a/euphonic/readers/phonopy.py
+++ b/euphonic/readers/phonopy.py
@@ -698,7 +698,7 @@ def read_interpolation_data(
     summary_dict = _extract_summary(summary_pathname, fc_extract=True)
 
     # Only read force constants if it's not in summary file
-    if not 'force_constants' in summary_dict:
+    if 'force_constants' not in summary_dict:
         hdf5_exts = ['hdf5', 'hd5', 'h5']
         if fc_format is None:
             fc_format = os.path.splitext(fc_name)[1].strip('.')

--- a/euphonic/sampling.py
+++ b/euphonic/sampling.py
@@ -268,7 +268,7 @@ def spherical_polar_improved(npts: int,
         Yield points in Cartesian coordinates. If False, instead yield
         points in spherical coordinates.
 
-    jitter 
+    jitter
         Randomly displace each point within its own "cell" of the
         irregular grid
 

--- a/euphonic/validate.py
+++ b/euphonic/validate.py
@@ -103,7 +103,7 @@ def _replace_dim(expected_shape: Tuple[int, ...],
 
 
 def _ensure_contiguous_attrs(obj: object, required_attrs: List[str],
-                             opt_attrs: List[str]|None = None) -> None:
+                             opt_attrs: Sequence[str] = ()) -> None:
     """
     Make sure all listed attributes of obj are C Contiguous and of the
     correct type (int32, float64, complex128). This should only be used

--- a/euphonic/validate.py
+++ b/euphonic/validate.py
@@ -103,7 +103,7 @@ def _replace_dim(expected_shape: Tuple[int, ...],
 
 
 def _ensure_contiguous_attrs(obj: object, required_attrs: List[str],
-                             opt_attrs: List[str] = []) -> None:
+                             opt_attrs: List[str]|None = None) -> None:
     """
     Make sure all listed attributes of obj are C Contiguous and of the
     correct type (int32, float64, complex128). This should only be used
@@ -122,6 +122,8 @@ def _ensure_contiguous_attrs(obj: object, required_attrs: List[str],
         will not throw an error. e.g. Depending on the material
         ForceConstants objects may or may not have 'born' defined
     """
+    opt_attrs = [] if opt_attrs is None else opt_attrs
+
     for attr_name in required_attrs:
         attr = getattr(obj, attr_name)
         attr = attr.astype(_get_dtype(attr), order='C', copy=False)

--- a/euphonic/validate.py
+++ b/euphonic/validate.py
@@ -123,7 +123,6 @@ def _ensure_contiguous_attrs(obj: object, required_attrs: List[str],
         will not throw an error. e.g. Depending on the material
         ForceConstants objects may or may not have 'born' defined
     """
-    opt_attrs = [] if opt_attrs is None else opt_attrs
 
     for attr_name in required_attrs:
         attr = getattr(obj, attr_name)

--- a/euphonic/validate.py
+++ b/euphonic/validate.py
@@ -1,3 +1,4 @@
+from collections.abc import Sequence
 from typing import List, Any, Union, Type, Tuple, Optional
 
 import numpy as np

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,3 +67,17 @@ euphonic-optimise-dipole-parameter = "euphonic.cli.optimise_dipole_parameter:mai
 euphonic-show-sampling = "euphonic.cli.show_sampling:main"
 euphonic-intensity-map = "euphonic.cli.intensity_map:main"
 euphonic-powder-map = "euphonic.cli.powder_map:main"
+
+[tool.ruff]
+line-length = 79
+target-version = "py310"
+
+[tool.ruff.lint]
+preview = true
+explicit-preview-rules = true
+select = [
+       "W291", # trailing-whitespace
+       "W293", # blank-line-with-whitespace
+       "B006", # mutable-argument-default
+       "PLR0203", # no-staticmethod-decorator
+]

--- a/tests_and_analysis/test/euphonic_test/test_castep_reader.py
+++ b/tests_and_analysis/test/euphonic_test/test_castep_reader.py
@@ -76,7 +76,7 @@ class TestReadPhononData:
         with open(get_data_path('readers', expected_data_file), 'r') as fp:
             expected_data = _from_json_dict(
                 json.loads(fp.read()),
-                type_dict={'eigenvectors': np.complex128})                
+                type_dict={'eigenvectors': np.complex128})
 
         crystal = ExpectedCrystal(data.pop('crystal'))
         expected_crystal = ExpectedCrystal(

--- a/tests_and_analysis/test/euphonic_test/test_crystal.py
+++ b/tests_and_analysis/test/euphonic_test/test_crystal.py
@@ -383,7 +383,7 @@ class TestCrystalMethods:
         (get_crystal('LZO'), lzo_spglib_cell)])
     def test_to_spglib_cell(self, crystal, expected_spglib_cell):
         spglib_cell = crystal.to_spglib_cell()
-        assert type(spglib_cell) is tuple
+        assert isinstance(spglib_cell, tuple)
         npt.assert_allclose(spglib_cell[0], expected_spglib_cell[0],
                             atol=np.finfo(np.float64).eps)
         npt.assert_allclose(spglib_cell[1], expected_spglib_cell[1],

--- a/tests_and_analysis/test/euphonic_test/test_force_constants.py
+++ b/tests_and_analysis/test/euphonic_test/test_force_constants.py
@@ -191,7 +191,7 @@ class TestForceConstantsCreation:
         'material, castep_bin_file',
         [
             ('ZnS', 'zns-25-loadborn.castep_bin'),
-            ('ZnS', 'zns-25-born-only.castep_bin'),            
+            ('ZnS', 'zns-25-born-only.castep_bin'),
         ],
     )
     def test_create_from_castep25(self, material, castep_bin_file):

--- a/tests_and_analysis/test/euphonic_test/test_force_constants_calculate_qpoint_frequencies.py
+++ b/tests_and_analysis/test/euphonic_test/test_force_constants_calculate_qpoint_frequencies.py
@@ -16,6 +16,7 @@ from tests_and_analysis.test.euphonic_test.test_force_constants import (
 
 class TestForceConstantsCalculateQPointFrequencies:
 
+    @staticmethod
     def get_lzo_fc():
         return ForceConstants.from_castep(
             get_castep_path('LZO', 'La2Zr2O7.castep_bin'))
@@ -27,6 +28,7 @@ class TestForceConstantsCalculateQPointFrequencies:
          [get_test_qpts(), {'asr': 'realspace'}],
          'LZO_realspace_qpoint_frequencies.json')]
 
+    @staticmethod
     def get_quartz_fc():
         return ForceConstants.from_castep(
             get_castep_path('quartz', 'quartz.castep_bin'))

--- a/tests_and_analysis/test/euphonic_test/test_force_constants_calculate_qpoint_phonon_modes.py
+++ b/tests_and_analysis/test/euphonic_test/test_force_constants_calculate_qpoint_phonon_modes.py
@@ -21,6 +21,7 @@ from tests_and_analysis.test.euphonic_test.test_force_constants import (
 
 class TestForceConstantsCalculateQPointPhononModes:
 
+    @staticmethod
     def get_lzo_fc():
         return ForceConstants.from_castep(
             get_castep_path('LZO', 'La2Zr2O7.castep_bin'))
@@ -35,6 +36,7 @@ class TestForceConstantsCalculateQPointPhononModes:
          [get_test_qpts(), {'asr': 'reciprocal'}],
          'LZO_reciprocal_qpoint_phonon_modes.json')]
 
+    @staticmethod
     def get_si2_fc():
         return ForceConstants.from_castep(
             get_castep_path('Si2-sc-skew', 'Si2-sc-skew.castep_bin'))
@@ -49,6 +51,7 @@ class TestForceConstantsCalculateQPointPhononModes:
          [get_test_qpts(), {'asr': 'reciprocal'}],
          'Si2-sc-skew_reciprocal_qpoint_phonon_modes.json')]
 
+    @staticmethod
     def get_quartz_fc():
         return ForceConstants.from_castep(
             get_castep_path('quartz', 'quartz.castep_bin'))

--- a/tests_and_analysis/test/euphonic_test/test_qpoint_frequencies.py
+++ b/tests_and_analysis/test/euphonic_test/test_qpoint_frequencies.py
@@ -583,6 +583,7 @@ class TestQpointFrequenciesCalculateDosMap:
             expected_dos_map_json)
         check_spectrum2d(dos_map, expected_dos_map)
 
+    @staticmethod
     def get_test_nacl_mode_widths():
         mode_widths = np.ones((23, 24))
         mode_widths[:, :5] = 2.

--- a/tests_and_analysis/test/script_tests/test_powder_map.py
+++ b/tests_and_analysis/test/script_tests/test_powder_map.py
@@ -85,7 +85,7 @@ class TestRegression:
         matplotlib.pyplot.close('all')
 
     def run_powder_map_and_test_result(
-            self, powder_map_args, keys_to_omit=['x_ticklabels']):
+            self, powder_map_args, keys_to_omit=('x_ticklabels',)):
         euphonic.cli.powder_map.main(powder_map_args)
 
         image_data = get_current_plot_image_data()

--- a/tests_and_analysis/test/script_tests/test_powder_map.py
+++ b/tests_and_analysis/test/script_tests/test_powder_map.py
@@ -47,7 +47,7 @@ powder_map_params = [
     [graphite_fc_file, '--asr', *quick_calc_params],
     [graphite_fc_file, '--asr=realspace', '--dipole-parameter=0.75',
      *quick_calc_params],
-    [graphite_fc_file, '--e-i=15', '--ebins=50', *quick_calc_params],    
+    [graphite_fc_file, '--e-i=15', '--ebins=50', *quick_calc_params],
     [graphite_fc_file, '--e-i=15', '--e-max=20', '--ebins=50',
      *quick_calc_params],
     [graphite_fc_file, '--e-f=15', '--ebins=50', '--q-max=16',

--- a/tests_and_analysis/test/utils.py
+++ b/tests_and_analysis/test/utils.py
@@ -317,7 +317,7 @@ def get_spectrum_from_text(text_filename, is_collection=True):
             line = fp.readline()  # 'Column i + 2: y_data[i]...' line
             line_data = json.loads(line[line.index('{'):])
             if line_data:
-                if not 'line_data' in metadata:
+                if 'line_data' not in metadata:
                     metadata['line_data'] = [
                         {} for i in range(len(y_data[0]))]
                 metadata['line_data'][idx] = line_data


### PR DESCRIPTION
Pylint has been complaining for a while about some stuff that is easy to fix but would clutter other PRs. They should be done in manageable batches in separate PRs.