### PR TITLE
Allow spectrum collection slices to exceed length

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,8 +1,20 @@
 `Unreleased <https://github.com/pace-neutrons/Euphonic/compare/v1.6.0...HEAD>`_
 -------------------------------------------------------------------------------
 
+- Features
+
+  - Spectrum1DCollection and Spectrum2DCollection can be indexed with
+    slices where the stop value exceeds the collection
+    length. (e.g. if a collection of 5 spectra is indexed with [3:10]
+    it will return a collection with the spectra at indices 3 and 4.)
+    This is consistent with the behaviour of Python lists and numpy
+    arrays.
+
+    Previously this would raise an IndexError. Technically it is a
+    **breaking change** as somebody's code could depend on this
+    IndexError. At this stage it seems an acceptable risk.
+
 `v1.6.0 <https://github.com/pace-neutrons/Euphonic/compare/v1.5.1...v1.6.0>`_
------------------------------------------------------------------------------
 
 - Requirements
 

--- a/euphonic/spectra/collections.py
+++ b/euphonic/spectra/collections.py
@@ -231,12 +231,7 @@ class SpectrumCollectionMixin(ABC):
             of float or bool was provided when ints are needed.
 
         """
-        if isinstance(item, Integral):
-            return
-        if isinstance(item, slice):
-            if (item.stop is not None) and (item.stop >= len(self)):
-                msg = f'index "{item.stop}" out of range'
-                raise IndexError(msg)
+        if isinstance(item, (Integral, slice)):
             return
 
         if not all(isinstance(i, Integral) for i in item):

--- a/tests_and_analysis/test/euphonic_test/test_spectrum1dcollection.py
+++ b/tests_and_analysis/test/euphonic_test/test_spectrum1dcollection.py
@@ -472,8 +472,7 @@ class TestSpectrum1DCollectionIndexAccess:
           np.arange(4.0), TypeError),
          (get_spectrum1dcollection('gan_bands.json'),
           6, IndexError),
-         (get_spectrum1dcollection('gan_bands.json'),
-          slice(2, 6), IndexError)])
+         ])
     def test_index_errors(self, spectrum, index, expected_error):
         with pytest.raises(expected_error):
             spectrum[index]


### PR DESCRIPTION
Closes #407

Following established conventions for python list and numpy array, if a slice exceeds the array length the result can quietly return up to the last available item. This allows things like [:10] to mean "up to first ten items" which is nice for printing etc.

As discussed in #407 this might be a dubious API break. But it's difficult to see the real-world harm.