### PR TITLE
Linting: ruff autofix flake8-commas (COM)

### DIFF
--- a/build_utils/bump_changelog.py
+++ b/build_utils/bump_changelog.py
@@ -54,7 +54,7 @@ def parse_changelog(changelog_file: Path) -> list[Block]:
     with changelog_file.open(encoding="utf8") as fd:
         split_text = re.split(
             LINK_STRING.replace(".", r"\.").format(
-                tag=r"(\S+)", previous_tag=r"(\S+)", compare_tag=r"\S+"
+                tag=r"(\S+)", previous_tag=r"(\S+)", compare_tag=r"\S+",
             )
             + r"\n-+",
             fd.read(),

--- a/build_utils/release.py
+++ b/build_utils/release.py
@@ -57,7 +57,7 @@ def release_github(test=True):
         "name": euphonic_ver,
         "body": desc,
         "draft": False,
-        "prerelease": is_prerelease
+        "prerelease": is_prerelease,
     }
     if test:
         print(payload)

--- a/build_utils/version.py
+++ b/build_utils/version.py
@@ -42,7 +42,7 @@ for gitcmd in gits:
     try:
         print(f"Trying {gitcmd} ...", file=sys.stderr)
         proc = subprocess.run([gitcmd, "describe", "--tags", "--dirty"],  # noqa: S603
-                              capture_output=True, check=True, text=True
+                              capture_output=True, check=True, text=True,
                               )
     except FileNotFoundError:
         print(f"Tried {gitcmd}, File Not Found", file=sys.stderr)

--- a/euphonic/brille.py
+++ b/euphonic/brille.py
@@ -69,7 +69,7 @@ class BrilleInterpolator:
         """Get the Brille grid object."""
         return self._grid
 
