### PR TITLE
Try restoring mac-Brille tests

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 min_version = 4.0
 # The python environments to run the tests in
-envlist = py{311,312,313,314},py{311,312,313,314}-mac-no-brille,py310-{base,brille,matplotlib,phonopy-reader,all,minrequirements-linux,minrequirements-mac,no-c}
+envlist = py{311,312,313,314},py310-{base,brille,matplotlib,phonopy-reader,all,minrequirements-linux,minrequirements-mac,no-c}
 allowlist_externals = git
 
 [testenv]
@@ -21,22 +21,12 @@ extras =
 
 # Test with all extras
 [testenv:py{311,312,313,314}]
-platform = (linux)|(win32)
 extras =
     {[testenv]extras}
     matplotlib
     phonopy-reader
     brille
 commands = {[testenv]test_command} {posargs}
-
-# Test with non-brille extras only
-[testenv:py{311,312,313,314}-mac-no-brille]
-platform = darwin
-extras =
-    {[testenv]extras}
-    matplotlib
-    phonopy-reader
-commands = {[testenv]test_command} {posargs} -m "not brille"
 
 # Test with no extras
 [testenv:py310-base]
@@ -58,8 +48,6 @@ extras =
 commands = {[testenv]test_command} -m "phonopy_reader and not multiple_extras"
 
 [testenv:py310-brille]
-platform = (linux)|(win32)
-
 extras =
     {[testenv]extras}
     brille
@@ -67,7 +55,6 @@ commands = {[testenv]test_command} -m "brille and not multiple_extras"
 
 # Run remaining tests that require multiple extras
 [testenv:py310-all]
-platform = (linux)|(win32)
 extras =
     {[testenv]extras}
     matplotlib


### PR DESCRIPTION
Brille 0.8.3 uses a revised build/link process which might fix the OpenMP issues when used with Euphonic.