### PR TITLE
Register pytest marks in pyproject.toml

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,13 @@
 `Unreleased <https://github.com/pace-neutrons/Euphonic/compare/v1.4.4...HEAD>`_
 -------------------------------------------------------------------------------
 
+- Maintenance
+
+  - Pytest configuration has been moved from
+    tests_and_analysis/test/pytest.ini to the main
+    pyproject.toml. This means it is more likely to be picked up
+    automatically when running tests outside of the CI workflows.
+
 `v1.4.4 <https://github.com/pace-neutrons/Euphonic/compare/v1.4.3...v1.4.4>`_
 -----------------------------------------------------------------------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,6 +68,15 @@ euphonic-show-sampling = "euphonic.cli.show_sampling:main"
 euphonic-intensity-map = "euphonic.cli.intensity_map:main"
 euphonic-powder-map = "euphonic.cli.powder_map:main"
 
+[tool.pytest.ini_options]
+markers = [
+    "brille: test requires 'brille' extra",
+    "c_extension: test requires C extension to be available",
+    "matplotlib: test requires 'matplotlib' extra",
+    "multiple_extras: test requires multiple extras to be installed",
+    "phonopy_reader: test requires 'phonopy-reader' extra",
+]
+
 [tool.ruff]
 line-length = 79
 target-version = "py310"

--- a/tests_and_analysis/test/pytest.ini
+++ b/tests_and_analysis/test/pytest.ini
@@ -1,7 +1,0 @@
-[pytest]
-markers =
-    phonopy_reader: requires euphonic[phonopy_reader] extra to be installed
-    matplotlib: requires euphonic[matplotlib] extra to be installed
-    brille: requires euphonic[brille] extra to be installed
-    multiple_extras: requires any combination of the above extras e.g. phonopy_reader and matplotlib
-    c_extension: Requires c extension compiled


### PR DESCRIPTION
Currently the test suite produces a lot of warnings about the "marks" used to control which subset of tests runs.

I see these when running locally, but not in the CI logs. Not sure if they are suppressed somehow or it is a matter of different pytest versions, but it doesn't hurt to clear them up either way.

(Tox tends to hide the pytest warnings but you can see them in the GCC14 CI logs, which call the run_tests.py script directly. e.g. https://github.com/pace-neutrons/Euphonic/actions/runs/15066709878/job/42353084713)