-    def calculate_qpoint_phonon_modes(self, qpts: np.ndarray, **kwargs
+    def calculate_qpoint_phonon_modes(self, qpts: np.ndarray, **kwargs,
                                       ) -> QpointPhononModes:
         """
         Calculate phonon frequencies and eigenvectors at specified
@@ -96,7 +96,7 @@ class BrilleInterpolator:
         return QpointPhononModes(
             self.crystal, qpts, vals, vecs)
 
-    def calculate_qpoint_frequencies(self, qpts: np.ndarray, **kwargs
+    def calculate_qpoint_frequencies(self, qpts: np.ndarray, **kwargs,
                                       ) -> QpointFrequencies:
         """
         Calculate phonon frequencies at specified

--- a/euphonic/broadening.py
+++ b/euphonic/broadening.py
@@ -32,7 +32,7 @@ def variable_width_broadening(
     width_convention: Literal['fwhm', 'std'] = 'fwhm',
     adaptive_error: float = 1e-2,
     shape: KernelShape = 'gauss',
-    fit: ErrorFit = 'cheby-log'
+    fit: ErrorFit = 'cheby-log',
     ) -> Quantity:
     r"""Apply x-dependent Gaussian broadening to 1-D data series
 
@@ -112,7 +112,7 @@ def width_interpolated_broadening(
     weights: np.ndarray,
     adaptive_error: float,
     shape: KernelShape = 'gauss',
-    fit: ErrorFit = 'cheby-log'
+    fit: ErrorFit = 'cheby-log',
     ) -> Quantity:
     """
     Uses a fast, approximate method to broaden a spectrum
@@ -246,10 +246,10 @@ def _width_interpolated_broadening(
         x_values = np.arange(-int(len(bins)/2), int(len(bins)/2)+1)*bin_width
 
     if shape == 'gauss':
-        kernels = norm.pdf(x_values, scale=width_samples[:, np.newaxis]
+        kernels = norm.pdf(x_values, scale=width_samples[:, np.newaxis],
                            ) * bin_width
     elif shape == 'lorentz':
-        kernels = _lorentzian(x_values, gamma=width_samples[:, np.newaxis]
+        kernels = _lorentzian(x_values, gamma=width_samples[:, np.newaxis],
                               ) * bin_width
 
     kernels_idx = np.searchsorted(width_samples, widths, side="right")

--- a/euphonic/cli/brille_convergence.py
+++ b/euphonic/cli/brille_convergence.py
@@ -41,7 +41,7 @@ def check_brille_settings(
         e_max: Optional[float] = None,
         energy_unit: str = 'meV',
         shape: str = 'gauss',
-        **calc_modes_kwargs
+        **calc_modes_kwargs,
         ) -> None:
 
     fc = load_data_from_file(filename)
@@ -200,7 +200,7 @@ def plot_to_intensity_axes(axes: tuple[Axes, Axes], sqw1d: Spectrum1D,
 
 
 def add_intensity_legend(axes: tuple[Axes, Axes], euphonic_handle: Line2D,
-                         brille_handles: Sequence[Line2D], title: str
+                         brille_handles: Sequence[Line2D], title: str,
                          ) -> None:
     euph_legend = axes[0].legend(handles=[euphonic_handle], loc='upper left')
     axes[0].add_artist(euph_legend)

--- a/euphonic/cli/dos.py
+++ b/euphonic/cli/dos.py
@@ -88,7 +88,7 @@ def main(params: Optional[list[str]] = None) -> None:
                 mode_widths = sqrt(
                     mode_widths**2
                     + (energy_broadening_poly(modes.frequencies
-                                              .to(args.energy_unit).magnitude
+                                              .to(args.energy_unit).magnitude,
                                               ) * ureg(args.energy_unit))**2)
         else:
             modes = data.calculate_qpoint_phonon_modes(
@@ -118,7 +118,7 @@ def main(params: Optional[list[str]] = None) -> None:
     elif (args.inst_broadening and len(energy_broadening_poly) > 1):
         # Variable-width Gaussian broadening
         def energy_broadening_func(x):
-            return energy_broadening_poly(x.to(args.energy_unit).magnitude
+            return energy_broadening_poly(x.to(args.energy_unit).magnitude,
                                           ) * ureg(args.energy_unit)
 
         dos = dos.broaden(x_width=energy_broadening_func,

--- a/euphonic/cli/optimise_dipole_parameter.py
+++ b/euphonic/cli/optimise_dipole_parameter.py
@@ -32,7 +32,7 @@ def calculate_optimum_dipole_parameter(
         dipole_parameter_step: float = 0.25,
         n: int = 500,
         print_to_terminal: bool = False,
-        **calc_modes_kwargs
+        **calc_modes_kwargs,
         ) -> tuple[float, float, float, np.ndarray, np.ndarray, np.ndarray]:
     """
     Calculate the optimum dipole_parameter and other dipole_parameters

--- a/euphonic/cli/powder_map.py
+++ b/euphonic/cli/powder_map.py
@@ -103,7 +103,7 @@ def _get_broaden_kwargs(q_broadening: Optional[Sequence[float]] = None,
         q_poly = Polynomial(q_broadening)
 
         def q_width(x):
-            return q_poly(x.to(q_unit).magnitude
+            return q_poly(x.to(q_unit).magnitude,
                           ) * q_unit
     elif q_broadening:
         q_width = q_broadening[0] * q_unit
@@ -114,7 +114,7 @@ def _get_broaden_kwargs(q_broadening: Optional[Sequence[float]] = None,
         energy_poly = Polynomial(energy_broadening)
 
         def energy_width(x):
-            return energy_poly(x.to(energy_unit).magnitude
+            return energy_poly(x.to(energy_unit).magnitude,
                                ) * ureg(energy_unit)
     elif energy_broadening:
         energy_width = energy_broadening[0] * ureg(energy_unit)

--- a/euphonic/cli/show_sampling.py
+++ b/euphonic/cli/show_sampling.py
@@ -98,7 +98,7 @@ def main(params: Optional[list[str]] = None) -> None:
     elif args.sampling == "random-sphere":
         ax.scatter(
             *zips(*euphonic.sampling.random_sphere(args.npts)),
-            marker="x"
+            marker="x",
         )
 
     elif args.sampling == "recurrence-cube":

--- a/euphonic/cli/utils.py
+++ b/euphonic/cli/utils.py
@@ -30,7 +30,7 @@ import euphonic.util
 
 
 def _load_euphonic_json(filename: str | os.PathLike,
-                        frequencies_only: bool = False
+                        frequencies_only: bool = False,
                         ) -> QpointPhononModes | QpointFrequencies | ForceConstants:
     with open(filename) as f:
         data = json.load(f)
@@ -46,7 +46,7 @@ def _load_euphonic_json(filename: str | os.PathLike,
 
 
 def _load_phonopy_file(filename: str | os.PathLike,
-                       frequencies_only: bool = False
+                       frequencies_only: bool = False,
                        ) -> QpointPhononModes | QpointFrequencies | ForceConstants:
     path = pathlib.Path(filename)
     loaded_data = None
@@ -99,7 +99,7 @@ def _load_phonopy_file(filename: str | os.PathLike,
 
 def load_data_from_file(filename: str | os.PathLike,
                         frequencies_only: bool = False,
-                        verbose: bool = False
+                        verbose: bool = False,
                         ) -> QpointPhononModes | QpointFrequencies | ForceConstants:
     """
     Load phonon mode or force constants data from file
@@ -146,7 +146,7 @@ def load_data_from_file(filename: str | os.PathLike,
     return data
 
 
-def get_args(parser: ArgumentParser, params: Optional[list[str]] = None
+def get_args(parser: ArgumentParser, params: Optional[list[str]] = None,
              ) -> Namespace:
     """
     Get the arguments from the parser. params should only be none when
@@ -286,7 +286,7 @@ def _insert_gamma(bandpath: dict) -> None:
     This enables LO-TO splitting to be included
     """
     import numpy as np
-    gamma_indices = np.where(np.array(bandpath['explicit_kpoints_labels'][1:-1]
+    gamma_indices = np.where(np.array(bandpath['explicit_kpoints_labels'][1:-1],
                                       ) == 'GAMMA')[0] + 1
 
     rel_kpts = bandpath['explicit_kpoints_rel'].tolist()
@@ -313,7 +313,7 @@ def _bands_from_force_constants(data: ForceConstants,
                                 q_distance: Quantity,
                                 insert_gamma: bool = True,
                                 frequencies_only: bool = False,
-                                **calc_modes_kwargs
+                                **calc_modes_kwargs,
                                 ) -> tuple[QpointPhononModes | QpointFrequencies,
                                            XTickLabels, SplitArgs]:
     structure = data.crystal.to_spglib_cell()
@@ -350,7 +350,7 @@ def _bands_from_force_constants(data: ForceConstants,
 
 def _grid_spec_from_args(crystal: Crystal,
                            grid: Optional[Sequence[int]] = None,
-                           grid_spacing: Quantity = 0.1 * ureg('1/angstrom')
+                           grid_spacing: Quantity = 0.1 * ureg('1/angstrom'),
                            ) -> tuple[int, int, int]:
     """Get Monkorst-Pack mesh divisions from user arguments"""
     if grid:
@@ -364,7 +364,7 @@ def _get_debye_waller(temperature: Quantity,
                       fc: ForceConstants,
                       grid: Optional[Sequence[int]] = None,
                       grid_spacing: Quantity = 0.1 * ureg('1/angstrom'),
-                      **calc_modes_kwargs
+                      **calc_modes_kwargs,
                       ) -> DebyeWaller:
     """Generate Debye-Waller data from force constants and grid specification
     """
@@ -394,7 +394,7 @@ def _get_pdos_weighting(cl_arg_weighting: str) -> Optional[str]:
 
 
 def _arrange_pdos_groups(pdos: Spectrum1DCollection,
-                         cl_arg_pdos: Sequence[str]
+                         cl_arg_pdos: Sequence[str],
                          ) -> Spectrum1D | Spectrum1DCollection:
     """
     Convert PDOS returned by calculate_pdos to PDOS/DOS
@@ -450,7 +450,7 @@ def _brille_calc_modes_kwargs(args: Namespace) -> dict[str, Any]:
 
 
 def _get_cli_parser(features: Collection[str] = {},
-                    conflict_handler: str = 'error'
+                    conflict_handler: str = 'error',
                     ) -> tuple[ArgumentParser,
                                dict[str, _ArgumentGroup]]:
     """Instantiate an ArgumentParser with appropriate argument groups
@@ -496,7 +496,7 @@ def _get_cli_parser(features: Collection[str] = {},
                     ('plotting', 'Plotting arguments'),
                     ('performance', 'Performance-related arguments'),
                     ('brille', 'Brille interpolation related arguments. '
-                               'Only applicable if Brille has been installed.')
+                               'Only applicable if Brille has been installed.'),
                     ]
 
     sections = {label: parser.add_argument_group(doc)
@@ -726,7 +726,7 @@ def _get_cli_parser(features: Collection[str] = {},
                 section.add_argument(
                     '--adaptive-scale', type=float, default=None,
                     dest='adaptive_scale',
-                    help='Scale factor applied to adaptive broadening width'
+                    help='Scale factor applied to adaptive broadening width',
                     )
                 section.add_argument(
                     '--adaptive-fit', type=str, choices=['cubic', 'cheby-log'],
@@ -736,7 +736,7 @@ def _get_cli_parser(features: Collection[str] = {},
                           'default retained for backward-compatibility. This '
                           'only applies when adaptive broadening is used; if '
                           'variable-width instrument broadening is used alone '
-                          'then "cheby-log" will be used.' )
+                          'then "cheby-log" will be used.' ),
                     )
                 section.add_argument(
                     '--instrument-broadening', type=float, nargs='+',
@@ -841,25 +841,25 @@ def _get_cli_parser(features: Collection[str] = {},
             type=int,
             help=('The number of times to loop over q-points. A higher '
                   'value will get a more reliable timing, but will take '
-                  'longer')
+                  'longer'),
         )
         parser.add_argument(
             '--dipole-parameter-min', '--min',
             default=0.25,
             type=float,
-            help='The minimum value of dipole_parameter to test'
+            help='The minimum value of dipole_parameter to test',
         )
         parser.add_argument(
             '--dipole-parameter-max', '--max',
             default=1.5,
             type=float,
-            help='The maximum value of dipole_parameter to test'
+            help='The maximum value of dipole_parameter to test',
         )
         parser.add_argument(
             '--dipole-parameter-step', '--step',
             default=0.25,
             type=float,
-            help='The difference between each dipole_parameter to test'
+            help='The difference between each dipole_parameter to test',
         )
 
     return parser, sections
@@ -869,7 +869,7 @@ MplStyle = str | dict[str, str]
 
 
 def _compose_style(
-        *, user_args: Namespace, base: Optional[list[MplStyle]]
+        *, user_args: Namespace, base: Optional[list[MplStyle]],
         ) -> list[MplStyle]:
     """Combine user-specified style options with default stylesheets
 

--- a/euphonic/crystal.py
+++ b/euphonic/crystal.py
@@ -140,7 +140,7 @@ class Crystal:
         return _cell_vectors_to_volume(self.cell_vectors)
 
     def get_mp_grid_spec(self,
-                         spacing: Quantity = 0.1 * ureg('1/angstrom')
+                         spacing: Quantity = 0.1 * ureg('1/angstrom'),
                          ) -> tuple[int, int, int]:
         """
         Get suggested divisions for Monkhorst-Pack grid
@@ -162,7 +162,7 @@ class Crystal:
 
         recip_length_unit = spacing.units
         lattice = self.reciprocal_cell().to(recip_length_unit)
-        grid_spec = np.linalg.norm(lattice.magnitude, axis=1
+        grid_spec = np.linalg.norm(lattice.magnitude, axis=1,
                                    ) / spacing.magnitude
         # math.ceil is better than np.ceil because it returns ints
         return tuple(ceil(x) for x in grid_spec)
@@ -204,7 +204,7 @@ class Crystal:
                             for key, value in species_dict.items()])
 
     def get_symmetry_equivalent_atoms(
-            self, tol: Quantity = Quantity(1e-5, 'angstrom')
+            self, tol: Quantity = Quantity(1e-5, 'angstrom'),
             ) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
         """
         Returns the rotational and translational symmetry operations

--- a/euphonic/force_constants.py
+++ b/euphonic/force_constants.py
@@ -189,7 +189,7 @@ class ForceConstants:
             reduce_qpts: bool = True,
             use_c: Optional[bool] = None,
             n_threads: Optional[int] = None,
-            return_mode_gradients: bool = False
+            return_mode_gradients: bool = False,
             ) -> QpointPhononModes | tuple[QpointPhononModes, Quantity]:
         """
         Calculate phonon frequencies and eigenvectors at specified
@@ -529,7 +529,7 @@ class ForceConstants:
                 # so each gamma can have its own splitting
                 qpts_i[gamma_i[1:]] = range(n_rqpts, n_rqpts + n_gamma - 1)
                 reduced_qpts = np.append(reduced_qpts,
-                                         np.tile(np.array([0., 0., 0., ]),
+                                         np.tile(np.array([0., 0., 0. ]),
                                                  (n_gamma - 1, 1)),
                                          axis=0)
                 n_rqpts = len(reduced_qpts)
@@ -756,7 +756,7 @@ casting to real mode gradients.
             dyn_mat_weighting: np.ndarray,
             recip_asr_correction: np.ndarray,
             dipole: bool,
-            q_dir: Optional[np.ndarray] = None
+            q_dir: Optional[np.ndarray] = None,
             ) -> tuple[np.ndarray, np.ndarray, np.ndarray | None]:
         """
         Given a q-point and some precalculated q-independent values,
@@ -964,7 +964,7 @@ casting to real mode gradients.
     def _dipole_correction_init(crystal: Crystal,
                                 born: np.ndarray,
                                 dielectric: np.ndarray,
-                                dipole_parameter: float = 1.0
+                                dipole_parameter: float = 1.0,
                                 ) -> dict[str, float | np.ndarray]:
         """
         Calculate the q-independent parts of the long range correction
@@ -1149,7 +1149,7 @@ casting to real mode gradients.
     def _calculate_dipole_correction(
             q: np.ndarray, crystal: Crystal, born: np.ndarray,
             dielectric: np.ndarray,
-            dipole_init_data: dict[str, float | np.ndarray]
+            dipole_init_data: dict[str, float | np.ndarray],
             ) -> np.ndarray:
         """
         Calculate the long range correction to the dynamical matrix
@@ -1423,7 +1423,7 @@ casting to real mode gradients.
                         (n_cells_in_sc, 3*n_atoms, 3*n_atoms))
 
 
-    def _enforce_reciprocal_asr(self, dyn_mat_gamma: np.ndarray
+    def _enforce_reciprocal_asr(self, dyn_mat_gamma: np.ndarray,
             ) -> np.ndarray:
         """
         Calculate the correction to the dynamical matrix that would have
@@ -1466,7 +1466,7 @@ casting to real mode gradients.
 
         return recip_asr_correction
 
-    def _find_acoustic_modes(self, dyn_mat: np.ndarray
+    def _find_acoustic_modes(self, dyn_mat: np.ndarray,
             ) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
         """
         Find the acoustic modes from a dynamical matrix, they should
@@ -1642,7 +1642,7 @@ casting to real mode gradients.
                     dist_wsp = np.absolute(np.sum(dists*wsp, axis=-1))
                     if n == 0:
                         nc_idx, nj_idx = np.where(
-                            dist_wsp <= (0.5*cutoff_scale + 0.001)
+                            dist_wsp <= (0.5*cutoff_scale + 0.001),
                         )
                         # Reindex dists to remove elements where the ion
                         # is > halfway to WS point for efficiency
@@ -1651,7 +1651,7 @@ casting to real mode gradients.
                         # After first reindex, dists is now 1D so need
                         # to reindex like this instead
                         idx = np.where(
-                            dist_wsp <= (0.5*cutoff_scale + 0.001)
+                            dist_wsp <= (0.5*cutoff_scale + 0.001),
                         )[0]
                         nc_idx = nc_idx[idx]
                         nj_idx = nj_idx[idx]

--- a/euphonic/io.py
+++ b/euphonic/io.py
@@ -20,7 +20,7 @@ def _to_json_dict(dictionary: dict[str, Any]) -> dict[str, Any]:
     for key, val in dictionary.items():
         if isinstance(val, np.ndarray):
             if val.dtype == np.complex128:
-                val = val.view(np.float64                   # noqa: PLW2901
+                val = val.view(np.float64,                   # noqa: PLW2901
                                ).reshape([*val.shape, 2])
             dictionary[key] = val.tolist()
         elif isinstance(val, dict):

--- a/euphonic/powder.py
+++ b/euphonic/powder.py
@@ -28,7 +28,7 @@ def sample_sphere_dos(fc: ForceConstants,
                       sampling: SphericalSamplingOptions = 'golden',
                       npts: int = 1000, jitter: bool = False,
                       energy_bins: Quantity = None,
-                      **calc_modes_args
+                      **calc_modes_args,
                       ) -> Spectrum1D:
     """
     Calculate phonon DOS with QpointFrequencies.calculate_dos,
@@ -89,11 +89,11 @@ def sample_sphere_dos(fc: ForceConstants,
 
     """
 
-    qpts_cart = _get_qpts_sphere(npts, sampling=sampling, jitter=jitter
+    qpts_cart = _get_qpts_sphere(npts, sampling=sampling, jitter=jitter,
                                  ) * mod_q
     qpts_frac = _qpts_cart_to_frac(qpts_cart, fc.crystal)
 
-    phonons = fc.calculate_qpoint_frequencies(qpts_frac, **calc_modes_args
+    phonons = fc.calculate_qpoint_frequencies(qpts_frac, **calc_modes_args,
                                               )  # type: QpointFrequencies
 
     if energy_bins is None:
@@ -110,7 +110,7 @@ def sample_sphere_pdos(
         energy_bins: Quantity = None,
         weighting: Optional[str] = None,
         cross_sections: str | dict[str, Quantity] = 'BlueBook',
-        **calc_modes_args
+        **calc_modes_args,
         ) -> Spectrum1DCollection:
     """
     Calculate phonon PDOS with QpointPhononModes.calculate_pdos,
@@ -194,7 +194,7 @@ def sample_sphere_pdos(
     Spectrum1DCollection
 
     """
-    qpts_cart = _get_qpts_sphere(npts, sampling=sampling, jitter=jitter
+    qpts_cart = _get_qpts_sphere(npts, sampling=sampling, jitter=jitter,
                                  ) * mod_q
     qpts_frac = _qpts_cart_to_frac(qpts_cart, fc.crystal)
     phonons = fc.calculate_qpoint_phonon_modes(qpts_frac, **calc_modes_args)
@@ -216,7 +216,7 @@ def sample_sphere_structure_factor(
     npts: int = 1000, jitter: bool = False,
     energy_bins: Quantity = None,
     scattering_lengths: str | dict[str, Quantity] = 'Sears1992',
-    **calc_modes_args
+    **calc_modes_args,
     ) -> Spectrum1D:
     """Sample structure factor, averaging over a sphere of constant |q|
 
@@ -303,18 +303,18 @@ def sample_sphere_structure_factor(
             dw_qpts = mp_grid(fc.crystal.get_mp_grid_spec(dw_spacing))
             dw_phonons = fc.calculate_qpoint_phonon_modes(dw_qpts,
                                                           **calc_modes_args)
-            dw = dw_phonons.calculate_debye_waller(temperature
+            dw = dw_phonons.calculate_debye_waller(temperature,
                                                    )  # type: DebyeWaller
         elif not np.isclose(dw.temperature, temperature):
             raise ValueError('Temperature argument is not consistent with '
                              'temperature stored in DebyeWaller object.')
 
-    qpts_cart = _get_qpts_sphere(npts, sampling=sampling, jitter=jitter
+    qpts_cart = _get_qpts_sphere(npts, sampling=sampling, jitter=jitter,
                                  ) * mod_q
 
     qpts_frac = _qpts_cart_to_frac(qpts_cart, fc.crystal)
 
-    phonons = fc.calculate_qpoint_phonon_modes(qpts_frac, **calc_modes_args
+    phonons = fc.calculate_qpoint_phonon_modes(qpts_frac, **calc_modes_args,
                                                )  # type: QpointPhononModes
 
     if energy_bins is None:

--- a/euphonic/qpoint_frequencies.py
+++ b/euphonic/qpoint_frequencies.py
@@ -102,7 +102,7 @@ class QpointFrequencies:
         mode_widths_min: Quantity = Quantity(0.01, 'meV'),
         adaptive_method: AdaptiveMethod = 'reference',
         adaptive_error: float = 0.01,
-        adaptive_error_fit: ErrorFit = 'cubic'
+        adaptive_error_fit: ErrorFit = 'cubic',
         ) -> Spectrum1D:
         """
         Calculates a density of states, in units of modes per atom per
@@ -170,7 +170,7 @@ class QpointFrequencies:
         adaptive_method: AdaptiveMethod = 'reference',
         adaptive_error: float = 0.01,
         adaptive_error_fit: ErrorFit = 'cubic',
-        q_idx: Optional[int] = None
+        q_idx: Optional[int] = None,
         ) -> Quantity:
         """
         Calculates a density of states (same arg defs as calculate_dos),
@@ -254,7 +254,7 @@ class QpointFrequencies:
 
     def calculate_dos_map(self, dos_bins: Quantity,
                           mode_widths: Optional[Quantity] = None,
-                          mode_widths_min: Quantity = Quantity(0.01, 'meV')
+                          mode_widths_min: Quantity = Quantity(0.01, 'meV'),
                           ) -> Spectrum2D:
         """
         Produces a bandstructure-like plot, using the DOS at each q-point

--- a/euphonic/readers/castep.py
+++ b/euphonic/readers/castep.py
@@ -112,8 +112,8 @@ def read_phonon_dos_data(
 
     data_dict['dos'] = {}
     data_dict['dos_unit'] = f"1/{frequencies_unit}"
-    dos_conv = ureg('1 / (1/cm)'
-                    ).to(data_dict['dos_unit'], "reciprocal_spectroscopy"
+    dos_conv = ureg('1 / (1/cm)',
+                    ).to(data_dict['dos_unit'], "reciprocal_spectroscopy",
                          ).magnitude
 
     dos_dict = data_dict['dos']
@@ -134,7 +134,7 @@ def read_phonon_data(
         frequencies_unit: str = 'meV',
         read_eigenvectors: bool = True,
         average_repeat_points: bool = True,
-        prefer_non_loto: bool = False
+        prefer_non_loto: bool = False,
     ) -> dict[str, Any]:
     """
     Reads data from a .phonon file and returns it in a dictionary
@@ -281,7 +281,7 @@ def read_phonon_data(
 
 
 def _read_crystal_info(
-        f: TextIO, n_atoms: int
+        f: TextIO, n_atoms: int,
         ) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
     """
     Reads the header crystal information from a CASTEP text file, from
@@ -340,7 +340,7 @@ def _read_frequency_block(
     f: TextIO,
     n_branches: int,
     extra_columns: Optional[list] = None,
-    terminator: str = ''
+    terminator: str = '',
         ) -> _FrequencyBlock | None:
     """
     For a single q-point reads the q-point, weight, frequencies
@@ -538,7 +538,7 @@ def read_interpolation_data(
         raise RuntimeError(
             f'Force constants matrix could not be found in {filename}. '
             f'\nEnsure PHONON_WRITE_FORCE_CONSTANTS: true and a '
-            f'PHONON_FINE_METHOD has been chosen when running CASTEP'
+            f'PHONON_FINE_METHOD has been chosen when running CASTEP',
                            ) from None
 
     # Set entries relating to dipoles
@@ -555,7 +555,7 @@ def read_interpolation_data(
     return data_dict
 
 
-def _read_cell(file_obj: BinaryIO, int_type: str, float_type: str
+def _read_cell(file_obj: BinaryIO, int_type: str, float_type: str,
                ) -> tuple[int, np.ndarray, np.ndarray,
                           np.ndarray, np.ndarray]:
     """
@@ -640,7 +640,7 @@ def _read_cell(file_obj: BinaryIO, int_type: str, float_type: str
     return n_atoms, cell_vectors, atom_r, atom_mass, atom_type
 
 
-def _read_entry(file_obj: BinaryIO, dtype: str = ''
+def _read_entry(file_obj: BinaryIO, dtype: str = '',
                 ) -> str | int | float | np.ndarray:
     """
     Read a record from a Fortran binary file, including the beginning

--- a/euphonic/readers/phonopy.py
+++ b/euphonic/readers/phonopy.py
@@ -43,7 +43,7 @@ def _convert_weights(weights: np.ndarray) -> np.ndarray:
 
 
 def _extract_phonon_data_yaml(filename: str,
-                              read_eigenvectors: bool = True
+                              read_eigenvectors: bool = True,
                               ) -> dict[str, np.ndarray]:
     """
     From a mesh/band/qpoint.yaml file, extract the relevant information
@@ -119,7 +119,7 @@ def _extract_phonon_data_yaml(filename: str,
 
 
 def _extract_phonon_data_hdf5(filename: str,
-                              read_eigenvectors: bool = True
+                              read_eigenvectors: bool = True,
                               ) -> dict[str, np.ndarray]:
     """
     From a mesh/band/qpoint.hdf5 file, extract the relevant information
@@ -178,7 +178,7 @@ def _extract_phonon_data_hdf5(filename: str,
                 # transpose to handle this
                 data_dict['eigenvectors'] = hdf5_file[
                     'eigenvector'][()].reshape(
-                        -1, *hdf5_file['eigenvector'][()].shape[-2:]
+                        -1, *hdf5_file['eigenvector'][()].shape[-2:],
                         ).transpose([0,2,1])
             except KeyError:
                 pass
@@ -193,7 +193,7 @@ def read_phonon_data(
         cell_vectors_unit: str = 'angstrom',
         atom_mass_unit: str = 'amu',
         frequencies_unit: str = 'meV',
-        read_eigenvectors: bool = True
+        read_eigenvectors: bool = True,
         ) -> dict[str, int | str | np.ndarray]:
     """
     Reads precalculated phonon mode data from a Phonopy
@@ -314,7 +314,7 @@ def read_phonon_data(
     return data_dict
 
 
-def convert_eigenvector_phases(phonon_dict: dict[str, np.ndarray]
+def convert_eigenvector_phases(phonon_dict: dict[str, np.ndarray],
                                ) -> np.ndarray:
     """
     When interpolating the force constants matrix, Euphonic uses a phase
@@ -450,7 +450,7 @@ def _extract_born(born_file_obj: TextIO) -> dict[str, float | np.ndarray]:
     return born_dict
 
 
-def _extract_summary(filename: str, fc_extract: bool = False
+def _extract_summary(filename: str, fc_extract: bool = False,
                      ) -> dict[str, str | int | np.ndarray]:
     """
     Read phonopy.yaml for summary data produced during the Phonopy
@@ -581,7 +581,7 @@ def _extract_summary(filename: str, fc_extract: bool = False
     return summary_dict
 
 
-def _extract_crystal_data(crystal: dict[str, Any]
+def _extract_crystal_data(crystal: dict[str, Any],
                           ) -> tuple[np.ndarray, int, np.ndarray,
                                      np.ndarray, np.ndarray, np.ndarray]:
     """

--- a/euphonic/sampling.py
+++ b/euphonic/sampling.py
@@ -15,7 +15,7 @@ _golden_ratio = (1 + np.sqrt(5)) / 2
 #  and method development; clarity is prioritised over numerical efficiency
 
 
-def golden_square(npts: int, offset: bool = True, jitter: bool = False
+def golden_square(npts: int, offset: bool = True, jitter: bool = False,
                   ) -> Iterator[tuple[float, float]]:
     """Yield a series of well-distributed points in 2-D unit square
 
@@ -60,7 +60,7 @@ def golden_square(npts: int, offset: bool = True, jitter: bool = False
 
 
 def regular_square(n_rows: int, n_cols: int,
-                   offset: bool = True, jitter: bool = False
+                   offset: bool = True, jitter: bool = False,
                    ) -> Iterator[tuple[float, float]]:
     """Yield a regular grid of (x, y) points in 2-D unit square
 
@@ -155,7 +155,7 @@ def golden_sphere(npts: int, cartesian: bool = True, jitter: bool = False,
 
 
 def sphere_from_square_grid(n_rows: int, n_cols: int,
-                            cartesian: bool = True, jitter: bool = False
+                            cartesian: bool = True, jitter: bool = False,
                             ) -> Iterator[tuple[float, float, float]]:
     """Yield a series of 3D points on a unit sphere surface
 
@@ -326,7 +326,7 @@ def spherical_polar_improved(npts: int,
                 yield (1, phi, theta)
 
 
-def random_sphere(npts, cartesian: bool = True
+def random_sphere(npts, cartesian: bool = True,
                   ) -> Iterator[tuple[float, float, float]]:
     """Yield a series of 3D points on a unit sphere surface
 

--- a/euphonic/spectra/base.py
+++ b/euphonic/spectra/base.py
@@ -61,7 +61,7 @@ class Spectrum(ABC):
     @property
     def x_data(self) -> Quantity:
         """x-axis data with units"""
-        return ureg.Quantity(self._x_data, self._internal_x_data_unit
+        return ureg.Quantity(self._x_data, self._internal_x_data_unit,
                              ).to(self.x_data_unit, "reciprocal_spectroscopy")
 
     @x_data.setter
@@ -155,7 +155,7 @@ class Spectrum(ABC):
         return _obj_from_json_file(cls, filename, type_dict)
 
     @abstractmethod
-    def _split_by_indices(self: T, indices: Sequence[int] | np.ndarray
+    def _split_by_indices(self: T, indices: Sequence[int] | np.ndarray,
                           ) -> list[T]:
         """Split data along x axis at given indices"""
 
@@ -167,7 +167,7 @@ class Spectrum(ABC):
         return self._split_by_indices(breakpoints)
 
     @staticmethod
-    def _ranges_from_indices(indices: Sequence[int] | np.ndarray
+    def _ranges_from_indices(indices: Sequence[int] | np.ndarray,
                              ) -> list[tuple[int, Optional[int]]]:
         """Convert a series of breakpoints to a series of slice ranges"""
         if len(indices) == 0:
@@ -299,7 +299,7 @@ class Spectrum(ABC):
     def _gaussian_width_to_bin_sigma(
         width: float | None,
         ax_bin_centres: np.ndarray,
-        width_convention: Literal['fwhm', 'std']
+        width_convention: Literal['fwhm', 'std'],
     ) -> float:
         """
         Convert a Gaussian FWHM to sigma in units of the mean ax bin size
@@ -341,7 +341,7 @@ class Spectrum(ABC):
     @staticmethod
     def _bin_centres_to_edges(
             bin_centres: Quantity,
-            restrict_range: bool = True
+            restrict_range: bool = True,
     ) -> Quantity:
         if restrict_range:
             return np.concatenate((
@@ -494,7 +494,7 @@ class Spectrum1D(Spectrum):
 
     def __init__(self, x_data: Quantity, y_data: Quantity,
                  x_tick_labels: Optional[XTickLabels] = None,
-                 metadata: Optional[dict[str, int | str]] = None
+                 metadata: Optional[dict[str, int | str]] = None,
                  ) -> None:
         """
         Parameters
@@ -545,7 +545,7 @@ class Spectrum1D(Spectrum):
         return spec_col.sum()
 
     def _split_by_indices(self: T,
-                          indices: Sequence[int] | np.ndarray
+                          indices: Sequence[int] | np.ndarray,
                           ) -> list[T]:
         """Split data along x-axis at given indices"""
         ranges = self._ranges_from_indices(indices)
@@ -666,7 +666,7 @@ class Spectrum1D(Spectrum):
                 width_lower_limit: Optional[Quantity] = None,
                 width_convention: Literal['fwhm', 'std'] = 'fwhm',
                 width_interpolation_error: float = 0.01,
-                width_fit: ErrorFit = 'cheby-log'
+                width_fit: ErrorFit = 'cheby-log',
                 ) -> T: ...
 
     def broaden(self: T, x_width,
@@ -675,7 +675,7 @@ class Spectrum1D(Spectrum):
                 width_lower_limit=None,
                 width_convention='fwhm',
                 width_interpolation_error=0.01,
-                width_fit='cheby-log'
+                width_fit='cheby-log',
                 ) -> T:
         """
         Broaden y_data and return a new broadened spectrum object
@@ -747,7 +747,7 @@ class Spectrum1D(Spectrum):
                 width_convention=width_convention,
                 adaptive_error=width_interpolation_error,
                 shape=shape,
-                fit=width_fit
+                fit=width_fit,
             )
         else:
             raise TypeError("x_width must be a Quantity or Callable")
@@ -787,7 +787,7 @@ class Spectrum2D(Spectrum):
     def __init__(self, x_data: Quantity, y_data: Quantity,
                  z_data: Quantity,
                  x_tick_labels: Optional[XTickLabels] = None,
-                 metadata: Optional[OneSpectrumMetadata] = None
+                 metadata: Optional[OneSpectrumMetadata] = None,
                  ) -> None:
         """
         Parameters
@@ -831,7 +831,7 @@ class Spectrum2D(Spectrum):
     def z_data(self) -> Quantity:
         """z-axis data with units"""
         return ureg.Quantity(
-            self._z_data, self._internal_z_data_unit
+            self._z_data, self._internal_z_data_unit,
         ).to(self.z_data_unit, "reciprocal_spectroscopy")
 
     @z_data.setter
@@ -850,7 +850,7 @@ class Spectrum2D(Spectrum):
         super().__setattr__(name, value)
 
     def _split_by_indices(self,
-                          indices: Sequence[int] | np.ndarray
+                          indices: Sequence[int] | np.ndarray,
                           ) -> list[T]:
         """Split data along x-axis at given indices"""
         ranges = self._ranges_from_indices(indices)
@@ -870,7 +870,7 @@ class Spectrum2D(Spectrum):
                 y_width_lower_limit: Quantity = None,
                 width_convention: Literal['fwhm', 'std'] = 'fwhm',
                 width_interpolation_error: float = 0.01,
-                width_fit: ErrorFit = 'cheby-log'
+                width_fit: ErrorFit = 'cheby-log',
                 ) -> T:
         """
         Broaden z_data and return a new broadened Spectrum2D object
@@ -983,7 +983,7 @@ class Spectrum2D(Spectrum):
             width_convention: Literal['fwhm', 'std'] = 'fwhm',
             width_interpolation_error: float = 1e-2,
             shape: KernelShape = 'gauss',
-            width_fit: ErrorFit = 'cheby-log'
+            width_fit: ErrorFit = 'cheby-log',
     ) -> 'Spectrum2D':
         """
         Apply value-dependent Gaussian broadening to one axis of Spectrum2D
@@ -1040,7 +1040,7 @@ class Spectrum2D(Spectrum):
             self,
             bin_ax: Literal['x', 'y'] = 'x',
             *,
-            restrict_range: bool = True
+            restrict_range: bool = True,
     ) -> Quantity:
         """
         Get bin edges for the axis specified by bin_ax. If the size of bin_ax
@@ -1207,7 +1207,7 @@ class Spectrum2D(Spectrum):
 def apply_kinematic_constraints(spectrum: Spectrum2D,
                                 e_i: Quantity = None,
                                 e_f: Quantity = None,
-                                angle_range: tuple[float] = (0, 180.)
+                                angle_range: tuple[float] = (0, 180.),
                                 ) -> Spectrum2D:
     """
     Set events to NaN which violate energy/momentum limits:
@@ -1240,13 +1240,13 @@ def apply_kinematic_constraints(spectrum: Spectrum2D,
         (1 * spectrum.x_data.units).to('1/angstrom')
     except DimensionalityError as error:
         raise ValueError(
-            "x_data needs to have wavevector units (i.e. 1/length)"
+            "x_data needs to have wavevector units (i.e. 1/length)",
             ) from error
     try:
         (1 * spectrum.y_data.units).to('eV', 'spectroscopy')
     except DimensionalityError as error:
         raise ValueError(
-            "y_data needs to have energy (or wavenumber) units"
+            "y_data needs to have energy (or wavenumber) units",
             ) from error
 
     momentum2_to_energy = 0.5 * (ureg('hbar^2 / neutron_mass')
@@ -1282,7 +1282,7 @@ def apply_kinematic_constraints(spectrum: Spectrum2D,
                        - 2 * cos_values[:, np.newaxis]
                            * np.sqrt(k2_i.magnitude * k2_f.magnitude,
                                      dtype=complex)
-                           * (k2_i.units * k2_f.units)**0.5
+                           * (k2_i.units * k2_f.units)**0.5,
                        )
     q_bounds.magnitude.T[np.any(q_bounds.imag, axis=0)] = [float('Inf'),
                                                            float('-Inf')]

--- a/euphonic/spectra/collections.py
+++ b/euphonic/spectra/collections.py
@@ -134,7 +134,7 @@ class SpectrumCollectionMixin(ABC):
         metadata.update(self._tidy_metadata())
         summed_s_data = ureg.Quantity(
             np.sum(self._get_raw_spectrum_data(), axis=0),
-            units=self._get_internal_spectrum_data_unit()
+            units=self._get_internal_spectrum_data_unit(),
         ).to(self._get_spectrum_data_unit())
 
         bin_kwargs = {axis_name: getattr(self, axis_name)
@@ -144,14 +144,14 @@ class SpectrumCollectionMixin(ABC):
             **bin_kwargs,
             **{self._spectrum_data_name(): summed_s_data},
             x_tick_labels=copy.copy(self.x_tick_labels),
-            metadata=metadata
+            metadata=metadata,
         )
 
     # Required methods
     @classmethod
     @abstractmethod
     def from_spectra(
-            cls, spectra: Sequence[Spectrum], *, unsafe: bool = False
+            cls, spectra: Sequence[Spectrum], *, unsafe: bool = False,
     ) -> Self:
         """Construct spectrum collection from a sequence of components
 
@@ -175,7 +175,7 @@ class SpectrumCollectionMixin(ABC):
     def __getitem__(self, item: Sequence[int] | np.ndarray) -> Self: ...
 
     def __getitem__(
-            self, item: Integral | slice | Sequence[Integral] | np.ndarray
+            self, item: Integral | slice | Sequence[Integral] | np.ndarray,
     ):
         self._validate_item(item)
 
@@ -195,7 +195,7 @@ class SpectrumCollectionMixin(ABC):
     def _set_item_data(
             self,
             spectrum: Spectrum,
-            item: Integral | slice | Sequence[Integral] | np.ndarray
+            item: Integral | slice | Sequence[Integral] | np.ndarray,
     ) -> None:
         """Write axis and spectrum data from self to Spectrum
 
@@ -216,7 +216,7 @@ class SpectrumCollectionMixin(ABC):
         setattr(spectrum, f"{self._spectrum_data_name()}_unit",
                 self._get_spectrum_data_unit())
 
-    def _validate_item(self, item: Integral | slice | Sequence[Integral] | np.ndarray
+    def _validate_item(self, item: Integral | slice | Sequence[Integral] | np.ndarray,
                        ) -> None:
         """Raise Error if index has inappropriate typing/ranges
 
@@ -247,7 +247,7 @@ class SpectrumCollectionMixin(ABC):
         """Get a single metadata item with no line_data"""
 
     @overload
-    def _get_item_metadata(self, item: slice | Sequence[Integral] | np.ndarray
+    def _get_item_metadata(self, item: slice | Sequence[Integral] | np.ndarray,
                            ) -> Metadata:
         """Get a metadata collection (may include line_data)"""
 
@@ -345,7 +345,7 @@ class SpectrumCollectionMixin(ABC):
             If no matching spectra are found
         """
         # Convert all items to sequences of possibilities
-        def ensure_sequence(value: int | str | Sequence[int | str]
+        def ensure_sequence(value: int | str | Sequence[int | str],
                             ) -> Sequence[int | str]:
             return (value,) if isinstance(value, (int, str)) else value
 
@@ -444,7 +444,7 @@ class SpectrumCollectionMixin(ABC):
             metadata in 'line_data' not common across all spectra in a
             group will be discarded
         """
-        def get_key_items(enumerated_metadata: tuple[int, OneLineData]
+        def get_key_items(enumerated_metadata: tuple[int, OneLineData],
                           ) -> tuple[str | int, ...]:
             """Get sort keys from an item of enumerated input to groupby
 
@@ -543,7 +543,7 @@ class Spectrum1DCollection(SpectrumCollectionMixin,
     def __init__(
             self, x_data: Quantity, y_data: Quantity,
             x_tick_labels: Optional[XTickLabels] = None,
-            metadata: Optional[dict[str, str | int | LineData]] = None
+            metadata: Optional[dict[str, str | int | LineData]] = None,
     ) -> None:
         """
         Parameters
@@ -588,7 +588,7 @@ class Spectrum1DCollection(SpectrumCollectionMixin,
         self._check_metadata()
 
     def _split_by_indices(self,
-                          indices: Sequence[int] | np.ndarray
+                          indices: Sequence[int] | np.ndarray,
                           ) -> list[Self]:
         """Split data along x-axis at given indices"""
 
@@ -601,7 +601,7 @@ class Spectrum1DCollection(SpectrumCollectionMixin,
                 for x0, x1 in ranges]
 
     @staticmethod
-    def _from_spectra_data_check(spectrum, x_data, y_data_units, x_tick_labels
+    def _from_spectra_data_check(spectrum, x_data, y_data_units, x_tick_labels,
                                  ) -> None:
         if (spectrum.y_data.units != y_data_units
                 or spectrum.x_data.units != x_data.units):
@@ -613,7 +613,7 @@ class Spectrum1DCollection(SpectrumCollectionMixin,
 
     @classmethod
     def from_spectra(
-            cls: Self, spectra: Sequence[Spectrum1D], *, unsafe: bool = False
+            cls: Self, spectra: Sequence[Spectrum1D], *, unsafe: bool = False,
     ) -> Self:
         """Combine Spectrum1D to produce a new collection
 
@@ -708,7 +708,7 @@ class Spectrum1DCollection(SpectrumCollectionMixin,
     @overload
     def broaden(self: T, x_width: Quantity,
                 shape: KernelShape = 'gauss',
-                method: Optional[Literal['convolve']] = None
+                method: Optional[Literal['convolve']] = None,
                 ) -> T: ...
 
     @overload
@@ -718,7 +718,7 @@ class Spectrum1DCollection(SpectrumCollectionMixin,
                 width_lower_limit: Optional[Quantity] = None,
                 width_convention: Literal['fwhm', 'std'] = 'fwhm',
                 width_interpolation_error: float = 0.01,
-                width_fit: ErrorFit = 'cheby-log'
+                width_fit: ErrorFit = 'cheby-log',
                 ) -> T: ...
 
     def broaden(self: T,
@@ -728,7 +728,7 @@ class Spectrum1DCollection(SpectrumCollectionMixin,
                 width_lower_limit=None,
                 width_convention='fwhm',
                 width_interpolation_error=0.01,
-                width_fit='cheby-log'
+                width_fit='cheby-log',
                 ) -> T:
         """
         Individually broaden each line in y_data, returning a new
@@ -877,7 +877,7 @@ class Spectrum2DCollection(SpectrumCollectionMixin,
     def __init__(
             self, x_data: Quantity, y_data: Quantity, z_data: Quantity,
             x_tick_labels: Optional[XTickLabels] = None,
-            metadata: Optional[Metadata] = None
+            metadata: Optional[Metadata] = None,
     ) -> None:
         _check_constructor_inputs(
             [z_data, x_tick_labels, metadata],
@@ -900,7 +900,7 @@ class Spectrum2DCollection(SpectrumCollectionMixin,
         self.metadata = metadata if metadata is not None else {}
         self._check_metadata()
 
-    def _split_by_indices(self, indices: Sequence[int] | np.ndarray
+    def _split_by_indices(self, indices: Sequence[int] | np.ndarray,
                           ) -> list[Self]:
         """Split data along x axis at given indices"""
         ranges = self._ranges_from_indices(indices)
@@ -916,7 +916,7 @@ class Spectrum2DCollection(SpectrumCollectionMixin,
     def z_data(self) -> Quantity:
         """intensity data"""
         return ureg.Quantity(
-            self._z_data, self._internal_z_data_unit
+            self._z_data, self._internal_z_data_unit,
         ).to(self.z_data_unit, "reciprocal_spectroscopy")
 
     @z_data.setter
@@ -927,7 +927,7 @@ class Spectrum2DCollection(SpectrumCollectionMixin,
     @staticmethod
     def _from_spectra_data_check(
             spectrum_0_data_units, spectrum_i_data_units,
-            x_tick_labels, spectrum_i_x_tick_labels
+            x_tick_labels, spectrum_i_x_tick_labels,
     ) -> None:
         """Check spectrum data units and x_tick_labels are consistent"""
         if spectrum_0_data_units != spectrum_i_data_units:
@@ -954,7 +954,7 @@ class Spectrum2DCollection(SpectrumCollectionMixin,
 
     @classmethod
     def from_spectra(
-            cls, spectra: Sequence[Spectrum2D], *, unsafe: bool = False
+            cls, spectra: Sequence[Spectrum2D], *, unsafe: bool = False,
     ) -> Self:
         """Combine Spectrum2D to produce a new collection
 
@@ -1005,7 +1005,7 @@ class Spectrum2DCollection(SpectrumCollectionMixin,
             self,
             bin_ax: Literal["x", "y"] = "x",
             *,
-            restrict_range: bool = True
+            restrict_range: bool = True,
     ) -> Quantity:
         """
         Get bin edges for the axis specified by bin_ax. If the size of bin_ax

--- a/euphonic/structure_factor.py
+++ b/euphonic/structure_factor.py
@@ -124,7 +124,7 @@ class StructureFactor(QpointFrequencies):
                              e_bins: Quantity,
                              calc_bose: bool = True,
                              temperature: Optional[Quantity] = None,
-                             weights: Optional[np.ndarray] = None
+                             weights: Optional[np.ndarray] = None,
                              ) -> Spectrum1D:
         """Bin structure factor in energy, flattening q to produce 1D spectrum
 
@@ -165,7 +165,7 @@ class StructureFactor(QpointFrequencies):
     def calculate_sqw_map(self,
                           e_bins: Quantity,
                           calc_bose: bool = True,
-                          temperature: Optional[Quantity] = None
+                          temperature: Optional[Quantity] = None,
                           ) -> Spectrum2D:
         """
         Bin the structure factor in energy and apply the Bose population
@@ -224,7 +224,7 @@ class StructureFactor(QpointFrequencies):
 
     def _bose_corrected_structure_factor(self, e_bins: Quantity,
                                          calc_bose: bool = True,
-                                         temperature: Optional[Quantity] = None
+                                         temperature: Optional[Quantity] = None,
                                          ) -> Quantity:
         """Bin structure factor in energy, return (Bose-populated) array
 
@@ -289,7 +289,7 @@ class StructureFactor(QpointFrequencies):
 
         return sqw_map*sf_conv/e_conv
 
-    def _bose_factor(self, temperature: Optional[Quantity] = None
+    def _bose_factor(self, temperature: Optional[Quantity] = None,
                      ) -> np.ndarray:
         """
         Calculate the Bose factor for the frequencies stored in

--- a/euphonic/util.py
+++ b/euphonic/util.py
@@ -20,7 +20,7 @@ from euphonic.ureg import Quantity, ureg
 zips = partial(zip, strict=True)
 
 
-def direction_changed(qpts: np.ndarray, tolerance: float = 5e-6
+def direction_changed(qpts: np.ndarray, tolerance: float = 5e-6,
                       ) -> np.ndarray:
     """
     Determines whether the q-direction has changed between each pair of
@@ -134,7 +134,7 @@ def get_all_origins(max_xyz: tuple[int, int, int],
 def get_qpoint_labels(qpts: np.ndarray,
                       cell: Optional[tuple[list[list[float]],
                                            list[list[float]],
-                                           list[int]]] = None
+                                           list[int]]] = None,
                       ) -> list[tuple[int, str]]:
     """
     Gets q-point labels (e.g. GAMMA, X, L) for the q-points at which the
@@ -168,7 +168,7 @@ def get_qpoint_labels(qpts: np.ndarray,
 
 
 def get_reference_data(collection: str = 'Sears1992',
-                       physical_property: str = 'coherent_scattering_length'
+                       physical_property: str = 'coherent_scattering_length',
                        ) -> dict[str, Quantity]:
     """
     Get physical data as a dict of (possibly-complex) floats from reference
@@ -261,7 +261,7 @@ def get_reference_data(collection: str = 'Sears1992',
             if isinstance(value, (float, complex))}
 
 
-def mode_gradients_to_widths(mode_gradients: Quantity, cell_vectors: Quantity
+def mode_gradients_to_widths(mode_gradients: Quantity, cell_vectors: Quantity,
                              ) -> Quantity:
     """
     Converts either scalar or vector mode gradients (units
@@ -302,7 +302,7 @@ def mode_gradients_to_widths(mode_gradients: Quantity, cell_vectors: Quantity
 def convert_fc_phases(force_constants: np.ndarray, atom_r: np.ndarray,
                       sc_atom_r: np.ndarray, uc_to_sc_atom_idx: np.ndarray,
                       sc_to_uc_atom_idx: np.ndarray, sc_matrix: np.ndarray,
-                      cell_origins_tol: float = 1e-5
+                      cell_origins_tol: float = 1e-5,
                       ) -> tuple[np.ndarray, np.ndarray]:
     """
     Convert from a force constants matrix which uses the atom
@@ -443,7 +443,7 @@ def _cell_vectors_to_volume(cell_vectors: Quantity) -> Quantity:
 
 
 def _get_unique_elems_and_idx(
-        all_elems: Sequence[tuple[int | str, ...]]
+        all_elems: Sequence[tuple[int | str, ...]],
         ) -> dict[tuple[int | str, ...], np.ndarray]:
     """
     Returns an ordered dictionary mapping the unique sequences of
@@ -458,7 +458,7 @@ def _get_unique_elems_and_idx(
     }
 
 
-def _calc_abscissa(reciprocal_cell: Quantity, qpts: np.ndarray
+def _calc_abscissa(reciprocal_cell: Quantity, qpts: np.ndarray,
                    ) -> Quantity:
     """
     Calculates the distance between q-points (e.g. to use as a plot
@@ -519,7 +519,7 @@ def _calc_abscissa(reciprocal_cell: Quantity, qpts: np.ndarray
 def _recip_space_labels(qpts: np.ndarray,
                         cell: Optional[tuple[list[list[float]],
                                              list[list[float]],
-                                             list[int]]]
+                                             list[int]]],
                         ) -> tuple[np.ndarray, np.ndarray]:
     """
     Gets q-points point labels (e.g. GAMMA, X, L) for the q-points at
@@ -556,8 +556,8 @@ def _recip_space_labels(qpts: np.ndarray,
             reduce(np.logical_or,
                    (direction_changed(qpts),
                     is_gamma(qpts[1:-1]),
-                    np.all(qpts[2:] == qpts[1:-1], axis=1)
-                    )
+                    np.all(qpts[2:] == qpts[1:-1], axis=1),
+                    ),
                    ),
             [True]))
     qpts_with_labels = np.where(qpt_has_label)[0]
@@ -610,7 +610,7 @@ def _generic_qpt_labels() -> dict[str, tuple[float, float, float]]:
 
 
 def _get_qpt_label(qpt: np.ndarray,
-                   point_labels: dict[str, tuple[float, float, float]]
+                   point_labels: dict[str, tuple[float, float, float]],
                    ) -> str:
     """
     Gets a label for a particular q-point, based on the high symmetry

--- a/euphonic/writers/phonon_website.py
+++ b/euphonic/writers/phonon_website.py
@@ -110,7 +110,7 @@ def _crystal_website_data(crystal: Crystal) -> dict[str, Any]:
         "formula": symbols_to_formula(crystal.atom_type),
         "atom_pos_red": crystal.atom_r.tolist(),
         "atom_pos_car": (crystal.atom_r @ crystal.cell_vectors
-                      ).to("angstrom").magnitude.tolist()
+                      ).to("angstrom").magnitude.tolist(),
     }
 
 
@@ -220,6 +220,6 @@ def _modes_to_phonon_website_dict(
         eigenvalues=modes.frequencies.to("1/cm").magnitude.tolist(),
         vectors=vectors.tolist(),
         repetitions=repetitions,
-        line_breaks=line_breaks
+        line_breaks=line_breaks,
     )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,10 +84,10 @@ select = [
        "S",       # Security (flake8-bandit)
        "BLE",     # flake8-blind-except
        # "FBT",   # flake8-boolean-trap: don't use positional boolean arguments. Fixable, but API-breaking.
-       "B",     # flake8-bugbear: Fixable but a bit involved
+       "B",       # flake8-bugbear: Fixable but a bit involved
        "A",       # flake8-builtins
-       # "COM",   # flake8-commas: Fixable but a big diff
-       "C4",    # flake8-comprehensions: Good stuff, worth its own PR
+       "COM",     # flake8-commas
+       "C4",      # flake8-comprehensions: Good stuff, worth its own PR
        "T10",     # flake8-debugger
        # "EM",      # flake8-errmsg: Big diff, worth its own PR
        "EXE",     # flake8-executable

--- a/tests_and_analysis/test/euphonic_test/test_brille_interpolator.py
+++ b/tests_and_analysis/test/euphonic_test/test_brille_interpolator.py
@@ -78,7 +78,7 @@ class TestBrilleInterpolatorCreation:
          'lzo_trellis_10.hdf5'),
         ('quartz', {'grid_npts': 10,
                     'grid_type': 'mesh'},
-         'quartz_mesh_10.hdf5')
+         'quartz_mesh_10.hdf5'),
         ])
     def test_create_from_force_constants(
             self, material, kwargs, expected_grid_file):
@@ -133,7 +133,7 @@ class TestBrilleInterpolatorCreation:
               'interpolation_kwargs': {'insert_gamma': True}}),
             ({'interpolation_kwargs': {'reduce_qpts': True,
                                        'dipole_parameter': 0.5,
-                                       'n_threads': 2}})
+                                       'n_threads': 2}}),
         ])
     def test_from_force_constants_correct_interpolation_kwargs_passed(
             self, mocker, kwargs):
@@ -185,7 +185,7 @@ class TestBrilleInterpolatorCalculateQpointPhononModes:
     @pytest.mark.parametrize(
         'material, from_fc_kwargs, emax, expected_sf1d_file', [
             ('LZO', {'grid_npts': 100}, 100,
-             'La2Zr2O7_trellis_100_sf_1d_average.json')
+             'La2Zr2O7_trellis_100_sf_1d_average.json'),
         ])
     def test_calculate_qpoint_phonon_modes(
             self, material, from_fc_kwargs, emax, expected_sf1d_file):

--- a/tests_and_analysis/test/euphonic_test/test_crystal.py
+++ b/tests_and_analysis/test/euphonic_test/test_crystal.py
@@ -141,7 +141,7 @@ class TestCrystalCreation:
         (get_json_file('quartz_cv_only'),
          get_expected_crystal('quartz_cv_only')),
         (get_json_file('LZO'),
-         get_expected_crystal('LZO'))
+         get_expected_crystal('LZO')),
     ])
     def create_from_json_file(self, request):
         filename, expected_crystal = request.param
@@ -160,7 +160,7 @@ class TestCrystalCreation:
         pytest.lazy_fixture('create_from_constructor'),
         pytest.lazy_fixture('create_from_json_file'),
         pytest.lazy_fixture('create_from_dict'),
-        pytest.lazy_fixture('create_from_cell_vectors')
+        pytest.lazy_fixture('create_from_cell_vectors'),
     ])
     def test_create(self, crystal_creator):
         crystal, expected_crystal = crystal_creator
@@ -231,7 +231,7 @@ class TestCrystalSerialisation:
         (get_crystal('quartz_cv_only'),
          get_expected_crystal('quartz_cv_only')),
         (get_crystal('LZO'),
-         get_expected_crystal('LZO'))
+         get_expected_crystal('LZO')),
     ])
     def serialise_to_dict(self, request):
         crystal, expected_crystal = request.param
@@ -294,24 +294,24 @@ class TestCrystalMethods:
     quartz_reciprocal_cell = np.array([
         [1.29487418, -0.74759597, 0.],
         [1.29487418, 0.74759597, 0.],
-        [0., 0., 1.17436043]
+        [0., 0., 1.17436043],
     ])*ureg('1/angstrom')
 
     lzo_reciprocal_cell = np.array([
         [8.28488599e-01, 0.00000000e+00, -5.85829906e-01],
         [-2.01146673e-33, 8.28488599e-01, 5.85829906e-01],
-        [2.01146673e-33, -8.28488599e-01, 5.85829906e-01]
+        [2.01146673e-33, -8.28488599e-01, 5.85829906e-01],
     ])*ureg('1/angstrom')
 
     @pytest.mark.parametrize('crystal,expected_recip', [
         (get_crystal('quartz'), quartz_reciprocal_cell),
-        (get_crystal('LZO'), lzo_reciprocal_cell)
+        (get_crystal('LZO'), lzo_reciprocal_cell),
     ])
     def test_reciprocal_cell(self, crystal, expected_recip):
         recip = crystal.reciprocal_cell()
         npt.assert_allclose(
             recip.to('1/angstrom').magnitude,
-            expected_recip.to('1/angstrom').magnitude
+            expected_recip.to('1/angstrom').magnitude,
         )
 
     quartz_cell_volume = 109.09721804482547*ureg('angstrom**3')
@@ -320,13 +320,13 @@ class TestCrystalMethods:
 
     @pytest.mark.parametrize('crystal,expected_vol', [
         (get_crystal('quartz'), quartz_cell_volume),
-        (get_crystal('LZO'), lzo_cell_volume)
+        (get_crystal('LZO'), lzo_cell_volume),
     ])
     def test_cell_volume(self, crystal, expected_vol):
         vol = crystal.cell_volume()
         npt.assert_allclose(
             vol.to('angstrom**3').magnitude,
-            expected_vol.to('angstrom**3').magnitude
+            expected_vol.to('angstrom**3').magnitude,
         )
 
     quartz_spglib_cell = ([[2.426176, -4.20226, 0.000000],
@@ -407,7 +407,7 @@ class TestCrystalMethods:
          {'O': np.arange(6), 'Si': np.arange(6, 9)}),
         (get_crystal('LZO'),
          {'O': np.arange(14), 'Zr': np.arange(14, 18),
-          'La': np.arange(18, 22)})
+          'La': np.arange(18, 22)}),
         ])
     def test_get_species_idx(self, crystal, expected_spec_idx):
         spec_idx = crystal.get_species_idx()
@@ -417,7 +417,7 @@ class TestCrystalMethods:
 
     @pytest.mark.parametrize('crystal, kwargs, expected_res_file', [
         (get_crystal('quartz'), {}, 'quartz_equiv_atoms.json'),
-        (get_crystal('LZO'), {}, 'lzo_equiv_atoms.json')
+        (get_crystal('LZO'), {}, 'lzo_equiv_atoms.json'),
         ])
     def test_get_symmetry_equivalent_atoms(
             self, crystal, kwargs, expected_res_file):
@@ -451,7 +451,7 @@ class TestCrystalMethods:
 
     @pytest.mark.parametrize('crystal, kwargs, expected_symprec', [
         (get_crystal('LZO'), {'tol': 1e-12*ureg('angstrom')}, 1e-12),
-        (get_crystal('LZO'), {'tol': 1.8897261246e-12*ureg('bohr')}, 1e-12)
+        (get_crystal('LZO'), {'tol': 1.8897261246e-12*ureg('bohr')}, 1e-12),
         ])
     def test_get_symmetry_equivalent_atoms_with_tol(
             self, mocker, crystal, kwargs, expected_symprec):

--- a/tests_and_analysis/test/euphonic_test/test_debye_waller.py
+++ b/tests_and_analysis/test/euphonic_test/test_debye_waller.py
@@ -127,7 +127,7 @@ class TestDebyeWallerCreation:
     @pytest.mark.parametrize('dw_creator', [
         pytest.lazy_fixture('create_from_constructor'),
         pytest.lazy_fixture('create_from_json_file'),
-        pytest.lazy_fixture('create_from_dict')
+        pytest.lazy_fixture('create_from_dict'),
     ])
     def test_create(self, dw_creator):
         dw, expected_dw = dw_creator
@@ -185,7 +185,7 @@ class TestDebyeWallerSerialisation:
     @pytest.fixture(params=[
         ('quartz', 'quartz_666_0K_debye_waller.json'),
         ('Si2-sc-skew', 'Si2-sc-skew_666_300K_debye_waller.json'),
-        ('CaHgO2', 'CaHgO2_666_300K_debye_waller.json')
+        ('CaHgO2', 'CaHgO2_666_300K_debye_waller.json'),
     ])
     def serialise_to_dict(self, request):
         material, json_file = request.param
@@ -233,7 +233,7 @@ class TestDebyeWallerSetters:
         ('CaHgO2', 'CaHgO2_666_300K_debye_waller.json',
          'debye_waller', 'mbarn', 3.),
         ('CaHgO2', 'CaHgO2_666_300K_debye_waller.json',
-         'temperature', 'K', 2.)
+         'temperature', 'K', 2.),
         ])
     def test_setter_correct_units(self, material, json_file, attr,
                                   unit, scale):

--- a/tests_and_analysis/test/euphonic_test/test_force_constants.py
+++ b/tests_and_analysis/test/euphonic_test/test_force_constants.py
@@ -202,7 +202,7 @@ class TestForceConstantsCreation:
     )
     def test_create_from_castep25(self, material, castep_bin_file):
         expected_fc = ForceConstants.from_json_file(
-            get_json_file(Path(castep_bin_file).stem)
+            get_json_file(Path(castep_bin_file).stem),
         )
         castep_filepath = get_castep_path(material, castep_bin_file)
         fc = ForceConstants.from_castep(castep_filepath)

--- a/tests_and_analysis/test/euphonic_test/test_plot.py
+++ b/tests_and_analysis/test/euphonic_test/test_plot.py
@@ -62,7 +62,7 @@ class TestPlot1DCore:
         matplotlib.pyplot.close('all')
 
     @pytest.mark.parametrize('spectra, expected_error',
-                             [('wrong_type', TypeError), ])
+                             [('wrong_type', TypeError) ])
     def test_1d_core_errors(self, spectra, expected_error, axes):
         with pytest.raises(expected_error):
             plot_1d_to_axis(spectra, axes)
@@ -85,7 +85,7 @@ class TestPlot1DCore:
           {'x_tick_labels': [(1, 'B'), (2, 'B'), (3, 'C')]},
           ([[0., 1.], [2., 3.]], [[1., 2.], [2., 4.]]),
           #  Note that duplicated points get plotted twice. Weird but harmless.
-          [(1., 'B'), (1., 'B'), (2., 'C')]
+          [(1., 'B'), (1., 'B'), (2., 'C')],
           )])
     def test_plot_single_spectrum(self, spectrum_args, spectrum_kwargs,
                                   expected_data, expected_ticks, axes):
@@ -120,7 +120,7 @@ class TestPlot1DCore:
          # Case 2: Two lines with split points
          (spec1dcol_split_args,
           ([[0., 1.], [2., 3.]], [[1., 2.], [2., 4.]],
-           [[0., 1.], [5., 4.]], [[1., 2.], [3., 2.]]))
+           [[0., 1.], [5., 4.]], [[1., 2.], [3., 2.]])),
            ])
     def test_plot_collection(self, spectrum_args, expected_data, axes):
         plot_1d_to_axis(Spectrum1DCollection(*spectrum_args), axes)
