### PR TITLE
Bump "wheel" to 0.46.2 as recommended by dependabot

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,10 @@
 
 - Requirements
 
+  - Security
+
+    - Bumped *wheel* requirement for docs and testing to 0.46.2. (`CVE-2026-24049 <https://www.cve.org/CVERecord?id=CVE-2026-24049>`_)
+
   - Test requirements
 
     - Added *pytest-xdist* and *pytest-cov* requirements for parallel

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -5,4 +5,4 @@ sphinx==5.3.0
 sphinx-argparse==0.3.2
 sphinx-autodoc-typehints==1.19.5
 sphinx-rtd-theme==1.1.1
-wheel==0.43
+wheel==0.46.2

--- a/tests_and_analysis/tox_requirements.txt
+++ b/tests_and_analysis/tox_requirements.txt
@@ -6,5 +6,5 @@ pytest-lazy-fixtures
 pytest-xdist
 pytest-xvfb
 python-slugify
-wheel==0.43
+wheel==0.46.2
 setuptools==78.1.1


### PR DESCRIPTION
https://www.cve.org/CVERecord?id=CVE-2026-24049

It's not clear that this is of great concern as we use `wheel` to build our own packages rather than open other people's. But maybe this enables a supply-chain attack of some kind?