### PR TITLE
Tidy up some numpy code

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,12 +6,23 @@
   - CLI tools will now accept phonopy data produced by janus-core, with
     filenames in the form "{label}-phonopy.yml" and "{label}-force_constants.hdf5".
 
+- Bug fixes
+
+  - Fixed a bug in subtraction of dipole-dipole contribution from
+    force constants with non-symmetric supercell matrix.  (This
+    affects import from Phonopy results where a) Born effective
+    charges and dielectric tensor were included; b) sc_matrix !=
+    sc_matrix.T .)
+
 - Maintenance
 
   - Pytest configuration has been moved from
     tests_and_analysis/test/pytest.ini to the main
     pyproject.toml. This means it is more likely to be picked up
     automatically when running tests outside of the CI workflows.
+
+  - Some Einstein summations have been replaced with equivalent matrix
+    multiplications; this should improve performance and legibility.
 
 `v1.4.4 <https://github.com/pace-neutrons/Euphonic/compare/v1.4.3...v1.4.4>`_
 -----------------------------------------------------------------------------

--- a/euphonic/qpoint_phonon_modes.py
+++ b/euphonic/qpoint_phonon_modes.py
@@ -270,7 +270,7 @@ class QpointPhononModes(QpointFrequencies):
         # Eigenvectors are in Cartesian so need to convert hkl to
         # Cartesian by computing dot with hkl and reciprocal lattice
         recip = self.crystal.reciprocal_cell().to('1/bohr').magnitude
-        Q = np.einsum('ij,jk->ik', self.qpts, recip)  # noqa: N806
+        Q = self.qpts @ recip
 
         # Calculate dot product of Q and eigenvectors for all branches
         # atoms and q-points

--- a/euphonic/readers/phonopy.py
+++ b/euphonic/readers/phonopy.py
@@ -530,7 +530,7 @@ def _extract_summary(filename: str, fc_extract: bool = False,
         _, _, satom_r, _, _, sc_idx_in_pc = _extract_crystal_data(
             summary_object['supercell'])
         # Coords of supercell atoms in frac coords of the prim cell
-        satom_r_pcell = np.einsum('ij,jk->ik', satom_r, p_to_sc_matrix)
+        satom_r_pcell = satom_r @ p_to_sc_matrix
         # Determine mapping from atoms in the supercell to the prim cell
         # Note: -1 to get 0-indexed instead of 1-indexed values
         pc_to_sc_atom_idx, sc_to_pc_atom_idx = np.unique(

--- a/euphonic/util.py
+++ b/euphonic/util.py
@@ -432,7 +432,7 @@ def convert_fc_phases(force_constants: np.ndarray, atom_r: np.ndarray,
     cell_origins_map = np.zeros((n_atoms_sc), dtype=np.int32)
     # Get origins of adjacent supercells in prim cell frac coords
     sc_origins = get_all_origins((2, 2, 2), min_xyz=(-1, -1, -1))
-    sc_origins_pcell = np.einsum('ij,jk->ik', sc_origins, sc_matrix)
+    sc_origins_pcell = sc_origins @ sc_matrix
     for i in range(n_atoms_sc):
         co_idx = np.where(
             (cell_origins_per_atom[i] == cell_origins).all(axis=1))[0]
@@ -733,7 +733,6 @@ def _get_supercell_relative_idx(cell_origins: np.ndarray,
         equivalent vector in cell_origins
     """
     n_cells = len(cell_origins)
-    ax = np.newaxis
 
     # Get cell origins in supercell fractional coordinates
     inv_sc_matrix = np.linalg.inv(np.transpose(sc_matrix))
@@ -753,8 +752,8 @@ def _get_supercell_relative_idx(cell_origins: np.ndarray,
         for i in range(int((n_cells - 1) / CHUNK_SIZE) + 1):
             ci = i * CHUNK_SIZE
             cf = min((i + 1) * CHUNK_SIZE, n_cells)
-            dist = (inter_cell_vectors[:, ax, :]
-                    - cell_origins_sc[ax, ci:cf, :])
+            dist = (inter_cell_vectors[:, np.newaxis, :]
+                    - cell_origins_sc[np.newaxis, ci:cf, :])
             dist_frac = dist - np.rint(dist)
             dist_frac_sum = np.sum(np.abs(dist_frac), axis=2)
             scri_current = np.argmin(dist_frac_sum, axis=1)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -166,7 +166,7 @@ inline-quotes = "single"
 force-sort-within-sections = true
 
 [tool.ruff.lint.pep8-naming]
-extend-ignore-names = ["k_B", "H_ab"]
+extend-ignore-names = ["k_B", "H_ab", "Q"]
 
 [tool.ruff.lint.per-file-ignores]
 "build_utils/*" = ["E501"]  # Long lines


### PR DESCRIPTION
~~Based on top of #417 , rebase on master when that is done.~~

- Don't use einsum where a matmul (@) will do the job. There can be a performance benefit to matmul as it will be dispatched to the appropriate BLAS routine more reliably. But more importantly it makes some operations easier to read and easier to learn the conventions at work. The more complex einsums are left to stand out as needing closer scrutiny.

- There are a few places `np.newxis` is aliased to `ax` to save space. That's quite confusing because `ax` usually means a Matplotlib axis. And it is unnecesssary as `np.newxis` is just an alias to `None` and this is compact enough already.