@@ -189,7 +189,7 @@ class TestPlot1DCore:
 
     @pytest.mark.parametrize('kwargs', [
         ({'ls': '--'}),
-        ({'color': 'r', 'ms': '+'})
+        ({'color': 'r', 'ms': '+'}),
     ])
     def test_extra_plot_kwargs(self, mocker, axes, kwargs):
         mock = mocker.patch('matplotlib.axes.Axes.plot',
@@ -244,7 +244,7 @@ class TestPlot1D:
                                             {'label': 'Line B'},
                                             {'label': 'Line C'}]}),
          ['Line D', 'Line E'],
-         {})
+         {}),
          ])
     def test_plot_single(self, mocker, spectrum, labels, kwargs):
         core = self.mock_core(mocker)
@@ -313,7 +313,7 @@ class TestPlot1D:
         (Spectrum1D(*spec1d_args), {'ms': '*', 'color': 'g'}),
         (Spectrum1DCollection(*spec1dcol_args), {'ms': '*', 'color': 'g'}),
         (Spectrum1DCollection(*spec1dcol_args),
-         {'label': 'Line A', 'color': 'k'})
+         {'label': 'Line A', 'color': 'k'}),
     ])
     def test_plot_kwargs(self, mocker, spec, kwargs):
         mock = mocker.patch('matplotlib.axes.Axes.plot',

--- a/tests_and_analysis/test/euphonic_test/test_powder.py
+++ b/tests_and_analysis/test/euphonic_test/test_powder.py
@@ -41,7 +41,7 @@ def jitter(request):
                            (8, 4), {'jitter': None}),
                           (13, 'spherical-polar-improved',
                            (13,), {'jitter': None}),
