### PR TITLE
Pin numpy, spglib upper bounds

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,7 +3,8 @@
 
 - Requirements
 
-  - Pinned Numpy upper bound to 2.3.5 while addressing compatibility issues with 2.4.0
+  - Pinned Numpy upper bound to (inclusive) 2.3.5 while addressing compatibility issues with 2.4.0
+  - Pinned spglib upper bound to (non-inclusive) 2.7.0 while addressing compatibility issues.
 
   - Test requirements
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ dependencies = [
     "numpy>=1.24.0,<=2.3.5",
     "scipy>=1.10",
     "seekpath>=1.1.0",
-    "spglib>=2.1.0",
+    "spglib>=2.1.0,<2.7.0",
     "pint>=0.22",
     "threadpoolctl>=3.0.0",
     "toolz>=0.12.1",


### PR DESCRIPTION
We have a few errors to take care of. Some clearly related to deprecation warning, others not so much. In the mean time, pin to working version.