### PR TITLE
Security: Bump setuptools to 78.1.1 for docs build and test runs

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,5 +1,5 @@
 numpy>=1.21.3
-setuptools==71.1.0
+setuptools==78.1.1
 sphinx==5.3.0
 sphinx-argparse==0.3.2
 sphinx-autodoc-typehints==1.19.5

--- a/tests_and_analysis/tox_requirements.txt
+++ b/tests_and_analysis/tox_requirements.txt
@@ -6,4 +6,4 @@ pytest-lazy-fixture
 pytest-xvfb
 python-slugify
 wheel==0.43
-setuptools==71.1.0
+setuptools==78.1.1


### PR DESCRIPTION
In response to CVE-2025-47273

As Euphonic does not directly use setuptools this should only affect CI, so not a breaking change.