### PR TITLE
Add  "get_bin_edges", "get_bin_centres" to Spectrum2DCollection

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,12 @@
 `Unreleased <https://github.com/pace-neutrons/Euphonic/compare/v1.4.2...HEAD>`_
 -------------------------------------------------------------------------------
 
+- Features
+
+  - Add methods get_bin_edges, get_bin_centers to
+    Spectrum2DCollection, making interface consistent with other
+    Spectrum classes.
+
 - Bug fixes
 
   - Fix tox version number in Pyproject.toml; installation with [ci]

--- a/euphonic/spectra/collections.py
+++ b/euphonic/spectra/collections.py
@@ -1007,3 +1007,57 @@ class Spectrum2DCollection(SpectrumCollectionMixin,
                    **{f"{cls._spectrum_axis}_data": spectrum_data},
                    x_tick_labels=x_tick_labels,
                    metadata=metadata)
+
+    def get_bin_edges(
+            self,
+            bin_ax: Literal["x", "y"] = "x",
+            *,
+            restrict_range: bool = True
+    ) -> Quantity:
+        """
+        Get bin edges for the axis specified by bin_ax. If the size of bin_ax
+        is one element larger than z_data along that axis, bin_ax is assumed to
+        contain bin edges. If they are the same size, bin_ax is assumed to
+        contain bin centres and a conversion is made.
+
+        In this case, bin edges are assumed to be halfway between bin centres.
+
+        Parameters
+        ----------
+        bin_ax
+            The axis to get the bin edges for, 'x' or 'y'
+
+        restrict_range
+            If True (default), the bin edges will not go outside the existing
+            data bounds so the first and last bins may be half-size. This may
+            be desirable for plotting.  Otherwise, the outer bin edges will
+            extend from the initial data range.
+        """
+        enum = {"series": 0, "x": 1, "y": 2}
+        bin_data = getattr(self, f"{bin_ax}_data")
+        data_ax_len = self.z_data.shape[enum[bin_ax]]
+        if self._is_bin_edge(data_ax_len, bin_data.shape[0]):
+            return bin_data
+        return self._bin_centres_to_edges(bin_data, restrict_range=restrict_range)
+
+    def get_bin_centres(self, bin_ax: Literal["x", "y"] = "x") -> Quantity:
+        """
+        Get bin centres for the axis specified by bin_ax. If the size of
+        bin_ax is the same size as z_data along that axis, bin_ax is
+        assumed to contain bin centres, but if bin_ax is one element
+        larger, bin_ax is assumed to contain bin centres and a conversion
+        is made. In this conversion, the bin centres are assumed to be in
+        the middle of each bin, which may not be an accurate assumption in
+        the case of differently sized bins.
+
+        Parameters
+        ----------
+        bin_ax
+            The axis to get the bin centres for, 'x' or 'y'
+        """
+        enum = {"series": 0, "x": 1, "y": 2}
+        bin_data = getattr(self, f"{bin_ax}_data")
+        data_ax_len = self.z_data.shape[enum[bin_ax]]
+        if self._is_bin_edge(data_ax_len, bin_data.shape[0]):
+            return self._bin_edges_to_centres(bin_data)
+        return bin_data

--- a/tests_and_analysis/test/euphonic_test/test_spectrum2dcollection.py
+++ b/tests_and_analysis/test/euphonic_test/test_spectrum2dcollection.py
@@ -246,6 +246,36 @@ class TestSpectrum2DCollectionFunctionality:
             assert isinstance(item, Spectrum2D)
             check_spectrum2d(item, ref)
 
+    def test_bin_methods(self, quartz_fuzzy_collection):
+        """Check access to x and y bins"""
+
+        assert (
+            len(quartz_fuzzy_collection.get_bin_edges("x"))
+            == quartz_fuzzy_collection.z_data.shape[1] + 1
+        )
+        assert (
+            len(quartz_fuzzy_collection.get_bin_edges("y"))
+            == quartz_fuzzy_collection.z_data.shape[2] + 1
+        )
+        assert (
+            len(quartz_fuzzy_collection.get_bin_centres("x"))
+            == quartz_fuzzy_collection.z_data.shape[1]
+        )
+        assert (
+            len(quartz_fuzzy_collection.get_bin_centres("y"))
+            == quartz_fuzzy_collection.z_data.shape[2]
+        )
+
+        np.testing.assert_allclose(
+            quartz_fuzzy_collection.get_bin_centres("x"),
+            np.linspace(0, 1, 10) * ureg("1 / angstrom")
+        )
+
+        np.testing.assert_allclose(
+            quartz_fuzzy_collection.get_bin_edges("y"),
+            np.linspace(0, 100, 20) * ureg("1 / angstrom")
+        )
+
     def test_collection_methods(self, quartz_fuzzy_collection):
         """Check methods from SpectrumCollectionMixin
 


### PR DESCRIPTION
These methods were left out, which became apparent when trying to use them in an Abins refactor...