### PR TITLE
Linting: tryceratops

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -143,8 +143,8 @@ select = [
        "PLW",     # pylint warning
        "UP",      # pyupgrade
        "FURB",    # refurb
-       "RUF",   # Very reasonable changes but a few of them
-       # "TRY",   # tryceratops : quite a bit (maybe unnecessary) change in approach
+       "RUF",     # Ruff-specific rules
+       "TRY",     # tryceratops
 ]
 ignore = [
        "S101",    # Use of except

--- a/tests_and_analysis/test/script_tests/utils.py
+++ b/tests_and_analysis/test/script_tests/utils.py
@@ -117,7 +117,7 @@ def get_current_plot_image_data() -> dict[str,
             break
     else:
         msg = 'Could not find axes with a single image'
-        raise Exception(msg)
+        raise ValueError(msg)
 
     data = get_fig_label_data(fig)
     data.update(get_ax_image_data(ax))


### PR DESCRIPTION
Now that "E" has been sorted out, `tryceratops` was a lot easier to enable than expected.