-                          (7, 'random-sphere', (7,), {})]
+                          (7, 'random-sphere', (7,), {})],
                          )
 def test_get_qpts_sphere(mocker, random_qpts_array, jitter,
                          npts, sampling, sampling_args, sampling_kwargs):
@@ -193,7 +193,7 @@ class TestSphereSampledProperties:
                                'sampling': 'spherical-polar-improved',
                                'energy_bins': None,
                                'scattering_lengths': _scattering_lengths,
-                               'dw': 'mock_dw'}
+                               'dw': 'mock_dw'},
                               ])
     def test_sample_sphere_structure_factor(self, mocker, mock_crystal,
                                             mock_fc, mock_qpm,
@@ -267,7 +267,7 @@ class TestQpointConversion:
         [[0., 0., 0.5], [1, 1, 0.1], [-1, 2., 0.0]]])
     def nontrivial_crystal(self, request):
         """Some arbitrary non-diagonal lattices"""
-        return Crystal(np.asarray(request.param, dtype=float
+        return Crystal(np.asarray(request.param, dtype=float,
                                   ) * ureg('angstrom'),
                        np.array([[0., 0., 0.]]),
                        np.array(['Si']), np.array([28.055]) * ureg('amu'))
@@ -283,7 +283,7 @@ class TestQpointConversion:
     @staticmethod
     def test_qpts_cart_to_frac_trivial(trivial_crystal, trivial_qpts):
         """Check internal method for q-point conversion with trivial example"""
-        cart_qpts = np.asarray(trivial_qpts['cart'], dtype=float
+        cart_qpts = np.asarray(trivial_qpts['cart'], dtype=float,
                                ) * ureg('1 / angstrom')
         frac_qpts = np.asarray(trivial_qpts['frac'], dtype=float)
         calc_frac_qpts = _qpts_cart_to_frac(cart_qpts, trivial_crystal)
@@ -295,7 +295,7 @@ class TestQpointConversion:
                                          nontrivial_crystal):
         frac_qpts = random_qpts_array
         cart_qpts = frac_qpts.dot(nontrivial_crystal.reciprocal_cell()
-                                  .to('1 / angstrom').magnitude
+                                  .to('1 / angstrom').magnitude,
                                   ) * ureg('1 / angstrom')
         calc_frac_qpts = _qpts_cart_to_frac(cart_qpts, nontrivial_crystal)
 

--- a/tests_and_analysis/test/euphonic_test/test_qpoint_frequencies.py
+++ b/tests_and_analysis/test/euphonic_test/test_qpoint_frequencies.py
@@ -269,12 +269,12 @@ class TestQpointFrequenciesCreation:
          ValueError),
         ('frequencies',
          get_expected_qpt_freqs(
-             'quartz', 'quartz_666_qpoint_frequencies.json'
+             'quartz', 'quartz_666_qpoint_frequencies.json',
          ).frequencies.magnitude,
          TypeError),
         ('frequencies',
          get_expected_qpt_freqs(
-             'quartz', 'quartz_666_qpoint_frequencies.json'
+             'quartz', 'quartz_666_qpoint_frequencies.json',
          ).frequencies.magnitude*ureg('kg'),
          DimensionalityError),
         ('weights',
@@ -415,7 +415,7 @@ class TestQpointFrequenciesSetters:
         ('quartz', 'quartz_reciprocal_qpoint_frequencies.json',
          'frequencies', '1/cm', 2.),
         ('quartz', 'quartz_reciprocal_qpoint_frequencies.json',
-         'frequencies', 'meV', 3.)
+         'frequencies', 'meV', 3.),
         ])
     def test_setter_correct_units(self, material, json_file, attr,
                                   unit, scale):
