### PR TITLE
Linting: pycodestyle-error

### DIFF
--- a/euphonic/broadening.py
+++ b/euphonic/broadening.py
@@ -77,7 +77,8 @@ def variable_width_broadening(
     """
 
     if width_convention.lower() == 'fwhm' and shape == 'gauss':
-        sigma_function = (lambda x: width_function(x) * FWHM_TO_SIGMA)
+        def sigma_function(x: Quantity) -> Quantity:
+            return width_function(x) * FWHM_TO_SIGMA
     elif width_convention.lower() == 'std' and shape == 'lorentz':
         msg = (
             'Standard deviation unavailable for Lorentzian '

--- a/euphonic/cli/dispersion.py
+++ b/euphonic/cli/dispersion.py
@@ -85,8 +85,8 @@ def main(params: Optional[list[str]] = None) -> None:
 
 
 def get_parser() -> ArgumentParser:
-    parser, groups = _get_cli_parser(features={'read-fc', 'read-modes', 'plotting',
-                                          'q-e', 'btol'})
+    parser, groups = _get_cli_parser(
+        features={'read-fc', 'read-modes', 'plotting', 'q-e', 'btol'})
     parser.description = (
         'Plots a band structure from the file provided. If a force '
         'constants file is provided, a band structure path is '

--- a/euphonic/cli/optimise_dipole_parameter.py
+++ b/euphonic/cli/optimise_dipole_parameter.py
@@ -124,7 +124,8 @@ def calculate_optimum_dipole_parameter(
         print('******************************')
         print(('Suggested optimum dipole_parameter is ' + dparamfmt).format(
             dipole_parameters[opt]))
-        print((sfmt + ': ' + tfmt + ' s').format('Initialisation Time', t_init[opt]))
+        print((sfmt + ': ' + tfmt + ' s').format(
+            'Initialisation Time', t_init[opt]))
         print((sfmt + ': ' + tfmt + ' ms\n').format(
             'Time/qpt', t_per_qpt[opt]*1000))
 

--- a/euphonic/cli/optimise_dipole_parameter.py
+++ b/euphonic/cli/optimise_dipole_parameter.py
@@ -16,6 +16,12 @@ import numpy as np
 from euphonic import ForceConstants
 from euphonic.cli.utils import _get_cli_parser, get_args, load_data_from_file
 
+# Formatting string for timing output TEXT: VALUE UNITS
+TIMING_TEMPLATE = '{:20s}: {:3.2f} {:s}\n'
+
+# Formatting string for dipole parameter output TEXT VALUE
+DPARAM_TEMPLATE = '{:s} {:2.2f}'
+
 
 def main(params: Optional[list[str]] = None) -> None:
     args = get_args(get_parser(), params)
@@ -87,13 +93,11 @@ def calculate_optimum_dipole_parameter(
         warnings.warn('Born charges not found for this material - '
                       'changing dipole_parameter will have no effect.',
                       stacklevel=1)
-    sfmt = '{:20s}'
-    tfmt = '{: 3.2f}'
-    dparamfmt = '{: 2.2f}'
+
     for i, dipole_parameter in enumerate(dipole_parameters):
         if print_to_terminal:
-            print(('Results for dipole_parameter ' + dparamfmt).format(
-                dipole_parameter))
+            print(DPARAM_TEMPLATE.format(
+                'Results for dipole_parameter ', dipole_parameter))
 
         # Time Ewald sum initialisation
         start = time.time()
@@ -103,8 +107,8 @@ def calculate_optimum_dipole_parameter(
         end = time.time()
         t_init[i] = end - start
         if print_to_terminal:
-            print((sfmt + ': ' + tfmt + ' s').format(
-                'Initialisation Time', t_init[i]))
+            print(TIMING_TEMPLATE.format(
+                'Initialisation Time', t_init[i], 's'))
 
         # Time per qpt
         qpts = np.full((n, 3), 0.5)
@@ -117,17 +121,18 @@ def calculate_optimum_dipole_parameter(
         end = time.time()
         t_per_qpt[i] = (end - start)/n
         if print_to_terminal:
-            print((sfmt + ': ' + tfmt + ' ms\n').format(
-                'Time/qpt', t_per_qpt[i]*1000))
+            print(TIMING_TEMPLATE.format(
+                'Time/qpt', t_per_qpt[i]*1000, 'ms'))
+
     opt = np.argmin(t_per_qpt)
     if print_to_terminal:
         print('******************************')
-        print(('Suggested optimum dipole_parameter is ' + dparamfmt).format(
-            dipole_parameters[opt]))
-        print((sfmt + ': ' + tfmt + ' s').format(
-            'Initialisation Time', t_init[opt]))
-        print((sfmt + ': ' + tfmt + ' ms\n').format(
-            'Time/qpt', t_per_qpt[opt]*1000))
+        print(DPARAM_TEMPLATE.format(
+            'Suggested optimum dipole_parameter is ', dipole_parameters[opt]))
+        print(TIMING_TEMPLATE.format(
+            'Initialisation Time', t_init[opt], 's'))
+        print(TIMING_TEMPLATE.format(
+            'Time/qpt', t_per_qpt[opt]*1000, 'ms'))
 
     return (dipole_parameters[opt], t_init[opt], t_per_qpt[opt],
             dipole_parameters, t_init, t_per_qpt)

--- a/euphonic/crystal.py
+++ b/euphonic/crystal.py
@@ -264,7 +264,8 @@ class Crystal:
                 diff_frac = (atom_r_symm_i[:, np.newaxis, :]
                              - self.atom_r[np.newaxis, idx, :])
                 diff_frac -= np.floor(diff_frac + 0.5)
-                diff_cart = np.einsum('ijk,kl->ijl', diff_frac, self._cell_vectors)
+                diff_cart = np.einsum(
+                    'ijk,kl->ijl', diff_frac, self._cell_vectors)
                 diff_r = np.linalg.norm(diff_cart, axis=2)
                 equiv_idx = np.where(diff_r < tol_calc)
                 # There should be one matching atom per symm op

--- a/euphonic/force_constants.py
+++ b/euphonic/force_constants.py
@@ -396,7 +396,7 @@ class ForceConstants:
           \\sum_{l}\\Phi_{\\alpha\\alpha^\\prime}^{\\kappa\\kappa^\\prime}\\exp\\left(-i\\mathbf{q}\\cdot \\mathbf{R}_l\\right)
 
         .. [3] J. R. Yates, X. Wang, D. Vanderbilt and I. Souza, Phys. Rev. B, 2007, 75, 195121
-        """
+        """  # noqa: E501
         qpts, freqs, weights, evecs, grads = self._calculate_phonons_at_qpts(
             qpts, weights, asr, dipole, dipole_parameter, splitting,
             insert_gamma, reduce_qpts, use_c, n_threads,
@@ -1057,7 +1057,8 @@ casting to real mode gradients.
                     # Calculate H_ab
                     exp_term = 2*np.exp(-norms_2)/(sqrt_pi*norms_2)
                     erfc_term = erfc(norms)/(norms*norms_2)
-                    f1 = lambda_2*(3*erfc_term/norms_2 + exp_term*(3/norms_2 + 2))
+                    f1 = lambda_2 * (3 * erfc_term / norms_2
+                                     + exp_term * (3 / norms_2 + 2))
                     f2 = erfc_term + exp_term
                     deltas_ab = np.einsum('ij,ik->ijk', deltas, deltas)
                     H_ab_tmp[:, idx + j] = (
@@ -1703,7 +1704,9 @@ casting to real mode gradients.
             A dictionary with the following keys/values:
 
             - 'crystal': dict, see Crystal.from_dict
-            - 'force_constants': (n_cells_in_sc, 3*crystal.n_atoms, 3*crystal.n_atoms) float ndarray
+            - 'force_constants':
+              (n_cells_in_sc, 3*crystal.n_atoms, 3*crystal.n_atoms)
+              float ndarray
             - 'force_constants_unit': str
             - 'sc_matrix': (3,3) int ndarray
             - 'cell_origins': (n_cells_in_sc, 3) int ndarray

--- a/euphonic/io.py
+++ b/euphonic/io.py
@@ -19,7 +19,7 @@ def _to_json_dict(dictionary: dict[str, Any]) -> dict[str, Any]:
     """
     for key, val in dictionary.items():
         if isinstance(val, np.ndarray):
-            if val.dtype == np.complex128:
+            if val.dtype is np.complex128:
                 val = val.view(np.float64,                   # noqa: PLW2901
                                ).reshape([*val.shape, 2])
             dictionary[key] = val.tolist()
@@ -43,7 +43,7 @@ def _from_json_dict(dictionary: dict[str, Any],
         if isinstance(val, list):
             if key in type_dict and type_dict[key] is tuple:
                 dictionary[key] = [tuple(x) for x in val]
-            elif key in type_dict and type_dict[key] == np.complex128:
+            elif key in type_dict and type_dict[key] is np.complex128:
                 dictionary[key] = np.array(
                     val, dtype=np.float64).view(np.complex128).squeeze(axis=-1)
             else:

--- a/euphonic/io.py
+++ b/euphonic/io.py
@@ -19,7 +19,7 @@ def _to_json_dict(dictionary: dict[str, Any]) -> dict[str, Any]:
     """
     for key, val in dictionary.items():
         if isinstance(val, np.ndarray):
-            if val.dtype is np.complex128:
+            if val.dtype == np.complex128:
                 val = val.view(np.float64,                   # noqa: PLW2901
                                ).reshape([*val.shape, 2])
             dictionary[key] = val.tolist()
@@ -43,7 +43,7 @@ def _from_json_dict(dictionary: dict[str, Any],
         if isinstance(val, list):
             if key in type_dict and type_dict[key] is tuple:
                 dictionary[key] = [tuple(x) for x in val]
-            elif key in type_dict and type_dict[key] is np.complex128:
+            elif key in type_dict and type_dict[key] == np.complex128:
                 dictionary[key] = np.array(
                     val, dtype=np.float64).view(np.complex128).squeeze(axis=-1)
             else:

--- a/euphonic/io.py
+++ b/euphonic/io.py
@@ -30,7 +30,8 @@ def _to_json_dict(dictionary: dict[str, Any]) -> dict[str, Any]:
 
 
 def _from_json_dict(dictionary: dict[str, Any],
-                    type_dict: dict[str, type[Any]] | None = None) -> dict[str, Any]:
+                    type_dict: dict[str, type[Any]] | None = None,
+) -> dict[str, Any]:
     """
     For a dictionary read from a JSON file, convert all list key values
     to that specified in type_dict. If not specified in type_dict, just
@@ -40,7 +41,7 @@ def _from_json_dict(dictionary: dict[str, Any],
 
     for key, val in dictionary.items():
         if isinstance(val, list):
-            if key in type_dict and type_dict[key] == tuple:
+            if key in type_dict and type_dict[key] is tuple:
                 dictionary[key] = [tuple(x) for x in val]
             elif key in type_dict and type_dict[key] == np.complex128:
                 dictionary[key] = np.array(

--- a/euphonic/plot.py
+++ b/euphonic/plot.py
@@ -110,7 +110,12 @@ def plot_1d_to_axis(spectra: Spectrum1D | Spectrum1DCollection,
     return None
 
 
-def plot_1d(spectra: Spectrum1D | Spectrum1DCollection | Sequence[Spectrum1D] | Sequence[Spectrum1DCollection],
+OneDSpectrumOrSpectra = (Spectrum1D
+                         | Spectrum1DCollection
+                         | Sequence[Spectrum1D]
+                         | Sequence[Spectrum1DCollection])
+
+def plot_1d(spectra: OneDSpectrumOrSpectra,
             title: str | None = None,
             xlabel: str = '',
             ylabel: str = '',

--- a/euphonic/qpoint_phonon_modes.py
+++ b/euphonic/qpoint_phonon_modes.py
@@ -242,7 +242,7 @@ class QpointPhononModes(QpointFrequencies):
 
         .. [1] M.T. Dove, Structure and Dynamics, Oxford University Press, Oxford, 2003, 225-226
 
-        """
+        """  # noqa: E501
         if isinstance(scattering_lengths, str):
             scattering_length_data = get_reference_data(
                 collection=scattering_lengths,
@@ -374,7 +374,7 @@ class QpointPhononModes(QpointFrequencies):
         symmetry-reduced, all weights will be equal).
 
         .. [2] G.L. Squires, Introduction to the Theory of Thermal Neutron Scattering, Dover Publications, New York, 1996, 34-37
-        """
+        """  # noqa: E501
 
         # Convert units
         k_B = (1 * ureg.k).to('hartree/K').magnitude
@@ -541,7 +541,7 @@ class QpointPhononModes(QpointFrequencies):
         :math:`\\kappa`, so the neutron-weighted PDOS is returned in
         units of area per unit energy.
 
-        """
+        """  # noqa: E501
         weighting_opts = [None, 'coherent', 'incoherent',
                           'coherent-plus-incoherent']
         if weighting not in weighting_opts:
@@ -653,7 +653,7 @@ class QpointPhononModes(QpointFrequencies):
             There are also the following optional keys:
 
             - 'weights': (n_qpts,) float ndarray
-        """
+        """  # noqa: E501
         crystal = Crystal.from_dict(d['crystal'])
         d = _process_dict(d, quantities=['frequencies'], optional=['weights'])
         return cls(crystal, d['qpts'], d['frequencies'],

--- a/euphonic/readers/phonopy.py
+++ b/euphonic/readers/phonopy.py
@@ -252,7 +252,7 @@ def read_phonon_data(
         )
         raise ValueError(msg)
 
-    if read_eigenvectors and not 'eigenvectors' in phonon_dict:
+    if read_eigenvectors and 'eigenvectors' not in phonon_dict:
         msg = (
             f"Eigenvectors couldn't be found in {phonon_pathname}, ensure "
             f'--eigvecs was set when running Phonopy'

--- a/euphonic/spectra/collections.py
+++ b/euphonic/spectra/collections.py
@@ -217,8 +217,9 @@ class SpectrumCollectionMixin(ABC):
         setattr(spectrum, f'{self._spectrum_data_name()}_unit',
                 self._get_spectrum_data_unit())
 
-    def _validate_item(self, item: Integral | slice | Sequence[Integral] | np.ndarray,
-                       ) -> None:
+    def _validate_item(
+            self, item: Integral | slice | Sequence[Integral] | np.ndarray,
+    ) -> None:
         """Raise Error if index has inappropriate typing/ranges
 
         Raises
@@ -324,7 +325,10 @@ class SpectrumCollectionMixin(ABC):
         return [i for i, row in enumerate(self.iter_metadata())
                    if required_metadata <= row.items()]
 
-    def select(self, **select_key_values: str | int | Sequence[str] | Sequence[int]) -> Self:
+    def select(
+            self,
+            **select_key_values: str | int | Sequence[str] | Sequence[int],
+    ) -> Self:
         """
         Select spectra by their keys and values in metadata['line_data']
 
@@ -799,7 +803,8 @@ class Spectrum1DCollection(SpectrumCollectionMixin,
                     method=method, width_convention=width_convention)
 
             new_spectrum = self.copy()
-            new_spectrum.y_data = ureg.Quantity(y_broadened, units=self.y_data_unit)
+            new_spectrum.y_data = ureg.Quantity(
+                y_broadened, units=self.y_data_unit)
             return new_spectrum
 
         if isinstance(x_width, Callable):
@@ -1050,7 +1055,8 @@ class Spectrum2DCollection(SpectrumCollectionMixin,
         data_ax_len = self.z_data.shape[enum[bin_ax]]
         if self._is_bin_edge(data_ax_len, bin_data.shape[0]):
             return bin_data
-        return self._bin_centres_to_edges(bin_data, restrict_range=restrict_range)
+        return self._bin_centres_to_edges(
+            bin_data, restrict_range=restrict_range)
 
     def get_bin_centres(self, bin_ax: Literal['x', 'y'] = 'x') -> Quantity:
         """

--- a/euphonic/structure_factor.py
+++ b/euphonic/structure_factor.py
@@ -216,17 +216,19 @@ class StructureFactor(QpointFrequencies):
 
         .. [1] M.T. Dove, Structure and Dynamics, Oxford University Press,
                Oxford, 2003, 225-226
-        """
+        """  # noqa: E501
         sqw_map = self._bose_corrected_structure_factor(
             e_bins, calc_bose=calc_bose, temperature=temperature)
         x_data, x_tick_labels = self._get_qpt_axis_and_labels()
         return Spectrum2D(x_data, e_bins, sqw_map,
                           x_tick_labels=x_tick_labels)
 
-    def _bose_corrected_structure_factor(self, e_bins: Quantity,
-                                         calc_bose: bool = True,
-                                         temperature: Optional[Quantity] = None,
-                                         ) -> Quantity:
+    def _bose_corrected_structure_factor(
+            self,
+            e_bins: Quantity,
+            calc_bose: bool = True,
+            temperature: Optional[Quantity] = None,
+    ) -> Quantity:
         """Bin structure factor in energy, return (Bose-populated) array
 
         Parameters

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -129,7 +129,7 @@ select = [
        "N",       # pep8-naming
        "PERF",    # Perflint
        "F401",    # unused-import
-       # "E",     # pycodestyle error: this is a lot of stuff
+       "E",       # pycodestyle error
        "W",       # pycodestyle warning
        "DOC",     # pydoclint
        # "D",     # 2000 errors, code sprint material?
@@ -169,8 +169,11 @@ force-sort-within-sections = true
 extend-ignore-names = ["k_B", "H_ab"]
 
 [tool.ruff.lint.per-file-ignores]
+"build_utils/*" = ["E501"]  # Long lines
 "tests_and_analysis/test/**/*" = [
     "ARG",    # pytest fixtures can look like unused arguments
     "RUF012", # declaring sample data inside test classes is tidy
+    "E501",   # long lines seem more common with verbose test names
     ]
+
 "euphonic/version.py" = ["Q000"]  # Source build prefers double quotes here

--- a/tests_and_analysis/test/euphonic_test/test_plot.py
+++ b/tests_and_analysis/test/euphonic_test/test_plot.py
@@ -282,14 +282,14 @@ class TestPlot1D:
 
         legend = fig.axes[0].get_legend()
         if expected_labels is None:
-            assert legend == None
+            assert legend is None
         else:
             for text, label in zip(
                     legend.get_texts(), expected_labels, strict=True):
                 assert text.get_text() == label
         # Ensure legend only on first subplot
         for ax in fig.axes[1:]:
-            assert ax.get_legend() == None
+            assert ax.get_legend() is None
 
         if 'xlabel' in kwargs:
             assert fig.axes[-1].get_xlabel() == kwargs['xlabel']

--- a/tests_and_analysis/test/script_tests/test_intensity_map.py
+++ b/tests_and_analysis/test/script_tests/test_intensity_map.py
@@ -157,7 +157,7 @@ class TestRegression:
     def test_pdos_raises_causes_exit(self, intensity_map_args):
         with pytest.raises(SystemExit) as err:
             euphonic.cli.intensity_map.main(intensity_map_args)
-        assert err.type == SystemExit
+        assert err.type is SystemExit
         assert err.value.code == 2
 
     @pytest.mark.parametrize('intensity_map_args', [
@@ -166,7 +166,7 @@ class TestRegression:
         # Argparse should call sys.exit on invalid choices
         with pytest.raises(SystemExit) as err:
             euphonic.cli.intensity_map.main(intensity_map_args)
-        assert err.type == SystemExit
+        assert err.type is SystemExit
         assert err.value.code == 2
 
 

--- a/tests_and_analysis/test/script_tests/test_intensity_map.py
+++ b/tests_and_analysis/test/script_tests/test_intensity_map.py
@@ -157,7 +157,6 @@ class TestRegression:
     def test_pdos_raises_causes_exit(self, intensity_map_args):
         with pytest.raises(SystemExit) as err:
             euphonic.cli.intensity_map.main(intensity_map_args)
-        assert err.type is SystemExit
         assert err.value.code == 2
 
     @pytest.mark.parametrize('intensity_map_args', [
@@ -166,7 +165,6 @@ class TestRegression:
         # Argparse should call sys.exit on invalid choices
         with pytest.raises(SystemExit) as err:
             euphonic.cli.intensity_map.main(intensity_map_args)
-        assert err.type is SystemExit
         assert err.value.code == 2
 
 

--- a/tests_and_analysis/test/script_tests/test_powder_map.py
+++ b/tests_and_analysis/test/script_tests/test_powder_map.py
@@ -224,7 +224,7 @@ class TestRegression:
         # Argparse should call sys.exit on invalid choices
         with pytest.raises(SystemExit) as err:
             euphonic.cli.powder_map.main(powder_map_args)
-        assert err.type == SystemExit
+        assert err.type is SystemExit
         assert err.value.code == 2
 
     @pytest.mark.brille
@@ -236,7 +236,7 @@ class TestRegression:
         # Argparse should call sys.exit on invalid choices
         with pytest.raises(SystemExit) as err:
             euphonic.cli.powder_map.main(powder_map_args)
-        assert err.type == SystemExit
+        assert err.type is SystemExit
         assert err.value.code == 2
 
     @pytest.mark.phonopy_reader
@@ -255,7 +255,7 @@ class TestRegression:
     def test_no_pdos_args_raises_causes_exit(self, powder_map_args):
         with pytest.raises(SystemExit) as err:
             euphonic.cli.powder_map.main(powder_map_args)
-        assert err.type == SystemExit
+        assert err.type is SystemExit
         assert err.value.code == 2
 
     @pytest.mark.phonopy_reader
@@ -265,7 +265,7 @@ class TestRegression:
     def test_multiple_pdos_args_raises_causes_exit(self, powder_map_args):
         with pytest.raises(SystemExit) as err:
             euphonic.cli.powder_map.main(powder_map_args)
-        assert err.type == SystemExit
+        assert err.type is SystemExit
         assert err.value.code == 2
 
 


### PR DESCRIPTION
Depends on #408 

This mostly concerns line lengths and comparison with `is`.

Line length is a controversial topic and I'm open to loosening Euphonic a little from 79 to 90 or 100, say. But it should be done systematically, using a formatter to expand existing code where appropriate.

For now I have made exceptions for the test suite and build scripts, as these seem to be frequent but not egregious offenders: i.e. the writers probably had a limit in place, but one that is larger than 79.