### PR TITLE
Tweak calculation of atom positions during dipole-dipole subtraction

### DIFF
--- a/euphonic/force_constants.py
+++ b/euphonic/force_constants.py
@@ -1786,7 +1786,9 @@ casting to real mode gradients.
         sc_atom_r = (np.repeat(cell_origins, n_atoms, axis=0)
                      + np.tile(crystal.atom_r, (n_cells, 1)))
         sc_to_u_matrix = np.linalg.inv(sc_matrix).transpose()
-        sc_atom_r_scell = np.einsum('ij,jk->ik', sc_atom_r, sc_to_u_matrix)
+        sc_atom_r_scell = np.einsum('ij,jk->ik',
+                                    sc_atom_r,
+                                    sc_to_u_matrix.transpose())
         sc_vecs = np.einsum('ji,ik->jk', sc_matrix, crystal._cell_vectors)
         sc_mass = np.tile(crystal._atom_mass, n_cells)
         sc_crystal = Crystal(sc_vecs*ureg('bohr'), sc_atom_r_scell,


### PR DESCRIPTION
Fixes #377 

Issue #377 reported some inconsistencies between Phonopy and Euphonic band structures when using long-range corrections. The system in that case has a rotation between unit cell and primitive cell, which leads to a non-symmetric derived supercell matrix. That makes it rather easy for a missing `transpose()` operation to cause subtle problems!

There seems to be an error in the calculation of long-range contributions to the force constants. When importing force constants from Phonopy these are subtracted to give short-range force constants in the form used by Euphonic.