@@ -454,7 +454,7 @@ class TestQpointFrequenciesCalculateDos:
             ('quartz', 'toy_quartz_qpoint_frequencies.json',
              'toy_quartz_cropped_uneven_hartree_dos.json',
              np.concatenate((np.arange(5, 21, 2),
-                             np.arange(21, 30)))*ureg('meV').to('hartree'))
+                             np.arange(21, 30)))*ureg('meV').to('hartree')),
         ])
     def test_calculate_dos(
             self, material, qpt_freqs_json, expected_dos_json, ebins):
@@ -589,7 +589,7 @@ class TestQpointFrequenciesCalculateDosMap:
             ('NaCl', 'NaCl_band_yaml_from_phonopy_qpoint_frequencies.json',
              np.arange(0, 300, 5)*ureg('1/cm'),
              'NaCl_band_yaml_dos_map.json',
-             does_not_raise())
+             does_not_raise()),
         ])
     def test_calculate_dos_map(
             self, material, qpt_freqs_json, ebins, expected_dos_map_json, context):
@@ -619,7 +619,7 @@ class TestQpointFrequenciesCalculateDosMap:
              np.arange(0, 250, 4)*ureg('1/cm'),
              {'mode_widths': get_test_nacl_mode_widths(),
               'mode_widths_min': 1.1*ureg('meV')},
