### PR TITLE
387 more lint, small bugfix

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,10 @@
 
   - Fix tox version number in Pyproject.toml; installation with [ci]
     "extra" was broken.
+  - Fix the *mode_gradients_unit* argument to
+    ``euphonic.readers.castep.read_phonon_dos_data``; this was
+    returning consistent data/units but ignoring the preference
+    expressed in that argument.
 
 - Maintenance
 

--- a/build_utils/release.py
+++ b/build_utils/release.py
@@ -44,11 +44,11 @@ def release_github(test=True):
                 f'{ver}'))
 
     if is_prerelease:
-        BODY_RE = r'`Unreleased.*?^-+\n(.*?)^`v'
+        body_re = r'`Unreleased.*?^-+\n(.*?)^`v'
     else:
-        BODY_RE = r'`v\d+\.\d+\.\S+.*?^-+\n(.*?)^`v'
+        body_re = r'`v\d+\.\d+\.\S+.*?^-+\n(.*?)^`v'
 
-    desc = re.search(BODY_RE, changelog,
+    desc = re.search(body_re, changelog,
                      re.DOTALL | re.MULTILINE).groups()[0].strip()
 
     payload = {

--- a/build_utils/version.py
+++ b/build_utils/version.py
@@ -44,7 +44,7 @@ for gitcmd in gits:
         proc = subprocess.run([gitcmd, "describe", "--tags", "--dirty"],  # noqa: S603
                               capture_output=True, check=True, text=True
                               )
-    except FileNotFoundError as err:
+    except FileNotFoundError:
         print(f"Tried {gitcmd}, File Not Found", file=sys.stderr)
         continue
 

--- a/euphonic/broadening.py
+++ b/euphonic/broadening.py
@@ -261,21 +261,21 @@ def _width_interpolated_broadening(
 
     spectrum = np.zeros(len(bins)-1)
 
+    upper_weights_prev = np.array([], dtype=float)
+    x_prev = np.array([], dtype=float)
+
     for i in range(1, len(width_samples)+1):
         masked_block = (kernels_idx == i)
         width_factors = widths[masked_block]/width_samples[i-1]
         lower_mix = np.polyval(lower_coeffs, width_factors)
         lower_weights = lower_mix * weights[masked_block]
 
-        if i == 1:
-            hist, _ = np.histogram(x[masked_block], bins=bins,
-                                   weights=lower_weights/bin_width)
-        else:
-            mixing_weights = np.concatenate((upper_weights_prev,
-                                             lower_weights))
-            hist_x = np.concatenate((x_prev, x[masked_block]))
-            hist, _ = np.histogram(hist_x, bins=bins,
-                                   weights=mixing_weights/bin_width)
+        mixing_weights = np.concatenate((upper_weights_prev,
+                                         lower_weights))
+        hist_x = np.concatenate((x_prev, x[masked_block]))
+
+        hist, _ = np.histogram(hist_x, bins=bins,
+                               weights=mixing_weights/bin_width)
 
         x_prev = x[masked_block]
         upper_weights_prev = weights[masked_block] - lower_weights

--- a/euphonic/cli/brille_convergence.py
+++ b/euphonic/cli/brille_convergence.py
@@ -1,4 +1,4 @@
-# -*- coding: UTF-8 -*-
+# -*- coding: utf-8 -*-
 from argparse import SUPPRESS, ArgumentParser, Namespace
 import itertools
 from pathlib import Path
@@ -30,7 +30,7 @@ def main(params: Optional[List[str]] = None) -> None:
 def check_brille_settings(
         filename: str,
         npts: int = 500,
-        use_brille: bool = True,
+        use_brille: bool = True,  # noqa: ARG001  # Removal scheduled for v2
         brille_grid_type: str = 'trellis',
         brille_npts: int = 5000,
         brille_npts_density: Optional[int] = None,

--- a/euphonic/cli/show_sampling.py
+++ b/euphonic/cli/show_sampling.py
@@ -1,4 +1,4 @@
-# -*- coding: UTF-8 -*-
+# -*- coding: utf-8 -*-
 from argparse import ArgumentParser
 from typing import List, Optional
 

--- a/euphonic/cli/utils.py
+++ b/euphonic/cli/utils.py
@@ -564,10 +564,6 @@ def _get_cli_parser(features: Collection[str] = {},
             help=('Number of parallel processes for computing phonon modes. '
                   '(Only applies when using C extension.)'))
 
-    pdos_desc = ('coherent neutron-weighted DOS, incoherent '
-                 'neutron-weighted DOS or total (coherent + incoherent) '
-                 'neutron-weighted DOS')
-    ins_desc = ('coherent inelastic neutron scattering')
     if 'pdos-weighting' in features:
         # Currently do not support multiple PDOS for 2D plots
         if 'q-e' not in features:

--- a/euphonic/force_constants.py
+++ b/euphonic/force_constants.py
@@ -1043,6 +1043,7 @@ casting to real mode gradients.
         # minimise size of stored H_ab)
         n_elems = np.sum(range(1, n_atoms + 1))
         H_ab = np.zeros((0, n_elems, 3, 3))
+
         cells = np.zeros((0, 3))
         atom_r_cart = np.einsum('ij,jk->ik', atom_r, cell_vectors)
         atom_r_e = np.einsum('ij,jk->ik', atom_r_cart, inv_dielectric)
@@ -1051,7 +1052,7 @@ casting to real mode gradients.
             cells_cart = np.einsum('ij,jk->ik', cells_tmp, cell_vectors)
             cells_e = np.einsum(
                 'ij,jk->ik', cells_cart, inv_dielectric)
-            H_ab_tmp = np.zeros((len(cells_tmp), n_elems, 3, 3))
+            H_ab_tmp = np.zeros((len(cells_tmp), n_elems, 3, 3))  # noqa: N806
             for i in range(n_atoms):
                 idx = np.sum(range(n_atoms - i, n_atoms), dtype=np.int32)
                 for j in range(i, n_atoms):

--- a/euphonic/plot.py
+++ b/euphonic/plot.py
@@ -1,4 +1,5 @@
-from typing import Optional, Sequence, Tuple, Union
+from itertools import pairwise
+from typing import TYPE_CHECKING, Optional, Sequence, Tuple, Union
 
 try:
     from matplotlib.axes import Axes
@@ -18,6 +19,9 @@ import numpy as np
 from euphonic.spectra import Spectrum1D, Spectrum1DCollection, Spectrum2D
 from euphonic.ureg import Quantity
 from euphonic.util import zips
+
+if TYPE_CHECKING:
+    from matplotlib.lines import Line2D
 
 
 def plot_1d_to_axis(spectra: Union[Spectrum1D, Spectrum1DCollection],
@@ -71,10 +75,11 @@ def plot_1d_to_axis(spectra: Union[Spectrum1D, Spectrum1DCollection],
         labels = [spec.metadata.get('label', None) for spec in spectra]
 
     for label, spectrum in zips(labels, spectra):
+        p: list[Line2D] | None = None
         # Plot each line in segments
-        for x0, x1 in zips(breakpoints[:-1], breakpoints[1:]):
+        for x0, x1 in pairwise(breakpoints):
             # Keep colour consistent across segments
-            if x0 == 0:
+            if p is None:  # i.e. on first iteration
                 color = None
             else:
                 # Only add legend label to the first segment

--- a/euphonic/qpoint_phonon_modes.py
+++ b/euphonic/qpoint_phonon_modes.py
@@ -268,7 +268,7 @@ class QpointPhononModes(QpointFrequencies):
         # Eigenvectors are in Cartesian so need to convert hkl to
         # Cartesian by computing dot with hkl and reciprocal lattice
         recip = self.crystal.reciprocal_cell().to('1/bohr').magnitude
-        Q = np.einsum('ij,jk->ik', self.qpts, recip)
+        Q = np.einsum('ij,jk->ik', self.qpts, recip)  # noqa: N806
 
         # Calculate dot product of Q and eigenvectors for all branches
         # atoms and q-points
@@ -373,7 +373,7 @@ class QpointPhononModes(QpointFrequencies):
         """
 
         # Convert units
-        kB = (1*ureg.k).to('hartree/K').magnitude
+        k_B = (1 * ureg.k).to('hartree/K').magnitude
         n_atoms = self.crystal.n_atoms
         atom_mass = self.crystal._atom_mass
         freqs = self._frequencies
@@ -390,7 +390,7 @@ class QpointPhononModes(QpointFrequencies):
         freq_mask[freqs < freq_min] = 0
 
         if temp > 0:
-            x = freqs/(2*kB*temp)
+            x = freqs/(2 * k_B * temp)
             freq_term = 1/(freqs*np.tanh(x))
         else:
             freq_term = 1/(freqs)

--- a/euphonic/readers/castep.py
+++ b/euphonic/readers/castep.py
@@ -243,7 +243,7 @@ def read_phonon_data(
             idx += 1
 
     # Multiple qpts with same CASTEP q-pt index: correct weights
-    for _qpt_id, indices in repeated_qpt_ids.items():
+    for indices in repeated_qpt_ids.values():
         if (prefer_non_loto
             and (intersection := indices & loto_split_indices)
             and len(indices) > len(intersection)):

--- a/euphonic/readers/castep.py
+++ b/euphonic/readers/castep.py
@@ -100,13 +100,16 @@ def read_phonon_dos_data(
     data_dict['frequencies'] = ((freqs*(1/ureg.cm)).to(
         frequencies_unit)).magnitude
     data_dict['frequencies_unit'] = frequencies_unit
-    # Pint conversion 'angstrom*(1/cm)' to 'angstrom*(meV)' doesn't
-    # work so convert separately
-    mode_grads = mode_grads*ureg('angstrom').to(cell_vectors_unit).magnitude
-    data_dict['mode_gradients'] = mode_grads*ureg('1/cm').to(
-            frequencies_unit).magnitude
-    data_dict['mode_gradients_unit'] = (frequencies_unit + '*'
-                                        + cell_vectors_unit)
+    # Pint conversion 'angstrom * (1/cm)' to 'angstrom * (meV)' doesn't
+    # work so convert to meV first then go to specified units
+    mode_grads = (mode_grads * ureg("angstrom")
+                  ).to(cell_vectors_unit).magnitude
+    data_dict["mode_gradients"] = (
+        ((mode_grads * ureg("1/cm")).to("meV") * ureg("angstrom"))
+        .to(mode_gradients_unit)
+        .magnitude
+    )
+    data_dict['mode_gradients_unit'] = mode_gradients_unit
     data_dict['dos_bins'] = dos_data[:, 0]*ureg('1/cm').to(
             frequencies_unit).magnitude
     data_dict['dos_bins_unit'] = frequencies_unit

--- a/euphonic/readers/phonopy.py
+++ b/euphonic/readers/phonopy.py
@@ -710,9 +710,8 @@ def read_interpolation_data(
         n_atoms = summary_dict['n_atoms']
         n_cells = int(len(summary_dict['sc_atom_r'])/n_atoms)
         if fc_format == 'phonopy':
-            with open(fc_pathname, 'r') as fc_file:
-                summary_dict['force_constants'] = _extract_force_constants(
-                    fc_pathname, n_atoms, n_cells, summary_pathname)
+            summary_dict['force_constants'] = _extract_force_constants(
+                fc_pathname, n_atoms, n_cells, summary_pathname)
         elif fc_format in 'hdf5':
             summary_dict['force_constants'] =  _extract_force_constants_hdf5(
                 fc_pathname, n_atoms, n_cells, summary_pathname)

--- a/euphonic/structure_factor.py
+++ b/euphonic/structure_factor.py
@@ -330,11 +330,11 @@ class StructureFactor(QpointFrequencies):
                 'When calculating the Bose factor, no temperature was '
                 'provided, and no temperature could be found in '
                 'StructureFactor')
-        kB = (1*ureg.k).to('E_h/K').magnitude
+        k_B = (1*ureg.k).to('E_h/K').magnitude
         temp = temperature.to('K').magnitude
         bose = np.zeros(self._frequencies.shape)
         if temperature > 0:
-            bose = 1/(np.exp(np.absolute(self._frequencies)/(kB*temp)) - 1)
+            bose = 1/(np.exp(np.absolute(self._frequencies)/(k_B*temp)) - 1)
         else:
             bose = 0
         return bose

--- a/euphonic/util.py
+++ b/euphonic/util.py
@@ -495,10 +495,10 @@ def _calc_abscissa(reciprocal_cell: Quantity, qpts: np.ndarray
     # If delta is more than the tolerance, but delta_rem is less than
     # the tolerance, the q-points differ by G so are equivalent and the
     # distance shouldn't be calculated
-    TOL = 0.001
+    tol = 0.001
     calc_modq = np.logical_not(np.logical_and(
-        np.sum(np.abs(delta), axis=1) > TOL,
-        delta_rem < TOL))
+        np.sum(np.abs(delta), axis=1) > tol,
+        delta_rem < tol))
 
     # Multiply each delta by the recip lattice to get delta in Cartesian
     deltaq = np.einsum('ji,kj->ki', recip, delta)
@@ -645,21 +645,24 @@ def _get_qpt_label(qpt: np.ndarray,
 
     # Check for matching symmetry point coordinates (roll q-point
     # coordinates if no match is found)
-    TOL = 1e-6
+    atol = 1e-6
     matching_label_index = np.where((np.isclose(
-        label_coords, qpt_norm, atol=TOL)).all(axis=1))[0]
+        label_coords, qpt_norm, atol=atol)).all(axis=1))[0]
     if matching_label_index.size == 0:
         matching_label_index = np.where((np.isclose(
-            label_coords, np.roll(qpt_norm, 1), atol=TOL)).all(axis=1))[0]
+            label_coords, np.roll(qpt_norm, 1), atol=atol)).all(axis=1))[0]
     if matching_label_index.size == 0:
         matching_label_index = np.where((np.isclose(
-            label_coords, np.roll(qpt_norm, 2), atol=TOL)).all(axis=1))[0]
+            label_coords, np.roll(qpt_norm, 2), atol=atol)).all(axis=1))[0]
 
     label = ''
     if matching_label_index.size > 0:
         label = labels[matching_label_index[0]]
 
     return label
+
+
+CHUNK_SIZE = 100
 
 
 def _get_supercell_relative_idx(cell_origins: np.ndarray,
@@ -702,11 +705,10 @@ def _get_supercell_relative_idx(cell_origins: np.ndarray,
         # equivalent
         # Do calculation in chunks, so loop can be broken if all
         # equivalent vectors have been found
-        N = 100
         dist_min = np.full((n_cells), sys.float_info.max)
-        for i in range(int((n_cells - 1)/N) + 1):
-            ci = i*N
-            cf = min((i + 1)*N, n_cells)
+        for i in range(int((n_cells - 1) / CHUNK_SIZE) + 1):
+            ci = i * CHUNK_SIZE
+            cf = min((i + 1) * CHUNK_SIZE, n_cells)
             dist = (inter_cell_vectors[:, ax, :]
                     - cell_origins_sc[ax, ci:cf, :])
             dist_frac = dist - np.rint(dist)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,7 +77,6 @@ extend-exclude = ["doc/source/conf.py"]
 preview = true
 explicit-preview-rules = true
 select = [
-       "I",       # isort
        "ERA001",  # Eradicate commented-out code
        "YTT",     # Flake8-2020
        # "ANN",   # Full type annotation, not realistic right now
@@ -112,7 +111,14 @@ select = [
        "TID",     # flake8-tidy-imports
        "TD",      # flake8-todos
        "TC",      # flake8-type-checking
-       "ARG",
+       "ARG",     # flake8-unused-arguments
+       # "PTH",     # flake8-use-pathlib : would love to but maybe easier with API breaks
+       "FLY",     # flynt
+       "I",       # isort
+       # "C90",     # mccabe : code complexity check. Worth a look but non-trivial
+       # "NPY",   # NumPy-specific rules : good stuff, worth its own PR
+       "N",       # pep8-naming
+       "PERF",    # Perflint
        "F401",    # unused-import
        # "F821",    # undefined-name : This is useful for missing imports, but currently catches a few other things
        "W291",    # trailing-whitespace
@@ -127,6 +133,7 @@ ignore = [
        "S101",    # Use of except
        "CPY001",  # Missing copyright notice at top of every file. Not for us.
        "T20",     # flake8-print forbids use of print and pprint.
+       "PERF203", # No try-except in loop. Micro-optimisation, not relevant for Py 3.11+
        ]
 task-tags = ["Note"]  # Avoid false positives for ERA001 on lines like "# Note: CODE-LIKE-THINGS"
 
@@ -139,6 +146,9 @@ inline-quotes = "single"
 
 [tool.ruff.lint.isort]
 force-sort-within-sections = true
+
+[tool.ruff.lint.pep8-naming]
+extend-ignore-names = ["k_B", "H_ab"]
 
 [tool.ruff.lint.per-file-ignores]
 "tests_and_analysis/test/**/*" = ["ARG"]  # pytest fixtures can look like unused arguments

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -120,6 +120,11 @@ select = [
        "N",       # pep8-naming
        "PERF",    # Perflint
        "F401",    # unused-import
+       # "E",     # pycodestyle error: this is a lot of stuff
+       "W",       # pycodestyle warning
+       "DOC",     # pydoclint
+       # "D",     # 2000 errors, code sprint material?
+       "F",
        # "F821",    # undefined-name : This is useful for missing imports, but currently catches a few other things
        "W291",    # trailing-whitespace
        "W293",    # blank-line-with-whitespace

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,6 +107,12 @@ select = [
        "RSE",     # flake8-raise
        "RET",     # flake8-return
        # "SLF",     # flake8-self : would be good to take a closer look at some of this private attribute access
+       # "SIM",   # flake8-simplify : good stuff, worth its own PR
+       "SLOT",    # flake8-slots
+       "TID",     # flake8-tidy-imports
+       "TD",      # flake8-todos
+       "TC",      # flake8-type-checking
+       "ARG",
        "F401",    # unused-import
        # "F821",    # undefined-name : This is useful for missing imports, but currently catches a few other things
        "W291",    # trailing-whitespace
@@ -133,3 +139,6 @@ inline-quotes = "single"
 
 [tool.ruff.lint.isort]
 force-sort-within-sections = true
+
+[tool.ruff.lint.per-file-ignores]
+"tests_and_analysis/test/**/*" = ["ARG"]  # pytest fixtures can look like unused arguments

--- a/tests_and_analysis/test/euphonic_test/test_broadening.py
+++ b/tests_and_analysis/test/euphonic_test/test_broadening.py
@@ -21,8 +21,7 @@ from tests_and_analysis.test.euphonic_test.test_qpoint_frequencies import (
 from tests_and_analysis.test.euphonic_test.test_spectrum1d import (
     get_expected_spectrum1d,
 )
-
-from ..utils import get_mode_widths
+from tests_and_analysis.test.utils import get_mode_widths
 
 
 def test_variable_close_to_exact():

--- a/tests_and_analysis/test/euphonic_test/test_calculate_structure_factor.py
+++ b/tests_and_analysis/test/euphonic_test/test_calculate_structure_factor.py
@@ -175,8 +175,8 @@ class TestCalculateStructureFactorFromQpointPhononModes:
     def test_incompatible_debye_waller_raises_valueerror(
             self, qpt_ph_modes, dw_material, dw_file):
         with pytest.raises(ValueError):
-             qpt_ph_modes.calculate_structure_factor(
-                 dw=get_dw(dw_material, dw_file))
+            qpt_ph_modes.calculate_structure_factor(
+                dw=get_dw(dw_material, dw_file))
 
 
 class TestCalculateStructureFactorUsingReferenceData:

--- a/tests_and_analysis/test/euphonic_test/test_calculate_structure_factor.py
+++ b/tests_and_analysis/test/euphonic_test/test_calculate_structure_factor.py
@@ -175,8 +175,8 @@ class TestCalculateStructureFactorFromQpointPhononModes:
     def test_incompatible_debye_waller_raises_valueerror(
             self, qpt_ph_modes, dw_material, dw_file):
         with pytest.raises(ValueError):
-            sf = qpt_ph_modes.calculate_structure_factor(
-                dw=get_dw(dw_material, dw_file))
+             qpt_ph_modes.calculate_structure_factor(
+                 dw=get_dw(dw_material, dw_file))
 
 
 class TestCalculateStructureFactorUsingReferenceData:

--- a/tests_and_analysis/test/euphonic_test/test_plot.py
+++ b/tests_and_analysis/test/euphonic_test/test_plot.py
@@ -306,7 +306,7 @@ class TestPlot1D:
 
     def test_plot_with_incorrect_labels_raises_valueerror(self, band_segments):
         with pytest.raises(ValueError):
-            fig = plot_1d(band_segments, labels=['Band A', 'Band B'])
+             plot_1d(band_segments, labels=['Band A', 'Band B'])
 
     @pytest.mark.parametrize('spec, kwargs', [
         (Spectrum1D(*spec1d_args), {'ls': '.-'}),

--- a/tests_and_analysis/test/euphonic_test/test_plot.py
+++ b/tests_and_analysis/test/euphonic_test/test_plot.py
@@ -4,8 +4,7 @@ import pytest
 
 from euphonic import ureg
 from euphonic.spectra import Spectrum1D, Spectrum1DCollection
-
-from ..script_tests.utils import get_ax_image_data
+from tests_and_analysis.test.script_tests.utils import get_ax_image_data
 
 # Allow tests with matplotlib marker to be collected and
 # deselected if Matplotlib is not installed

--- a/tests_and_analysis/test/euphonic_test/test_plot.py
+++ b/tests_and_analysis/test/euphonic_test/test_plot.py
@@ -306,7 +306,7 @@ class TestPlot1D:
 
     def test_plot_with_incorrect_labels_raises_valueerror(self, band_segments):
         with pytest.raises(ValueError):
-             plot_1d(band_segments, labels=['Band A', 'Band B'])
+            plot_1d(band_segments, labels=['Band A', 'Band B'])
 
     @pytest.mark.parametrize('spec, kwargs', [
         (Spectrum1D(*spec1d_args), {'ls': '.-'}),

--- a/tests_and_analysis/test/euphonic_test/test_spectrum1dcollection.py
+++ b/tests_and_analysis/test/euphonic_test/test_spectrum1dcollection.py
@@ -230,31 +230,31 @@ class TestSpectrum1DCollectionCreation:
 
     bad_sequences = [
         [
-            ["NotASpectrum", get_spectrum1d(f"gan_bands_index_2.json")],
+            ["NotASpectrum", get_spectrum1d("gan_bands_index_2.json")],
             TypeError,
         ],
         [
-            [get_spectrum1d(f"gan_bands_index_2.json"), "NotASpectrum"],
+            [get_spectrum1d("gan_bands_index_2.json"), "NotASpectrum"],
             TypeError,
         ],
         [
             [
-                get_spectrum1d(f"gan_bands_index_2.json"),
-                get_spectrum1d(f"methane_pdos_index_1.json"),
+                get_spectrum1d("gan_bands_index_2.json"),
+                get_spectrum1d("methane_pdos_index_1.json"),
             ],
             ValueError,
         ],
         [
             [
-                get_spectrum1d(f"gan_bands_index_2.json"),
-                get_spectrum1d(f"gan_bands_index_3.json"),
+                get_spectrum1d("gan_bands_index_2.json"),
+                get_spectrum1d("gan_bands_index_3.json"),
             ],
             ValueError,
         ],
         [
             [
-                get_spectrum1d(f"gan_bands_index_2.json"),
-                get_spectrum1d(f"gan_bands_index_3.json"),
+                get_spectrum1d("gan_bands_index_2.json"),
+                get_spectrum1d("gan_bands_index_3.json"),
             ],
             ValueError,
         ],
@@ -274,8 +274,8 @@ class TestSpectrum1DCollectionCreation:
     def test_unsafe_from_sequence(self):
         """Ensure that unsafe from_spectra doesn't check units"""
 
-        spec1 = get_spectrum1d(f'gan_bands_index_2.json')
-        spec2 = get_spectrum1d(f'gan_bands_index_3.json')
+        spec1 = get_spectrum1d('gan_bands_index_2.json')
+        spec2 = get_spectrum1d('gan_bands_index_3.json')
 
         spec1.x_data_unit = '1/angstrom'
         spec2.x_data_unit = '1/mm'

--- a/tests_and_analysis/test/euphonic_test/test_structure_factor.py
+++ b/tests_and_analysis/test/euphonic_test/test_structure_factor.py
@@ -436,7 +436,7 @@ class TestStructureFactorCalculateSqwMap:
         sf = get_sf('CaHgO2', 'CaHgO2_300K_fc_structure_factor.json')
         ebins = np.array([0, 50, 100, 150, 200, 250, 300])*ureg('1/cm')
         with warnings.catch_warnings(record=True) as warn_record:
-            sqw = sf.calculate_sqw_map(ebins)
+             sf.calculate_sqw_map(ebins)
         assert len(warn_record) == 0
 
     @pytest.mark.parametrize(
@@ -507,5 +507,5 @@ class TestStructureFactorCalculateDos:
             'quartz', 'quartz_666_300K_structure_factor.json')
         ebins = np.arange(0, 1300, 4)*ureg('1/cm')
         with warnings.catch_warnings(record=True) as warn_record:
-            dos = sf.calculate_dos(ebins)
+             sf.calculate_dos(ebins)
         assert len(warn_record) == 0

--- a/tests_and_analysis/test/script_tests/test_brille_convergence.py
+++ b/tests_and_analysis/test/script_tests/test_brille_convergence.py
@@ -143,14 +143,14 @@ class TestRegression:
         # Stop execution once from_fc has been called - we're only
         # checking here that the correct arguments have been passed
         # through
-        class MockException(Exception):
+        class MockError(Exception):
             pass
         mock = mocker.patch.object(BrilleInterpolator, 'from_force_constants',
-                                   side_effect=MockException())
+                                   side_effect=MockError())
         try:
             euphonic.cli.brille_convergence.main(
                 [graphite_fc_file] + brille_conv_args)
-        except MockException:
+        except MockError:
             pass
         default_interp_kwargs =  {'asr': None, 'dipole_parameter': 1.0,
                                   'n_threads': None, 'use_c': None}

--- a/tests_and_analysis/test/script_tests/test_brille_convergence.py
+++ b/tests_and_analysis/test/script_tests/test_brille_convergence.py
@@ -144,7 +144,8 @@ class TestRegression:
         # checking here that the correct arguments have been passed
         # through
         class MockError(Exception):
-            pass
+            """Throw exception to stop working on Brille interpolator"""
+
         mock = mocker.patch.object(BrilleInterpolator, 'from_force_constants',
                                    side_effect=MockError())
         try:

--- a/tests_and_analysis/test/script_tests/test_powder_map.py
+++ b/tests_and_analysis/test/script_tests/test_powder_map.py
@@ -163,14 +163,14 @@ class TestRegression:
         # Stop execution once from_fc has been called - we're only
         # checking here that the correct arguments have been passed
         # through
-        class MockException(Exception):
+        class MockError(Exception):
             pass
         mock = mocker.patch.object(BrilleInterpolator, 'from_force_constants',
-                                   side_effect=MockException())
+                                   side_effect=MockError())
         try:
             euphonic.cli.powder_map.main(
                 [graphite_fc_file] + powder_map_args + quick_calc_params)
-        except MockException:
+        except MockError:
             pass
         default_interp_kwargs =  {'asr': None, 'dipole_parameter': 1.0,
                                   'n_threads': None, 'use_c': None}

--- a/tests_and_analysis/test/script_tests/test_powder_map.py
+++ b/tests_and_analysis/test/script_tests/test_powder_map.py
@@ -164,7 +164,8 @@ class TestRegression:
         # checking here that the correct arguments have been passed
         # through
         class MockError(Exception):
-            pass
+            """Throw exception to stop working on Brille interpolator"""
+
         mock = mocker.patch.object(BrilleInterpolator, 'from_force_constants',
                                    side_effect=MockError())
         try:

--- a/tests_and_analysis/test/script_tests/utils.py
+++ b/tests_and_analysis/test/script_tests/utils.py
@@ -10,7 +10,7 @@ try:
 except ModuleNotFoundError:
     pass
 
-from ..utils import get_data_path
+from tests_and_analysis.test.utils import get_data_path
 
 
 def args_to_key(cl_args: List[str]) -> str:

--- a/tests_and_analysis/test/script_tests/utils.py
+++ b/tests_and_analysis/test/script_tests/utils.py
@@ -52,19 +52,14 @@ def get_plot_line_data(fig: Optional['matplotlib.figure.Figure'] = None
 
 
 def get_all_figs() -> List['matplotlib.figure.Figure']:
-    all_figs = []
     fignums = matplotlib.pyplot.get_fignums()
-    for fignum in fignums:
-        all_figs.append(matplotlib.pyplot.figure(fignum))
-    return all_figs
+    return [matplotlib.pyplot.figure(fignum) for fignum in fignums]
+
 
 
 def get_all_plot_line_data(figs: List['matplotlib.figure.Figure']
                            ) -> List[Dict[str, Any]]:
-    data = []
-    for fig in figs:
-        data.append(get_plot_line_data(fig))
-    return data
+    return [get_plot_line_data(fig) for fig in figs]
 
 
 def get_fig_label_data(fig) -> Dict[str, Union[str, List[str]]]:

--- a/tests_and_analysis/test/utils.py
+++ b/tests_and_analysis/test/utils.py
@@ -241,7 +241,7 @@ def check_json_metadata(json_file: str, class_name: str) -> None:
     assert data['__euphonic_version__'] == __version__
 
 
-def sum_at_degenerate_modes(values_to_sum, frequencies, TOL=0.05):
+def sum_at_degenerate_modes(values_to_sum, frequencies, tol=0.05):
     """
     For degenerate frequency modes, eigenvectors are an arbitrary
     admixture, so derived quantities (e.g. structure factors) can
@@ -268,8 +268,8 @@ def sum_at_degenerate_modes(values_to_sum, frequencies, TOL=0.05):
         value_sum = np.expand_dims(value_sum, -1)
         values_to_sum = np.expand_dims(values_to_sum, -1)
     for i in range(len(frequencies)):
-        diff = np.append(TOL + 1, np.diff(frequencies[i]))
-        unique_index = np.where(diff > TOL)[0]
+        diff = np.append(tol + 1, np.diff(frequencies[i]))
+        unique_index = np.where(diff > tol)[0]
         x = np.zeros(len(frequencies[0]), dtype=np.int32)
         x[unique_index] = 1
         unique_modes = np.cumsum(x) - 1


### PR DESCRIPTION
Mostly trivial linter stuff, but:

- the reworked loop in broadening.py is a more substantial change, but should be safer in the end.
- found a bug in CASTEP mode gradients; units parameter ignored. This shouldn't have led to inconsistent results as returned data had consistent units and values; but if you blindly used the results with provided units there could be trouble.