### PR TITLE
Remove "push" trigger for test_prerelease

### DIFF
--- a/.github/workflows/test_prerelease.yml
+++ b/.github/workflows/test_prerelease.yml
@@ -1,9 +1,5 @@
 name: test-prerelease-python
 on:
-  push:
-    branches:
-      - '**master**'
-      - '**release**'
   workflow_dispatch:
 
 jobs:

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -27,6 +27,8 @@
     when testing a single Python version. (i.e. typical local testing
     scenario before pushing to CI.)
 
+  - Stopped testing every master push against Python 3.15
+
 `v1.5.0 <https://github.com/pace-neutrons/Euphonic/compare/v1.4.5...v1.5.0>`_
 -----------------------------------------------------------------------------
 


### PR DESCRIPTION
We know prerelease fails for reasons that are not our fault. No reason to get a red x on every master commit, then!

We can still run manual dispatch if required, and re-enable this when Python 3.15 is closer to release.