-             [0, 15])
+             [0, 15]),
         ])
     def test_calculate_dos_map_gives_same_result_as_dos_at_single_qpt(
             self, material, qpt_freqs_json, ebins, dos_kwargs, qpts_to_test):
@@ -654,7 +654,7 @@ class TestQpointFrequenciesGetDispersion:
                           match="Could not determine cell symmetry, using generic q-point labels")),
             ('NaCl', 'NaCl_band_yaml_from_phonopy_qpoint_frequencies.json',
              'NaCl_band_yaml_dispersion.json',
-             does_not_raise())
+             does_not_raise()),
         ])
     def test_get_dispersion(
             self, material, qpt_freqs_json, expected_dispersion_json, context):

--- a/tests_and_analysis/test/euphonic_test/test_qpoint_phonon_modes.py
+++ b/tests_and_analysis/test/euphonic_test/test_qpoint_phonon_modes.py
@@ -464,7 +464,7 @@ class TestQpointPhononModesSetters:
 
     @pytest.mark.parametrize('material, attr, unit, scale', [
         ('quartz', 'frequencies', '1/cm', 2.),
-        ('quartz', 'frequencies', 'meV', 3.)
+        ('quartz', 'frequencies', 'meV', 3.),
         ])
     def test_setter_correct_units(self, material, attr, unit, scale):
         qpt_ph_modes = get_qpt_ph_modes(material)
