### PR TITLE
Pin macos-latest -> macos-14

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -18,7 +18,7 @@ jobs:
   build-wheels:
     strategy:
       matrix:
-        os: [windows-latest, macos-13, macos-latest, ubuntu-latest]
+        os: [windows-latest, macos-13, macos-14, ubuntu-latest]
         python-version: ['3.10', '3.11', '3.12', '3.13']
         include:
           - os: windows-latest
@@ -27,7 +27,7 @@ jobs:
           - os: macos-13
             wheelname: macosx
             cibw_archs: "x86_64"
-          - os: macos-latest
+          - os: macos-14
             wheelname: macosx
             cibw_archs: "arm64"
           - os: ubuntu-latest

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -35,7 +35,7 @@ jobs:
           skip: false
           all-python-versions: ${{(github.event_name != 'pull_request')}}
           coverage: false
-        - os: macos-latest
+        - os: macos-14
           skip: false
           all-python-versions: ${{(github.event_name != 'pull_request')}}
           coverage: false

--- a/.github/workflows/test_release_conda.yml
+++ b/.github/workflows/test_release_conda.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest, macos-13]
+        os: [ubuntu-latest, windows-latest, macos-14, macos-13]
         python-version: ['3.10', '3.11', '3.12']
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/test_release_pypi.yml
+++ b/.github/workflows/test_release_pypi.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest, macos-13]
+        os: [ubuntu-latest, windows-latest, macos-14, macos-13]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
I'm having issues migrating to `macos-15`. Tests are also failing on `master` now and it's not clear if that is the same problem; see if we can get it green again by pinning back to `macos-14`.