### PR TITLE
Replace Optional with 3.10+ alternation

### DIFF
--- a/euphonic/brille.py
+++ b/euphonic/brille.py
@@ -1,7 +1,7 @@
 import dataclasses
 from multiprocessing import cpu_count
 import textwrap
-from typing import Any, Optional, TypeVar
+from typing import Any, TypeVar
 
 import numpy as np
 import spglib as spg
@@ -145,9 +145,9 @@ class BrilleInterpolator:
     def from_force_constants(
             cls: type[T], force_constants: ForceConstants,
             grid_type: str = 'trellis', grid_npts: int = 1000,
-            grid_density: Optional[int] = None,
-            grid_kwargs: Optional[dict[str, Any]] = None,
-            interpolation_kwargs: Optional[dict[str, Any]] = None) -> T:
+            grid_density: int | None = None,
+            grid_kwargs: dict[str, Any] | None = None,
+            interpolation_kwargs: dict[str, Any] | None = None) -> T:
         """
         Generates a grid over the irreducible Brillouin Zone to be
         used for linear interpolation with Brille, with properties

--- a/euphonic/cli/brille_convergence.py
+++ b/euphonic/cli/brille_convergence.py
@@ -2,7 +2,6 @@ from argparse import SUPPRESS, ArgumentParser, Namespace
 from collections.abc import Sequence
 import itertools
 from pathlib import Path
-from typing import Optional
 
 from matplotlib.axes import Axes
 from matplotlib.lines import Line2D
@@ -21,7 +20,7 @@ from euphonic.cli.utils import (
 from euphonic.sampling import recurrence_sequence
 
 
-def main(params: Optional[list[str]] = None) -> None:
+def main(params: list[str] | None = None) -> None:
     args = get_args(get_parser(), params)
     params = vars(args)
 
@@ -44,12 +43,12 @@ def check_brille_settings(
         use_brille: bool = True,  # noqa: ARG001  # Removal scheduled for v2
         brille_grid_type: str = 'trellis',
         brille_npts: int = 5000,
-        brille_npts_density: Optional[int] = None,
+        brille_npts_density: int | None = None,
         n: int = 0,
-        energy_broadening: Optional[float] = None,
+        energy_broadening: float | None = None,
         ebins: int = 500,
-        e_min: Optional[float] = None,
-        e_max: Optional[float] = None,
+        e_min: float | None = None,
+        e_max: float | None = None,
         energy_unit: str = 'meV',
         shape: str = 'gauss',
         **calc_modes_kwargs,

--- a/euphonic/cli/dispersion.py
+++ b/euphonic/cli/dispersion.py
@@ -1,5 +1,4 @@
 from argparse import ArgumentParser
-from typing import Optional
 
 import matplotlib.style
 
@@ -22,7 +21,7 @@ from .utils import (
 )
 
 
-def main(params: Optional[list[str]] = None) -> None:
+def main(params: list[str] | None = None) -> None:
     args = get_args(get_parser(), params)
 
     # Need eigenvectors to reorder bands or write website JSON

--- a/euphonic/cli/dos.py
+++ b/euphonic/cli/dos.py
@@ -1,5 +1,4 @@
 from argparse import ArgumentParser
-from typing import Optional
 
 import matplotlib.style
 from numpy import sqrt
@@ -25,7 +24,7 @@ from .utils import (
 )
 
 
-def main(params: Optional[list[str]] = None) -> None:
+def main(params: list[str] | None = None) -> None:
     parser = get_parser()
     args = get_args(parser, params)
 

--- a/euphonic/cli/intensity_map.py
+++ b/euphonic/cli/intensity_map.py
@@ -1,5 +1,4 @@
 from argparse import ArgumentParser
-from typing import Optional
 
 import matplotlib.style
 
@@ -24,7 +23,7 @@ from .utils import (
 )
 
 
-def main(params: Optional[list[str]] = None) -> None:
+def main(params: list[str] | None = None) -> None:
     args = get_args(get_parser(), params)
     calc_modes_kwargs = _calc_modes_kwargs(args)
 

--- a/euphonic/cli/optimise_dipole_parameter.py
+++ b/euphonic/cli/optimise_dipole_parameter.py
@@ -8,7 +8,6 @@ value
 
 from argparse import ArgumentParser
 import time
-from typing import Optional
 import warnings
 
 import numpy as np
@@ -23,7 +22,7 @@ TIMING_TEMPLATE = '{:20s}: {:3.2f} {:s}\n'
 DPARAM_TEMPLATE = '{:s} {:2.2f}'
 
 
-def main(params: Optional[list[str]] = None) -> None:
+def main(params: list[str] | None = None) -> None:
     args = get_args(get_parser(), params)
     params = vars(args)
     params.update({'print_to_terminal': True})

--- a/euphonic/cli/powder_map.py
+++ b/euphonic/cli/powder_map.py
@@ -1,7 +1,6 @@
 from argparse import ArgumentParser
 from collections.abc import Callable, Sequence
 from math import ceil
-from typing import Optional
 
 import matplotlib.style
 import numpy as np
@@ -87,9 +86,9 @@ def get_parser() -> ArgumentParser:
     return parser
 
 
-def _get_broaden_kwargs(q_broadening: Optional[Sequence[float]] = None,
+def _get_broaden_kwargs(q_broadening: Sequence[float] | None = None,
                         q_unit: Unit = ureg('1/angstrom').units,  # noqa: B008
-                        energy_broadening: Optional[Sequence[float]] = None,
+                        energy_broadening: Sequence[float] | None = None,
                         energy_unit: Unit = ureg('meV').units,  # noqa: B008
                         ) -> dict[str, Quantity | Callable | None]:
     """Collect suitable width arguments for 2D broaden() method