@@ -536,7 +536,7 @@ class TestQpointPhononModesCalculateDebyeWaller:
         'material, qpt_ph_modes_file, expected_dw_json, temperature, kwargs', [
             ('CaHgO2', 'CaHgO2-666-grid.yaml',
                 'CaHgO2_666_300K_debye_waller.json', 300,
-                {'symmetrise': False})
+                {'symmetrise': False}),
         ])
     def test_calculate_debye_waller_from_phonopy(
             self, material, qpt_ph_modes_file,
@@ -568,7 +568,7 @@ class TestQpointPhononModesCalculateDos:
     @pytest.mark.parametrize(
         'material, qpt_ph_modes_file, expected_dos_json, ebins', [
             ('CaHgO2', 'CaHgO2-666-grid.yaml',
-             'CaHgO2_666_dos.json', np.arange(0, 95, 0.4)*ureg('meV'))
+             'CaHgO2_666_dos.json', np.arange(0, 95, 0.4)*ureg('meV')),
         ])
     def test_calculate_dos_from_phonopy(
             self, material, qpt_ph_modes_file,
@@ -669,7 +669,7 @@ class TestQpointPhononModesCalculatePdos:
              np.arange(0, 100, 0.8)*ureg('meV'), {'weighting': 'coherent'}),
             ('LZO', 'La2Zr2O7-666-grid.phonon', 'La2Zr2O7_666_incoh_pdos.json',
              np.arange(0, 100, 0.8)*ureg('meV'),
-             {'weighting': 'incoherent'})
+             {'weighting': 'incoherent'}),
         ])
     def test_calculate_pdos(
             self, material, qpt_ph_modes_file, expected_pdos_json, ebins,
@@ -729,7 +729,7 @@ class TestQpointPhononModesCalculatePdos:
              'quartz_554_full_mode_widths.json',
              'quartz_554_full_adaptive_dos_fast.json',
              np.arange(0, 155, 0.1)*ureg('meV'),
-             {'adaptive_method': 'fast'})
+             {'adaptive_method': 'fast'}),
         ])
     def test_total_dos_from_pdos_same_as_calculate_dos_with_mode_widths(
             self, material, qpt_ph_modes_json, mode_widths_json,
@@ -772,7 +772,7 @@ class TestQpointPhononModesGetDispersion:
             ('quartz', 'quartz_bandstructure_qpoint_phonon_modes.json',
              'quartz_bandstructure_dispersion.json'),
             ('NaCl', 'NaCl_band_yaml_from_phonopy_qpoint_phonon_modes.json',
-             'NaCl_band_yaml_dispersion.json')
+             'NaCl_band_yaml_dispersion.json'),
         ])
     def test_get_dispersion(
             self, material, qpt_ph_modes_json, expected_dispersion_json):

--- a/tests_and_analysis/test/euphonic_test/test_sampling.py
+++ b/tests_and_analysis/test/euphonic_test/test_sampling.py
@@ -30,7 +30,7 @@ class TestSquareSampling:
                             ({'npts': 3, 'offset': False, 'jitter': True},
                              [[0.0281824896325298, 0.12423963860186140],
                               [0.3926637961711317, 0.64394730653524050],
-                              [0.6225887445136473, 0.32029998295200524]])
+                              [0.6225887445136473, 0.32029998295200524]]),
                             ]
 
     @pytest.mark.parametrize('params, ref_results', gold_square_ref_data)
@@ -54,7 +54,7 @@ class TestSquareSampling:
                            ({'n_rows': 1, 'n_cols': 2,
                              'offset': False, 'jitter': True},
                             [[0.024406751963662376, 0.21518936637241948],
-                             [0.551381688035822, 0.044883182996896864]])
+                             [0.551381688035822, 0.044883182996896864]]),
                            ]
 
     @pytest.mark.parametrize('params, ref_results', reg_square_ref_data)

--- a/tests_and_analysis/test/euphonic_test/test_spectrum1d.py
+++ b/tests_and_analysis/test/euphonic_test/test_spectrum1d.py
@@ -405,7 +405,7 @@ class TestSpectrum1DMethods:
          'quartz_666_1meV_lorentz_broaden_dos.json',
         pytest.raises(
              ValueError,
-             match='Lorentzian function width must be specified as FWHM')
+             match='Lorentzian function width must be specified as FWHM'),
          ),
         ((1*ureg('meV'), {'method': 'convolve'}),
          'toy_quartz_cropped_uneven_dos.json',
@@ -501,7 +501,7 @@ class TestSpectrum1DMethods:
             ('xsq_bin_edges_spectrum1d.json',
              np.array([0., 1., 2., 3., 4., 5., 6., 8., 10., 12., 14., 16., 20.,
                        24., 28.]) * ureg('1/angstrom'),
-             {'restrict_range': True})
+             {'restrict_range': True}),
         ])
     def test_get_bin_edges(self, spectrum1d_file, expected_bin_edges, kwargs):
         spec1d = get_spectrum1d(spectrum1d_file)

--- a/tests_and_analysis/test/euphonic_test/test_spectrum1dcollection.py
+++ b/tests_and_analysis/test/euphonic_test/test_spectrum1dcollection.py
@@ -222,7 +222,7 @@ class TestSpectrum1DCollectionCreation:
            for i in range(1, 4)],
           get_spectrum1dcollection('methane_pdos_index_1_4.json')),
          ([get_spectrum1d('xsq_spectrum1d.json')],
-          get_spectrum1dcollection('xsq_from_single_spectrum1d.json'))
+          get_spectrum1dcollection('xsq_from_single_spectrum1d.json')),
          ])
     def test_create_from_sequence(self, input_spectra, expected_spectrum):
         spectrum = Spectrum1DCollection.from_spectra(input_spectra)
@@ -265,7 +265,7 @@ class TestSpectrum1DCollectionCreation:
     bad_sequences[4][0][1].x_tick_labels = [(0, "$\\Gamma$"), (54, "X")]
 
     @pytest.mark.parametrize(
-        'input_spectra, expected_error', bad_sequences
+        'input_spectra, expected_error', bad_sequences,
     )
     def test_create_from_bad_sequence(self, input_spectra, expected_error):
         with pytest.raises(expected_error):
@@ -289,26 +289,26 @@ class TestSpectrum1DCollectionCreation:
         'input_metadata, expected_metadata',
         [([{},
            {'label': 'H3'},
-           {'Another key': 'Anything'}
+           {'Another key': 'Anything'},
           ],
-          {'line_data': [{}, {'label': 'H3'}, {'Another key': 'Anything'}]}
+          {'line_data': [{}, {'label': 'H3'}, {'Another key': 'Anything'}]},
          ),
          ([{'desc': 'PDOS H2', 'common_key_value': 3},
            {'desc': 'PDOS H3', 'label': 'H3', 'common_key_value': 3},
-           {'desc': 'PDOS', 'common_key_value': 3}
+           {'desc': 'PDOS', 'common_key_value': 3},
           ],
           {'common_key_value': 3, 'line_data': [
                {'desc': 'PDOS H2'},
                {'desc': 'PDOS H3', 'label': 'H3'},
-               {'desc': 'PDOS'}]}
+               {'desc': 'PDOS'}]},
          ),
          ([{'desc': 'methane PDOS'}, {}, {}],
           {'line_data': [{'desc': 'methane PDOS'}, {}, {}]}),
          ([{'desc': 'methane PDOS'},
            {'desc': 'methane PDOS'},
-           {'desc': 'methane PDOS'}
+           {'desc': 'methane PDOS'},
           ],
-          {'desc': 'methane PDOS'}
+          {'desc': 'methane PDOS'},
          )])
     def test_create_methane_pdos_from_sequence_metadata_handling(
             self, input_metadata, expected_metadata):
@@ -460,7 +460,7 @@ class TestSpectrum1DCollectionIndexAccess:
         [(get_spectrum1dcollection('gan_bands.json'), np.arange(2, 5),
           get_expected_spectrum1dcollection('gan_bands_index_2_5.json')),
          (get_spectrum1dcollection('gan_bands.json'), [2, 3, 4],
-          get_expected_spectrum1dcollection('gan_bands_index_2_5.json'))
+          get_expected_spectrum1dcollection('gan_bands_index_2_5.json')),
          ])
     def test_index_sequence(self, spectrum, index, expected_spectrum):
         extracted_spectrum = spectrum[index]
@@ -578,7 +578,7 @@ class TestSpectrum1DCollectionMethods:
 
     @pytest.mark.parametrize(
         'spectrum_file, summed_spectrum_file', [
-            ('quartz_666_pdos.json', 'quartz_666_dos.json')
+            ('quartz_666_pdos.json', 'quartz_666_dos.json'),
         ])
     def test_sum(self, spectrum_file, summed_spectrum_file):
         spec_col = get_spectrum1dcollection(spectrum_file)
@@ -591,7 +591,7 @@ class TestSpectrum1DCollectionMethods:
             ('La2Zr2O7_666_incoh_pdos.json', ('species',),
              'La2Zr2O7_666_incoh_species_pdos.json'),
             ('La2Zr2O7_666_coh_pdos.json', ('species',),
-             'La2Zr2O7_666_coh_species_pdos.json')
+             'La2Zr2O7_666_coh_species_pdos.json'),
             ])
     def test_group_by(self, spectrum_file, group_by_args,
                       grouped_spectrum_file):
@@ -637,7 +637,7 @@ class TestSpectrum1DCollectionMethods:
               'line_data': [
                   {'index': 10},
                   {'sample': 2, 'index': 5},
-                  {'sample': 0, 'inst': 'TOSCA', 'index': 7}]})
+                  {'sample': 0, 'inst': 'TOSCA', 'index': 7}]}),
             ])
     def test_group_by_fake_metadata(
             self, spectrum_file, metadata, group_by_args, expected_metadata):
@@ -669,7 +669,7 @@ class TestSpectrum1DCollectionMethods:
              'methane_pdos_index_1_4.json'),
             ('La2Zr2O7_666_coh_incoh_species_append_pdos.json',
              {'weighting': 'coherent'},
-             'La2Zr2O7_666_coh_species_pdos.json')
+             'La2Zr2O7_666_coh_species_pdos.json'),
             ])
     def test_select(self, spectrum_file, select_kwargs,
                     selected_spectrum_file):
@@ -726,7 +726,7 @@ class TestSpectrum1DCollectionMethods:
         'spectrum_file, other_spectrum_file, expected_spectrum_file', [
             ('La2Zr2O7_666_coh_species_pdos.json',
              'La2Zr2O7_666_incoh_species_pdos.json',
-             'La2Zr2O7_666_coh_incoh_species_append_pdos.json')
+             'La2Zr2O7_666_coh_incoh_species_append_pdos.json'),
             ])
     def test_add(self, spectrum_file, other_spectrum_file,
                  expected_spectrum_file):

--- a/tests_and_analysis/test/euphonic_test/test_spectrum2d.py
+++ b/tests_and_analysis/test/euphonic_test/test_spectrum2d.py
@@ -353,19 +353,19 @@ class TestSpectrum2DMethods:
              pytest.warns(UserWarning,
                           match="Not all x-axis bins are the same width")),
             (({'x_width': (lambda x: np.polyval([0.2, -0.5],
-                                                x.to('1/nm').magnitude
+                                                x.to('1/nm').magnitude,
                                                 ) * ureg('1/nm')),
                'y_width': (lambda y: np.polyval([0., -0.4, 3.],
-                                                y.to('J').magnitude
+                                                y.to('J').magnitude,
                                                 ) * ureg('J')),
                'width_fit': 'cubic'},
               'synthetic_x.json', 'synthetic_x_poly_broadened.json',
               does_not_raise())),
             (({'x_width': (lambda x: np.polyval([0.2, -0.5],
-                                                x.to('1/nm').magnitude
+                                                x.to('1/nm').magnitude,
                                                 ) * ureg('1/nm')),
                'y_width': (lambda y: np.polyval([0., -0.4, 3.],
-                                                y.to('J').magnitude
+                                                y.to('J').magnitude,
                                                 ) * ureg('J')),
                'width_fit': 'cheby-log'},
               'synthetic_x.json', 'synthetic_x_poly_broadened_cheby.json',
@@ -392,7 +392,7 @@ class TestSpectrum2DMethods:
     @pytest.mark.parametrize('unequal_bin_json, unequal_axes', [
         ('La2Zr2O7_cut_sqw_uneven_bins.json', ['y_data']),
         ('quartz_bandstructure_dos_map.json', ['x_data']),
-        ('quartz_bandstructure_dos_map_uneven_bins.json', ['x_data', 'y_data'])
+        ('quartz_bandstructure_dos_map_uneven_bins.json', ['x_data', 'y_data']),
         ])
     def test_broaden_uneven_bins_and_explicit_convolve_warns(
             self, unequal_bin_json, unequal_axes):
@@ -425,7 +425,7 @@ class TestSpectrum2DMethods:
 
         # Force regular x bins so x-broadening is allowed
         spectrum.x_data = np.linspace(
-            1, 10,len(spectrum.get_bin_edges())
+            1, 10,len(spectrum.get_bin_edges()),
         ) * spectrum.get_bin_edges().units
         fixed_broad_x = spectrum.broaden(x_width=fwhm)
         variable_broad_x = spectrum.broaden(
@@ -478,7 +478,7 @@ class TestSpectrum2DMethods:
                             expected_bin_centres.magnitude)
 
     @pytest.mark.parametrize(
-        'bin_ax', ['x', 'y']
+        'bin_ax', ['x', 'y'],
     )
     def test_get_bin_edges_with_invalid_data_shape_raises_value_error(
             self, bin_ax):
@@ -488,7 +488,7 @@ class TestSpectrum2DMethods:
             spec2d.get_bin_centres()
 
     @pytest.mark.parametrize(
-        'bin_ax', ['x', 'y']
+        'bin_ax', ['x', 'y'],
     )
     def test_get_bin_centres_with_invalid_data_shape_raises_value_error(
             self, bin_ax):
@@ -563,7 +563,7 @@ class TestKinematicAngles:
         [((0, np.pi / 2), (1, 0)),
          ((np.pi / 2, 0), (1, 0)),
          ((0, 1.4 * np.pi), (1, -1)),
-         ((-2.25 * np.pi, -2.5 * np.pi), (np.sqrt(2) / 2, 0))
+         ((-2.25 * np.pi, -2.5 * np.pi), (np.sqrt(2) / 2, 0)),
          ])
     def test_cos_range(self, angle_range, expected):
         from euphonic.spectra.base import _get_cos_range
@@ -589,7 +589,7 @@ class TestKinematicConstraints:
           'NaCl_constrained_ef_32_cm_angle_45_135.json'),
          ({'e_f': 32 * ureg('1/cm'), 'angle_range': (-135., -45.)},
           'NaCl_band_yaml_dos_map.json',
-          'NaCl_constrained_ef_32_cm_angle_45_135.json')
+          'NaCl_constrained_ef_32_cm_angle_45_135.json'),
          ])
     def test_kinematic_constraints(self, kwargs,
                                    spectrum2d_file, constrained_file):

--- a/tests_and_analysis/test/euphonic_test/test_spectrum2dcollection.py
+++ b/tests_and_analysis/test/euphonic_test/test_spectrum2dcollection.py
@@ -101,7 +101,7 @@ def rand_spectrum2d(seed: int = 1,
 
     return Spectrum2D(x_data=x_bins,
                           y_data=y_bins,
-                          z_data=rng.random([len(x_bins) - 1, len(y_bins) - 1]
+                          z_data=rng.random([len(x_bins) - 1, len(y_bins) - 1],
                                             ) * ureg("millibarn / meV"),
                           metadata=metadata)
 
@@ -167,7 +167,7 @@ class TestSpectrum2DCollectionCreation:
         ],
     )
     def test_from_bad_spectra(
-        self, bad_item_name, message, quartz_fuzzy_items, request
+        self, bad_item_name, message, quartz_fuzzy_items, request,
     ):
         """Spectrum2DCollection.from_spectra with inconsistent input"""
 
@@ -187,24 +187,24 @@ class TestSpectrum2DCollectionCreation:
 
         Spectrum2DCollection.from_spectra(
             [*quartz_fuzzy_items, inconsistent_x_item],
-            unsafe=True
+            unsafe=True,
         )
 
         Spectrum2DCollection.from_spectra(
             [*quartz_fuzzy_items, inconsistent_x_units_item],
-            unsafe=True
+            unsafe=True,
         )
 
         # Inconsistent length will still cause trouble but should fall to numpy
         with pytest.raises(ValueError, match="could not broadcast input"):
             Spectrum2DCollection.from_spectra(
                 [*quartz_fuzzy_items, inconsistent_x_length_item],
-                unsafe=True
+                unsafe=True,
             )
 
         Spectrum2DCollection.from_spectra(
             [*quartz_fuzzy_items, inconsistent_y_item],
-            unsafe=True
+            unsafe=True,
         )
 
 
@@ -242,7 +242,7 @@ class TestSpectrum2DCollectionFunctionality:
         assert item_1_to_end != quartz_fuzzy_collection
 
         for item, ref in zip(
-            item_1_to_end, quartz_fuzzy_items[1:], strict=True
+            item_1_to_end, quartz_fuzzy_items[1:], strict=True,
         ):
             assert isinstance(item, Spectrum2D)
             check_spectrum2d(item, ref)
@@ -269,12 +269,12 @@ class TestSpectrum2DCollectionFunctionality:
 
         np.testing.assert_allclose(
             quartz_fuzzy_collection.get_bin_centres("x"),
-            np.linspace(0, 1, 10) * ureg("1 / angstrom")
+            np.linspace(0, 1, 10) * ureg("1 / angstrom"),
         )
 
         np.testing.assert_allclose(
             quartz_fuzzy_collection.get_bin_edges("y"),
-            np.linspace(0, 100, 20) * ureg("1 / angstrom")
+            np.linspace(0, 100, 20) * ureg("1 / angstrom"),
         )
 
     def test_collection_methods(self, quartz_fuzzy_collection):

--- a/tests_and_analysis/test/euphonic_test/test_structure_factor.py
+++ b/tests_and_analysis/test/euphonic_test/test_structure_factor.py
@@ -381,7 +381,7 @@ class TestStructureFactorSetters:
         ('quartz', 'quartz_0K_structure_factor.json',
          'structure_factors', 'mbarn', 3.),
         ('quartz', 'quartz_0K_structure_factor.json',
-         'temperature', 'K', 2.)
+         'temperature', 'K', 2.),
         ])
     def test_setter_correct_units(self, material, json_file, attr,
                                   unit, scale):
@@ -479,7 +479,7 @@ class TestStructureFactorGetDispersion:
             ('quartz', 'quartz_bandstructure_structure_factor.json',
              'quartz_bandstructure_dispersion.json'),
             ('LZO', 'La2Zr2O7_cut_structure_factor.json',
-             'LZO_cut_dispersion.json')
+             'LZO_cut_dispersion.json'),
         ])
     def test_get_dispersion(
             self, material, sf_json, expected_dispersion_json):

--- a/tests_and_analysis/test/euphonic_test/test_util.py
+++ b/tests_and_analysis/test/euphonic_test/test_util.py
@@ -115,7 +115,7 @@ class TestModeGradientsToWidths:
          'lzo_222_full_mode_widths.json'),
         (get_modg_norm('lzo_222_full_mode_gradients.json'),
          get_crystal('LZO').cell_vectors,
-         'lzo_222_full_mode_widths.json')
+         'lzo_222_full_mode_widths.json'),
         ])
     def test_mode_gradients_to_widths(self, mode_grads, cell_vecs,
                                       expected_mode_widths_file):

--- a/tests_and_analysis/test/euphonic_test/test_writers.py
+++ b/tests_and_analysis/test/euphonic_test/test_writers.py
@@ -53,7 +53,7 @@ def modes_data(
 def test_phonon_website_writer(
         modes_data: tuple[
             QpointPhononModes, WritePhononWebsiteKwargs, PhononWebsiteData],
-        tmp_path
+        tmp_path,
 ) -> None:
     """Test QpointPhononModes -> phonon website JSON matches reference"""
     modes, kwargs, ref_data = modes_data
@@ -101,7 +101,7 @@ class TestPhononWebsiteWriterInternals:
          [(1, r"$\Gamma$"), (5, r"X")]),
         # 3-way merge:
         ([(1, "X"), (2, "Y"), (3, "Z"), (5, "OK")],
-         [(3, "X|Y|Z"), (5, "OK")])
+         [(3, "X|Y|Z"), (5, "OK")]),
         ])
     def test_combine_neighbouring_labels(
             self, x_tick_labels: XTickLabels, expected: XTickLabels) -> None:

--- a/tests_and_analysis/test/script_tests/test_brille_convergence.py
+++ b/tests_and_analysis/test/script_tests/test_brille_convergence.py
@@ -135,7 +135,7 @@ class TestRegression:
           '--n-threads', '2', '--asr', 'realspace'],
           {'grid_type': 'mesh', 'interpolation_kwargs': {'asr': 'realspace',
                                                          'use_c': True,
-                                                         'n_threads': 2}})
+                                                         'n_threads': 2}}),
     ])
     def test_brille_interpolator_from_force_constants_kwargs_passed(
             self, inject_mocks, mocker, brille_conv_args, expected_kwargs):

--- a/tests_and_analysis/test/script_tests/test_optimise_dipole_parameter.py
+++ b/tests_and_analysis/test/script_tests/test_optimise_dipole_parameter.py
@@ -43,7 +43,7 @@ class TestRegression:
               '--dipole-parameter-min=0.1', '--dipole-parameter-max=0.4',
               '--dipole-parameter-step=0.1'], 15, np.linspace(0.1, 0.4, 4),
              {'asr': 'reciprocal', 'use_c': False},
-             "Born charges not found for this material")
+             "Born charges not found for this material"),
         ])
     def test_calc_qpt_phonon_modes_called_with_correct_args(
             self, mocker, fc_file, opt_dipole_par_args, expected_n_qpts,

--- a/tests_and_analysis/test/script_tests/test_powder_map.py
+++ b/tests_and_analysis/test/script_tests/test_powder_map.py
@@ -155,7 +155,7 @@ class TestRegression:
         (['--use-brille', '--brille-grid-type', 'mesh', '--use-c',
           '--n-threads', '2'],
           {'grid_type': 'mesh', 'interpolation_kwargs': {'use_c': True,
-                                                         'n_threads': 2}})
+                                                         'n_threads': 2}}),
     ])
     def test_brille_interpolator_from_force_constants_kwargs_passed(
             self, inject_mocks, mocker, powder_map_args, expected_kwargs):

--- a/tests_and_analysis/test/script_tests/utils.py
+++ b/tests_and_analysis/test/script_tests/utils.py
@@ -35,7 +35,7 @@ def get_script_test_data_path(*subpaths: tuple[str]) -> str:
     return get_data_path('script_data', *subpaths)
 
 
-def get_plot_line_data(fig: Optional['matplotlib.figure.Figure'] = None
+def get_plot_line_data(fig: Optional['matplotlib.figure.Figure'] = None,
                        ) -> dict[str, Any]:
     if fig is None:
         fig = matplotlib.pyplot.gcf()
@@ -57,7 +57,7 @@ def get_all_figs() -> list['matplotlib.figure.Figure']:
 
 
 
-def get_all_plot_line_data(figs: list['matplotlib.figure.Figure']
+def get_all_plot_line_data(figs: list['matplotlib.figure.Figure'],
                            ) -> list[dict[str, Any]]:
     return [get_plot_line_data(fig) for fig in figs]
 
@@ -125,7 +125,7 @@ def get_current_plot_image_data() -> dict[str,
     return data
 
 
-def get_ax_image_data(ax: 'matplotlib.axes.Axes'
+def get_ax_image_data(ax: 'matplotlib.axes.Axes',
                       ) -> dict[str, str | list[float] | list[int]]:
     im = ax.get_images()[0]
     # Convert negative zero to positive zero


### PR DESCRIPTION
Add/remove trailing commas for consistency
- remove trailing commas where they might cause confusion
- add trailing commas for clearer diffs when adding/removing elements to/from collections