@@ -124,7 +123,7 @@ def _get_broaden_kwargs(q_broadening: Optional[Sequence[float]] = None,
     return {'x_width': q_width, 'y_width': energy_width}
 
 
-def main(params: Optional[list[str]] = None) -> None:
+def main(params: list[str] | None = None) -> None:
     args = get_args(get_parser(), params)
     calc_modes_kwargs = _calc_modes_kwargs(args)
 

--- a/euphonic/cli/show_sampling.py
+++ b/euphonic/cli/show_sampling.py
@@ -1,5 +1,4 @@
 from argparse import ArgumentParser
-from typing import Optional
 
 import matplotlib.pyplot as plt
 from mpl_toolkits.mplot3d import Axes3D  # noqa: F401
@@ -34,7 +33,7 @@ def get_parser() -> ArgumentParser:
     return parser
 
 
-def main(params: Optional[list[str]] = None) -> None:
+def main(params: list[str] | None = None) -> None:
     parser = get_parser()
     args = get_args(parser, params)
 

--- a/euphonic/cli/utils.py
+++ b/euphonic/cli/utils.py
@@ -10,7 +10,7 @@ import json
 import os
 from pathlib import Path
 import re
-from typing import Any, Optional
+from typing import Any
 import warnings
 
 import numpy as np
@@ -167,7 +167,7 @@ def load_data_from_file(filename: str | os.PathLike,
     return data
 
 
-def get_args(parser: ArgumentParser, params: Optional[list[str]] = None,
+def get_args(parser: ArgumentParser, params: list[str] | None = None,
              ) -> Namespace:
     """
     Get the arguments from the parser. `params` should only be `None` when
@@ -225,8 +225,8 @@ def _get_q_distance(length_unit_string: str, q_distance: float) -> Quantity:
 
 def _get_energy_bins(
         modes: QpointPhononModes | QpointFrequencies,
-        n_ebins: int, emin: Optional[float] = None,
-        emax: Optional[float] = None,
+        n_ebins: int, emin: float | None = None,
+        emax: float | None = None,
         headroom: float = 1.05) -> Quantity:
     """
     Gets recommended energy bins, in same units as modes.frequencies.
@@ -371,7 +371,7 @@ def _bands_from_force_constants(data: ForceConstants,
 
 
 def _grid_spec_from_args(crystal: Crystal,
-                           grid: Optional[Sequence[int]] = None,
+                           grid: Sequence[int] | None = None,
                            grid_spacing: Quantity = 0.1 * ureg('1/angstrom'),
                            ) -> tuple[int, int, int]:
     """Get Monkorst-Pack mesh divisions from user arguments"""
@@ -384,7 +384,7 @@ def _grid_spec_from_args(crystal: Crystal,
 
 def _get_debye_waller(temperature: Quantity,
                       fc: ForceConstants,
-                      grid: Optional[Sequence[int]] = None,
+                      grid: Sequence[int] | None = None,
                       grid_spacing: Quantity = 0.1 * ureg('1/angstrom'),
                       **calc_modes_kwargs,
                       ) -> DebyeWaller:
@@ -399,7 +399,7 @@ def _get_debye_waller(temperature: Quantity,
     return dw_phonons.calculate_debye_waller(temperature)
 
 
-def _get_pdos_weighting(cl_arg_weighting: str) -> Optional[str]:
+def _get_pdos_weighting(cl_arg_weighting: str) -> str | None:
     """
     Convert CL --weighting to weighting for calculate_pdos
     e.g. --weighting coherent-dos to weighting=coherent
@@ -891,7 +891,7 @@ MplStyle = str | dict[str, str]
 
 
 def _compose_style(
-        *, user_args: Namespace, base: Optional[list[MplStyle]],
+        *, user_args: Namespace, base: list[MplStyle] | None,
         ) -> list[MplStyle]:
     """Combine user-specified style options with default stylesheets
 

--- a/euphonic/force_constants.py
+++ b/euphonic/force_constants.py
@@ -6,7 +6,6 @@ import re
 from typing import (
     Any,
     Literal,
-    Optional,
     TypeVar,
 )
 import warnings
@@ -81,8 +80,8 @@ class ForceConstants:
 
     def __init__(self, crystal: Crystal, force_constants: Quantity,
                  sc_matrix: np.ndarray, cell_origins: np.ndarray,
-                 born: Optional[Quantity] = None,
-                 dielectric: Optional[Quantity] = None) -> None:
+                 born: Quantity | None = None,
+                 dielectric: Quantity | None = None) -> None:
         """
         Parameters
         ----------
@@ -182,15 +181,15 @@ class ForceConstants:
     def calculate_qpoint_phonon_modes(
             self,
             qpts: np.ndarray,
-            weights: Optional[np.ndarray] = None,
-            asr: Optional[Literal['realspace', 'reciprocal']] = None,
+            weights: np.ndarray | None = None,
+            asr: Literal['realspace', 'reciprocal'] | None = None,
             dipole: bool = True,
             dipole_parameter: float = 1.0,
             splitting: bool = True,
             insert_gamma: bool = False,
             reduce_qpts: bool = True,
-            use_c: Optional[bool] = None,
-            n_threads: Optional[int] = None,
+            use_c: bool | None = None,
+            n_threads: int | None = None,
             return_mode_gradients: bool = False,
             ) -> QpointPhononModes | tuple[QpointPhononModes, Quantity]:
         """
@@ -412,15 +411,15 @@ class ForceConstants:
     def calculate_qpoint_frequencies(
             self,
             qpts: np.ndarray,
-            weights: Optional[np.ndarray] = None,
-            asr: Optional[Literal['realspace', 'reciprocal']] = None,
+            weights: np.ndarray | None = None,
+            asr: Literal['realspace', 'reciprocal'] | None = None,
             dipole: bool = True,
             dipole_parameter: float = 1.0,
             splitting: bool = True,
             insert_gamma: bool = False,
             reduce_qpts: bool = True,
-            use_c: Optional[bool] = None,
-            n_threads: Optional[int] = None,
+            use_c: bool | None = None,
+            n_threads: int | None = None,
             return_mode_gradients: bool = False,
             ) -> QpointFrequencies | tuple[QpointFrequencies, Quantity]:
         """
@@ -441,19 +440,19 @@ class ForceConstants:
     def _calculate_phonons_at_qpts(
             self,
             qpts: np.ndarray,
-            weights: Optional[np.ndarray],
-            asr: Optional[Literal['realspace', 'reciprocal']],
+            weights: np.ndarray | None,
+            asr: Literal['realspace', 'reciprocal'] | None,
             dipole: bool,
             dipole_parameter: float,
             splitting: bool,
             insert_gamma: bool,
             reduce_qpts: bool,
-            use_c: Optional[bool],
-            n_threads: Optional[int],
+            use_c: bool | None,
+            n_threads: int | None,
             return_mode_gradients: bool,
             return_eigenvectors: bool) -> tuple[
-                np.ndarray, Quantity, Optional[np.ndarray],
-                Optional[np.ndarray], Optional[Quantity]]:
+                np.ndarray, Quantity, np.ndarray | None,
+                np.ndarray | None, Quantity] | None:
         """
         Calculates phonon frequencies, and optionally eigenvectors and
         phonon frequency gradients. See calculate_qpoint_phonon_modes
@@ -771,7 +770,7 @@ casting to real mode gradients.
             dyn_mat_weighting: np.ndarray,
             recip_asr_correction: np.ndarray,
             dipole: bool,
-            q_dir: Optional[np.ndarray] = None,
+            q_dir: np.ndarray | None = None,
             ) -> tuple[np.ndarray, np.ndarray, np.ndarray | None]:
         """
         Given a q-point and some precalculated q-independent values,
@@ -887,7 +886,7 @@ casting to real mode gradients.
             unique_cell_origins: Sequence[Sequence[int]],
             unique_cell_i: np.ndarray,
             all_origins_cart: np.ndarray) -> tuple[np.ndarray,
-                                                   Optional[np.ndarray]]:
+                                                   np.ndarray] | None:
         """
         Calculate the non mass weighted dynamical matrix at a specified
         q-point from the image weighted force constants matrix and the
@@ -1864,9 +1863,9 @@ casting to real mode gradients.
     def from_phonopy(cls: type[T],
                      path: str = '.',
                      summary_name: str = 'phonopy.yaml',
-                     born_name: Optional[str] = None,
+                     born_name: str | None = None,
                      fc_name: str = 'FORCE_CONSTANTS',
-                     fc_format: Optional[str] = None) -> T:
+                     fc_format: str | None = None) -> T:
         """
         Reads data from the phonopy summary file (default phonopy.yaml)
         and optionally born and force constants files. Only attempts to

--- a/euphonic/plot.py
+++ b/euphonic/plot.py
@@ -1,6 +1,6 @@
 from collections.abc import Sequence
 from itertools import pairwise
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING
 
 import numpy as np
 
@@ -30,7 +30,7 @@ except ModuleNotFoundError as err:
 
 
 def plot_1d_to_axis(spectra: Spectrum1D | Spectrum1DCollection,
-                    ax: Axes, labels: Optional[Sequence[str]] = None,
+                    ax: Axes, labels: Sequence[str] | None = None,
                     **mplargs) -> None:
     """Plot a (collection of) 1D spectrum lines to matplotlib axis
 
@@ -119,9 +119,9 @@ def plot_1d(spectra: OneDSpectrumOrSpectra,
             title: str | None = None,
             xlabel: str = '',
             ylabel: str = '',
-            ymin: Optional[float] = None,
-            ymax: Optional[float] = None,
-            labels: Optional[Sequence[str]] = None,
+            ymin: float | None = None,
+            ymax: float | None = None,
+            labels: Sequence[str] | None = None,
             **line_kwargs) -> Figure:
     """
     Creates a Matplotlib figure for a Spectrum1D object, or multiple
@@ -221,7 +221,7 @@ def plot_1d(spectra: OneDSpectrumOrSpectra,
 def plot_2d_to_axis(spectrum: Spectrum2D, ax: Axes,
                     cmap: str | Colormap | None = None,
                     interpolation: str = 'nearest',
-                    norm: Optional[Normalize] = None,
+                    norm: Normalize | None = None,
                     ) -> NonUniformImage:
     """Plot Spectrum2D object to Axes
 
@@ -269,9 +269,9 @@ def plot_2d_to_axis(spectrum: Spectrum2D, ax: Axes,
 
 
 def plot_2d(spectra: Spectrum2D | Sequence[Spectrum2D],
-            vmin: Optional[float] = None,
-            vmax: Optional[float] = None,
-            cmap: Optional[str | Colormap] = None,
+            vmin: float | None = None,
+            vmax: float | None = None,
+            cmap: str | Colormap | None = None,
             title: str | None = None,
             xlabel: str = '',
             ylabel: str = '') -> Figure:
@@ -348,7 +348,7 @@ def plot_2d(spectra: Spectrum2D | Sequence[Spectrum2D],
 
 
 def _set_x_tick_labels(ax: Axes,
-                       x_tick_labels: Optional[Sequence[tuple[int, str]]],
+                       x_tick_labels: Sequence[tuple[int, str]] | None,
                        x_data: Quantity) -> None:
     if x_tick_labels is not None:
         locs, labels = [list(x) for x in zips(*x_tick_labels)]

--- a/euphonic/powder.py
+++ b/euphonic/powder.py
@@ -1,6 +1,6 @@
 """Functions for averaging spectra in spherical q bins"""
 
-from typing import Literal, Optional
+from typing import Literal
 
 import numpy as np
 
@@ -121,7 +121,7 @@ def sample_sphere_pdos(
         npts: int = 1000,
         jitter: bool = False,
         energy_bins: Quantity = None,
-        weighting: Optional[str] = None,
+        weighting: str | None = None,
         cross_sections: str | dict[str, Quantity] = 'BlueBook',
         rng: RNG = rng,
         **calc_modes_args,
@@ -236,7 +236,7 @@ def sample_sphere_structure_factor(
     mod_q: Quantity,
     dw: DebyeWaller = None,
     dw_spacing: Quantity = Quantity(0.025, '1/angstrom'),
-    temperature: Optional[Quantity] = Quantity(273., 'K'),
+    temperature: Quantity | None = Quantity(273., 'K'),
     sampling: SphericalSamplingOptions = 'golden',
     npts: int = 1000, jitter: bool = False,
     energy_bins: Quantity = None,

--- a/euphonic/qpoint_frequencies.py
+++ b/euphonic/qpoint_frequencies.py
@@ -1,4 +1,4 @@
-from typing import Any, Literal, Optional, TypeVar
+from typing import Any, Literal, TypeVar
 import warnings
 
 import numpy as np
@@ -43,7 +43,7 @@ class QpointFrequencies:
 
     def __init__(self, crystal: Crystal, qpts: np.ndarray,
                  frequencies: Quantity,
-                 weights: Optional[np.ndarray] = None) -> None:
+                 weights: np.ndarray | None = None) -> None:
         """
         Parameters
         ----------
@@ -98,7 +98,7 @@ class QpointFrequencies:
     def calculate_dos(
         self,
         dos_bins: Quantity,
-        mode_widths: Optional[Quantity] = None,
+        mode_widths: Quantity | None = None,
         mode_widths_min: Quantity = Quantity(0.01, 'meV'),
         adaptive_method: AdaptiveMethod = 'reference',
         adaptive_error: float = 0.01,
@@ -164,13 +164,13 @@ class QpointFrequencies:
     def _calculate_dos(
         self,
         dos_bins: Quantity,
-        mode_widths: Optional[Quantity] = None,
+        mode_widths: Quantity | None = None,
         mode_widths_min: Quantity = Quantity(0.01, 'meV'),
-        mode_weights: Optional[np.ndarray] = None,
+        mode_weights: np.ndarray | None = None,
         adaptive_method: AdaptiveMethod = 'reference',
         adaptive_error: float = 0.01,
         adaptive_error_fit: ErrorFit = 'cubic',
-        q_idx: Optional[int] = None,
+        q_idx: int | None = None,
         ) -> Quantity:
         """
         Calculates a density of states (same arg defs as calculate_dos),
@@ -255,7 +255,7 @@ class QpointFrequencies:
         return dos/conv
 
     def calculate_dos_map(self, dos_bins: Quantity,
-                          mode_widths: Optional[Quantity] = None,
+                          mode_widths: Quantity | None = None,
                           mode_widths_min: Quantity = Quantity(0.01, 'meV'),
                           ) -> Spectrum2D:
         """
@@ -424,7 +424,7 @@ class QpointFrequencies:
     @classmethod
     def from_phonopy(cls: type[T], path: str = '.',
                      phonon_name: str = 'band.yaml',
-                     phonon_format: Optional[str] = None,
+                     phonon_format: str | None = None,
                      summary_name: str = 'phonopy.yaml') -> T:
         """
         Reads precalculated phonon mode data from a Phonopy

--- a/euphonic/qpoint_phonon_modes.py
+++ b/euphonic/qpoint_phonon_modes.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Mapping
 import math
-from typing import Any, Optional, TypeVar
+from typing import Any, TypeVar
 
 import numpy as np
 
@@ -49,7 +49,7 @@ class QpointPhononModes(QpointFrequencies):
 
     def __init__(self, crystal: Crystal, qpts: np.ndarray,
                  frequencies: Quantity, eigenvectors: np.ndarray,
-                 weights: Optional[np.ndarray] = None) -> None:
+                 weights: np.ndarray | None = None) -> None:
         """
         Parameters
         ----------
@@ -173,7 +173,7 @@ class QpointPhononModes(QpointFrequencies):
     def calculate_structure_factor(
         self,
         scattering_lengths: str | dict[str, Quantity] = 'Sears1992',
-        dw: Optional[DebyeWaller] = None,
+        dw: DebyeWaller | None = None,
         ) -> StructureFactor:
         """
         Calculate the one phonon inelastic scattering for neutrons at
@@ -433,12 +433,12 @@ class QpointPhononModes(QpointFrequencies):
 
     def calculate_pdos(
             self, dos_bins: Quantity,
-            mode_widths: Optional[Quantity] = None,
+            mode_widths: Quantity | None = None,
             mode_widths_min: Quantity = Quantity(0.01, 'meV'),
             adaptive_method: AdaptiveMethod = 'reference',
-            adaptive_error: Optional[float] = 0.01,
+            adaptive_error: float | None = 0.01,
             adaptive_error_fit: ErrorFit = 'cubic',
-            weighting: Optional[str] = None,
+            weighting: str | None = None,
             cross_sections: str | dict[str, Quantity] = 'BlueBook',
             ) -> Spectrum1DCollection:
         """
@@ -705,7 +705,7 @@ class QpointPhononModes(QpointFrequencies):
     @classmethod
     def from_phonopy(cls: type[T], path: str = '.',
                      phonon_name: str = 'band.yaml',
-                     phonon_format: Optional[str] = None,
+                     phonon_format: str | None = None,
                      summary_name: str = 'phonopy.yaml') -> T:
         """
         Reads precalculated phonon mode data from a Phonopy

--- a/euphonic/readers/castep.py
+++ b/euphonic/readers/castep.py
@@ -6,7 +6,6 @@ from typing import (
     Any,
     BinaryIO,
     NamedTuple,
-    Optional,
     TextIO,
 )
 
@@ -329,16 +328,16 @@ _qpt_float_pattern = re.compile(r'-?\d+\.\d+')
 class _FrequencyBlock(NamedTuple):
     qpt_id: int
     qpt: np.ndarray
-    direction: Optional[np.ndarray]
+    direction: np.ndarray | None
     weight: float
     frequencies: np.ndarray
-    extra: Optional[np.ndarray]
+    extra: np.ndarray | None
 
 
 def _read_frequency_block(
     f: TextIO,
     n_branches: int,
-    extra_columns: Optional[list] = None,
+    extra_columns: list | None = None,
     terminator: str = '',
         ) -> _FrequencyBlock | None:
     """
@@ -391,7 +390,7 @@ def _read_frequency_block(
     qpt = np.array([float(x) for x in floats[:3]])
     qweight = float(floats[3])
 
-    direction: Optional[np.ndarray] = None
+    direction: np.ndarray | None = None
     if len(floats) >= 6:
         direction = floats[4:7]
 
@@ -399,7 +398,7 @@ def _read_frequency_block(
                   for i in range(n_branches)]
     freq_col = 1
     qfreq = np.array([float(line[freq_col]) for line in freq_lines])
-    extra: Optional[np.ndarray] = None
+    extra: np.ndarray | None = None
     if extra_columns is not None:
         if len(qpt_line.split()) > 6:
             # Indicates a split gamma point in .phonon, so there is an

--- a/euphonic/readers/phonopy.py
+++ b/euphonic/readers/phonopy.py
@@ -1,7 +1,7 @@
 from contextlib import suppress
 import os
 import re
-from typing import Any, Optional, TextIO
+from typing import Any, TextIO
 import warnings
 
 import numpy as np
@@ -180,7 +180,7 @@ def _extract_phonon_data_hdf5(filename: str,
 def read_phonon_data(
         path: str = '.',
         phonon_name: str = 'band.yaml',
-        phonon_format: Optional[str] = None,
+        phonon_format: str | None = None,
         summary_name: str = 'phonopy.yaml',
         cell_vectors_unit: str = 'angstrom',
         atom_mass_unit: str = 'amu',
@@ -635,9 +635,9 @@ def _extract_crystal_data(crystal: dict[str, Any],
 def read_interpolation_data(
         path: str = '.',
         summary_name: str = 'phonopy.yaml',
-        born_name: Optional[str] = None,
+        born_name: str | None = None,
         fc_name: str = 'FORCE_CONSTANTS',
-        fc_format: Optional[str] = None,
+        fc_format: str | None = None,
         cell_vectors_unit: str = 'angstrom',
         atom_mass_unit: str = 'amu',
         force_constants_unit: str = 'hartree/bohr**2',

--- a/euphonic/spectra/base.py
+++ b/euphonic/spectra/base.py
@@ -10,7 +10,6 @@ from numbers import Integral, Real
 from typing import (
     Any,
     Literal,
-    Optional,
     TypeVar,
     overload,
 )
@@ -172,7 +171,7 @@ class Spectrum(ABC):
 
     @staticmethod
     def _ranges_from_indices(indices: Sequence[int] | np.ndarray,
-                             ) -> list[tuple[int, Optional[int]]]:
+                             ) -> list[tuple[int, int]] | None:
         """Convert a series of breakpoints to a series of slice ranges"""
         if len(indices) == 0:
             ranges = [(0, None)]
@@ -242,7 +241,7 @@ class Spectrum(ABC):
                       widths: Sequence[float|None],
                       shape: KernelShape = 'gauss',
                       *,
-                      method: Optional[Literal['convolve']] = None,
+                      method: Literal['convolve'] | None = None,
                       width_convention: Literal['fwhm', 'std'] = 'fwhm',
                       ) -> np.ndarray:
         """
@@ -519,8 +518,8 @@ class Spectrum1D(Spectrum):
     T = TypeVar('T', bound='Spectrum1D')
 
     def __init__(self, x_data: Quantity, y_data: Quantity,
-                 x_tick_labels: Optional[XTickLabels] = None,
-                 metadata: Optional[dict[str, int | str]] = None,
+                 x_tick_labels: XTickLabels | None = None,
+                 metadata: dict[str, int | str] | None = None,
                  ) -> None:
         """
         Parameters
@@ -602,7 +601,7 @@ class Spectrum1D(Spectrum):
                                    'metadata'])
 
     def to_text_file(self, filename: str,
-                     fmt: Optional[str | Sequence[str]] = None) -> None:
+                     fmt: str | Sequence[str] | None = None) -> None:
         """
         Write to a text file. The header contains metadata and unit
         information, the first column contains x_data and the second
@@ -653,7 +652,7 @@ class Spectrum1D(Spectrum):
 
     @classmethod
     def from_castep_phonon_dos(cls: type[T], filename: str,
-                               element: Optional[str] = None) -> T:
+                               element: str | None = None) -> T:
         """
         Reads DOS from a CASTEP .phonon_dos file
 
@@ -681,15 +680,15 @@ class Spectrum1D(Spectrum):
     @overload
     def broaden(self: T, x_width: Quantity,
                 shape: KernelShape = 'gauss',
-                method: Optional[Literal['convolve']] = None,
+                method: Literal['convolve'] | None = None,
                 width_convention: Literal['fwhm', 'std'] = 'fwhm',
                 ) -> T: ...
 
     @overload
     def broaden(self: T, x_width: CallableQuantity,
                 shape: KernelShape = 'gauss',
-                method: Optional[Literal['convolve']] = None,
-                width_lower_limit: Optional[Quantity] = None,
+                method: Literal['convolve'] | None = None,
+                width_lower_limit: Quantity | None = None,
                 width_convention: Literal['fwhm', 'std'] = 'fwhm',
                 width_interpolation_error: float = 0.01,
                 width_fit: ErrorFit = 'cheby-log',
@@ -813,8 +812,8 @@ class Spectrum2D(Spectrum):
 
     def __init__(self, x_data: Quantity, y_data: Quantity,
                  z_data: Quantity,
-                 x_tick_labels: Optional[XTickLabels] = None,
-                 metadata: Optional[OneSpectrumMetadata] = None,
+                 x_tick_labels: XTickLabels | None = None,
+                 metadata: OneSpectrumMetadata | None = None,
                  ) -> None:
         """
         Parameters
@@ -889,10 +888,10 @@ class Spectrum2D(Spectrum):
                 for x0, x1 in ranges]
 
     def broaden(self: T,
-                x_width: Optional[Quantity | CallableQuantity] = None,
-                y_width: Optional[Quantity | CallableQuantity] = None,
+                x_width: Quantity | CallableQuantity | None = None,
+                y_width: Quantity | CallableQuantity | None = None,
                 shape: KernelShape = 'gauss',
-                method: Optional[Literal['convolve']] = None,
+                method: Literal['convolve'] | None = None,
                 x_width_lower_limit: Quantity = None,
                 y_width_lower_limit: Quantity = None,
                 width_convention: Literal['fwhm', 'std'] = 'fwhm',

--- a/euphonic/spectra/collections.py
+++ b/euphonic/spectra/collections.py
@@ -13,7 +13,6 @@ from operator import contains
 from typing import (
     Any,
     Literal,
-    Optional,
     TypeVar,
     overload,
 )
@@ -555,8 +554,8 @@ class Spectrum1DCollection(SpectrumCollectionMixin,
 
     def __init__(
             self, x_data: Quantity, y_data: Quantity,
-            x_tick_labels: Optional[XTickLabels] = None,
-            metadata: Optional[dict[str, str | int | LineData]] = None,
+            x_tick_labels: XTickLabels | None = None,
+            metadata: dict[str, str | int | LineData] | None = None,
     ) -> None:
         """
         Parameters
@@ -663,7 +662,7 @@ class Spectrum1DCollection(SpectrumCollectionMixin,
                    metadata=metadata)
 
     def to_text_file(self, filename: str,
-                     fmt: Optional[str | Sequence[str]] = None) -> None:
+                     fmt: str | Sequence[str] | None = None) -> None:
         """
         Write to a text file. The header contains metadata and unit
         information, the first column is x_data and each subsequent
@@ -725,14 +724,14 @@ class Spectrum1DCollection(SpectrumCollectionMixin,
     @overload
     def broaden(self: T, x_width: Quantity,
                 shape: KernelShape = 'gauss',
-                method: Optional[Literal['convolve']] = None,
+                method: Literal['convolve'] | None = None,
                 ) -> T: ...
 
     @overload
     def broaden(self: T, x_width: CallableQuantity,
                 shape: KernelShape = 'gauss',
-                method: Optional[Literal['convolve']] = None,
-                width_lower_limit: Optional[Quantity] = None,
+                method: Literal['convolve'] | None = None,
+                width_lower_limit: Quantity | None = None,
                 width_convention: Literal['fwhm', 'std'] = 'fwhm',
                 width_interpolation_error: float = 0.01,
                 width_fit: ErrorFit = 'cheby-log',
@@ -895,8 +894,8 @@ class Spectrum2DCollection(SpectrumCollectionMixin,
 
     def __init__(
             self, x_data: Quantity, y_data: Quantity, z_data: Quantity,
-            x_tick_labels: Optional[XTickLabels] = None,
-            metadata: Optional[Metadata] = None,
+            x_tick_labels: XTickLabels | None = None,
+            metadata: Metadata | None = None,
     ) -> None:
         _check_constructor_inputs(
             [z_data, x_tick_labels, metadata],

--- a/euphonic/structure_factor.py
+++ b/euphonic/structure_factor.py
@@ -1,4 +1,4 @@
-from typing import Any, NoReturn, Optional, TypeVar
+from typing import Any, NoReturn, TypeVar
 import warnings
 
 import numpy as np
@@ -46,8 +46,8 @@ class StructureFactor(QpointFrequencies):
 
     def __init__(self, crystal: Crystal, qpts: np.ndarray,
                  frequencies: Quantity, structure_factors: Quantity,
-                 weights: Optional[np.ndarray] = None,
-                 temperature: Optional[Quantity] = None) -> None:
+                 weights: np.ndarray | None = None,
+                 temperature: Quantity | None = None) -> None:
         """
         Parameters
         ----------
@@ -124,8 +124,8 @@ class StructureFactor(QpointFrequencies):
     def calculate_1d_average(self,
                              e_bins: Quantity,
                              calc_bose: bool = True,
-                             temperature: Optional[Quantity] = None,
-                             weights: Optional[np.ndarray] = None,
+                             temperature: Quantity | None = None,
+                             weights: np.ndarray | None = None,
                              ) -> Spectrum1D:
         """Bin structure factor in energy, flattening q to produce 1D spectrum
 
@@ -166,7 +166,7 @@ class StructureFactor(QpointFrequencies):
     def calculate_sqw_map(self,
                           e_bins: Quantity,
                           calc_bose: bool = True,
-                          temperature: Optional[Quantity] = None,
+                          temperature: Quantity | None = None,
                           ) -> Spectrum2D:
         """
         Bin the structure factor in energy and apply the Bose population
@@ -227,7 +227,7 @@ class StructureFactor(QpointFrequencies):
             self,
             e_bins: Quantity,
             calc_bose: bool = True,
-            temperature: Optional[Quantity] = None,
+            temperature: Quantity | None = None,
     ) -> Quantity:
         """Bin structure factor in energy, return (Bose-populated) array
 
@@ -292,7 +292,7 @@ class StructureFactor(QpointFrequencies):
 
         return sqw_map*sf_conv/e_conv
 
-    def _bose_factor(self, temperature: Optional[Quantity] = None,
+    def _bose_factor(self, temperature: Quantity | None = None,
                      ) -> np.ndarray:
         """
         Calculate the Bose factor for the frequencies stored in

--- a/euphonic/util.py
+++ b/euphonic/util.py
@@ -7,7 +7,6 @@ import math
 import os.path
 import sys
 import textwrap
-from typing import Optional
 import warnings
 
 import numpy as np
@@ -165,9 +164,9 @@ def get_all_origins(max_xyz: tuple[int, int, int],
 
 
 def get_qpoint_labels(qpts: np.ndarray,
-                      cell: Optional[tuple[list[list[float]],
-                                           list[list[float]],
-                                           list[int]]] = None,
+                      cell: tuple[list[list[float]],
+                                  list[list[float]],
+                                  list[int]] | None = None,
                       ) -> list[tuple[int, str]]:
     """
     Gets q-point labels (e.g. GAMMA, X, L) for the q-points at which the
@@ -567,9 +566,9 @@ def _calc_abscissa(reciprocal_cell: Quantity, qpts: np.ndarray,
 
 
 def _recip_space_labels(qpts: np.ndarray,
-                        cell: Optional[tuple[list[list[float]],
-                                             list[list[float]],
-                                             list[int]]],
+                        cell: tuple[list[list[float]],
+                                    list[list[float]],
+                                    list[int]] | None,
                         ) -> tuple[np.ndarray, np.ndarray]:
     """
     Gets q-points point labels (e.g. GAMMA, X, L) for the q-points at

--- a/euphonic/validate.py
+++ b/euphonic/validate.py
@@ -1,5 +1,5 @@
 from collections.abc import Sequence
-from typing import Any, Optional
+from typing import Any
 
 import numpy as np
 from pint import DimensionalityError
@@ -165,7 +165,7 @@ def _ensure_contiguous_args(*args: np.ndarray) -> tuple[np.ndarray, ...]:
                  for arg in args)
 
 
-def _get_dtype(arr: np.ndarray) -> Optional[type]:
+def _get_dtype(arr: np.ndarray) -> type | None:
     """
     Get the Numpy dtype that should be used for the input array
 

--- a/tests_and_analysis/test/euphonic_test/test_spectrum2dcollection.py
+++ b/tests_and_analysis/test/euphonic_test/test_spectrum2dcollection.py
@@ -3,8 +3,6 @@
 # Stop the linter from complaining when pytest fixtures are used idiomatically
 # pylint: disable=redefined-outer-name
 
-from typing import Optional
-
 import numpy as np
 import pytest
 
@@ -81,9 +79,9 @@ def inconsistent_x_tick_labels_item():
     return item
 
 def rand_spectrum2d(seed: int = 1,
-                    x_bins: Optional[Quantity] = None,
-                    y_bins: Optional[Quantity] = None,
-                    metadata: Optional[OneLineData] = None) -> Spectrum2D:
+                    x_bins: Quantity | None = None,
+                    y_bins: Quantity | None = None,
+                    metadata: OneLineData | None = None) -> Spectrum2D:
     """Generate a Spectrum2D with random axis lengths, ranges, and metadata"""
     rng = np.random.default_rng(seed=seed)
 

--- a/tests_and_analysis/test/script_tests/test_optimise_dipole_parameter.py
+++ b/tests_and_analysis/test/script_tests/test_optimise_dipole_parameter.py
@@ -1,7 +1,7 @@
 from contextlib import ExitStack
 
 # Required for mocking
-from typing import Any, Optional
+from typing import Any
 
 import numpy as np
 import pytest
@@ -21,7 +21,7 @@ quick_calc_params = ['-n=10', '--min=0.5', '--max=0.5']
 
 class TestRegression:
     @staticmethod
-    def call_cli(fc_file: str, args: list[Any], warning: Optional[str]) -> None:
+    def call_cli(fc_file: str, args: list[Any], warning: str | None) -> None:
         """Call optimise-dipole-parameter, checking for warning if appropriate"""
         with ExitStack() as stack:
             if warning is not None:

--- a/tests_and_analysis/test/script_tests/utils.py
+++ b/tests_and_analysis/test/script_tests/utils.py
@@ -1,7 +1,9 @@
+from __future__ import annotations
+
 from contextlib import suppress
 from copy import copy
 import os
-from typing import Any, Optional
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
@@ -11,6 +13,9 @@ with suppress(ModuleNotFoundError):
 
 from tests_and_analysis.test.utils import get_data_path
 
+if TYPE_CHECKING:
+    from matplotlib.axes import Axes
+    from matplotlib.figure import Figure
 
 def args_to_key(cl_args: list[str]) -> str:
     """
@@ -34,8 +39,7 @@ def get_script_test_data_path(*subpaths: tuple[str]) -> str:
     return get_data_path('script_data', *subpaths)
 
 
-def get_plot_line_data(fig: Optional['matplotlib.figure.Figure'] = None,
-                       ) -> dict[str, Any]:
+def get_plot_line_data(fig: Figure | None = None) -> dict[str, Any]:
     if fig is None:
         fig = matplotlib.pyplot.gcf()
     data = get_fig_label_data(fig)
@@ -50,14 +54,13 @@ def get_plot_line_data(fig: Optional['matplotlib.figure.Figure'] = None,
     return data
 
 
-def get_all_figs() -> list['matplotlib.figure.Figure']:
+def get_all_figs() -> list[Figure]:
     fignums = matplotlib.pyplot.get_fignums()
     return [matplotlib.pyplot.figure(fignum) for fignum in fignums]
 
 
 
-def get_all_plot_line_data(figs: list['matplotlib.figure.Figure'],
-                           ) -> list[dict[str, Any]]:
+def get_all_plot_line_data(figs: list[Figure]) -> list[dict[str, Any]]:
     return [get_plot_line_data(fig) for fig in figs]
 
 
@@ -125,8 +128,7 @@ def get_current_plot_image_data() -> dict[str,
     return data
 
 
-def get_ax_image_data(ax: 'matplotlib.axes.Axes',
-                      ) -> dict[str, str | list[float] | list[int]]:
+def get_ax_image_data(ax: Axes) -> dict[str, str | list[float] | list[int]]:
     im = ax.get_images()[0]
     # Convert negative zero to positive zero
     im_data = im.get_array()

--- a/tests_and_analysis/test/utils.py
+++ b/tests_and_analysis/test/utils.py
@@ -1,7 +1,6 @@
 from contextlib import contextmanager
 import json
 import os
-from typing import Optional
 
 import numpy as np
 import numpy.testing as npt
@@ -44,7 +43,7 @@ def get_castep_path(*subpaths: tuple[str]) -> str:
     return get_data_path('castep_files', *subpaths)
 
 
-def get_test_qpts(qpts_option: Optional[str] = 'default') -> np.ndarray:
+def get_test_qpts(qpts_option: str | None = 'default') -> np.ndarray:
     """
     Returns 'standard' sets of qpoints for testing
 


### PR DESCRIPTION
Since 3.10, the preferred way to do optional with with `| None` alternation. 

Replace all instances of `Optional` and remove from imports.