### PR TITLE
Use keyword-only arguments in euphonic.powder

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,11 @@
 `Unreleased <https://github.com/pace-neutrons/Euphonic/compare/v1.6.0...HEAD>`_
 -------------------------------------------------------------------------------
 
+- API changes
+
+  - Public functions in ``euphonic.powder`` now use mandatory keyword arguments
+    - This will break code that depends on these arguments being in a specific order
+
 - Features
 
   - Spectrum1DCollection and Spectrum2DCollection can be indexed with

--- a/euphonic/powder.py
+++ b/euphonic/powder.py
@@ -25,11 +25,12 @@ SphericalSamplingOptions = Literal['golden',
 
 def sample_sphere_dos(fc: ForceConstants,
                       mod_q: Quantity,
+                      *,
                       sampling: SphericalSamplingOptions = 'golden',
                       npts: int = 1000,
                       jitter: bool = False,
-                      energy_bins: Quantity = None,
                       rng: RNG = rng,
+                      energy_bins: Quantity = None,
                       **calc_modes_args,
                       ) -> Spectrum1D:
     """
@@ -78,11 +79,11 @@ def sample_sphere_dos(fc: ForceConstants,
     jitter
         For non-random sampling schemes, apply an additional random
         displacement to each point.
+    rng
+        Numpy random Generator for random sampling and jitter
     energy_bins
         Preferred energy bin edges. If not provided, will setup
         1000 bins (1001 bin edges) from 0 to 1.05 * [max energy]
-    rng
-        Numpy random Generator for random sampling and jitter
     **calc_modes_args
         other keyword arguments (e.g. 'use_c') will be passed to
         ForceConstants.calculate_qpoint_phonon_modes()
@@ -117,13 +118,14 @@ def sample_sphere_dos(fc: ForceConstants,
 def sample_sphere_pdos(
         fc: ForceConstants,
         mod_q: Quantity,
+        *,
         sampling: SphericalSamplingOptions = 'golden',
         npts: int = 1000,
         jitter: bool = False,
+        rng: RNG = rng,
         energy_bins: Quantity = None,
         weighting: str | None = None,
         cross_sections: str | dict[str, Quantity] = 'BlueBook',
-        rng: RNG = rng,
         **calc_modes_args,
         ) -> Spectrum1DCollection:
     """
@@ -172,6 +174,8 @@ def sample_sphere_pdos(
     jitter
         For non-random sampling schemes, apply an additional random
         displacement to each point.
+    rng
+        Numpy random Generator for random sampling and jitter
     energy_bins
         Preferred energy bin edges. If not provided, will setup
         1000 bins (1001 bin edges) from 0 to 1.05 * [max energy]
@@ -199,9 +203,6 @@ def sample_sphere_pdos(
         appropriate units, e.g::
 
             {'La': 8.0*ureg('barn'), 'Zr': 9.5*ureg('barn')}
-    rng
-        Numpy random Generator for random sampling and jitter
-
     **calc_modes_args
         other keyword arguments (e.g. 'use_c') will be passed to
         ForceConstants.calculate_qpoint_phonon_modes()
@@ -234,14 +235,16 @@ def sample_sphere_pdos(
 def sample_sphere_structure_factor(
     fc: ForceConstants,
     mod_q: Quantity,
+    *,
     dw: DebyeWaller = None,
     dw_spacing: Quantity = Quantity(0.025, '1/angstrom'),
     temperature: Quantity | None = Quantity(273., 'K'),
     sampling: SphericalSamplingOptions = 'golden',
-    npts: int = 1000, jitter: bool = False,
+    npts: int = 1000,
+    jitter: bool = False,
+    rng: RNG = rng,
     energy_bins: Quantity = None,
     scattering_lengths: str | dict[str, Quantity] = 'Sears1992',
-    rng: RNG = rng,
     **calc_modes_args,
     ) -> Spectrum1D:
     """Sample structure factor, averaging over a sphere of constant |q|
@@ -301,6 +304,8 @@ def sample_sphere_structure_factor(
     jitter
         For non-random sampling schemes, apply an additional random
         displacement to each point.
+    rng
+        Numpy random Generator for random sampling and jitter
     energy_bins
         Preferred energy bin edges. If not provided, will setup 1000
         bins (1001 bin edges) from 0 to 1.05 * [max energy]
@@ -309,8 +314,6 @@ def sample_sphere_structure_factor(
         string is provided, this selects coherent scattering lengths
         from reference data by setting the 'label' argument of the
         euphonic.util.get_reference_data() function.
-    rng
-        Numpy random Generator for random sampling and jitter
     **calc_modes_args
         other keyword arguments (e.g. 'use_c') will be passed to
         ForceConstants.calculate_qpoint_phonon_modes()

--- a/euphonic/powder.py
+++ b/euphonic/powder.py
@@ -354,8 +354,8 @@ def sample_sphere_structure_factor(
 
     qpts_frac = _qpts_cart_to_frac(qpts_cart, fc.crystal)
 
-    phonons = fc.calculate_qpoint_phonon_modes(qpts_frac, **calc_modes_args,
-                                               )  # type: QpointPhononModes
+    phonons: QpointPhononModes = fc.calculate_qpoint_phonon_modes(
+        qpts_frac, **calc_modes_args)
 
     if energy_bins is None:
         energy_bins = _get_default_bins(phonons)

--- a/euphonic/powder.py
+++ b/euphonic/powder.py
@@ -327,7 +327,9 @@ def sample_sphere_structure_factor(
     if isinstance(scattering_lengths, str):
         scattering_lengths = get_reference_data(
             physical_property='coherent_scattering_length',
-            collection=scattering_lengths)  # type: dict
+        scattering_lengths: dict = get_reference_data(
+            physical_property='coherent_scattering_length',
+            collection=scattering_lengths)
 
     if temperature is not None:
         if (dw is None):

--- a/euphonic/powder.py
+++ b/euphonic/powder.py
@@ -325,8 +325,6 @@ def sample_sphere_structure_factor(
     """
 
     if isinstance(scattering_lengths, str):
-        scattering_lengths = get_reference_data(
-            physical_property='coherent_scattering_length',
         scattering_lengths: dict = get_reference_data(
             physical_property='coherent_scattering_length',
             collection=scattering_lengths)
@@ -336,8 +334,7 @@ def sample_sphere_structure_factor(
             dw_qpts = mp_grid(fc.crystal.get_mp_grid_spec(dw_spacing))
             dw_phonons = fc.calculate_qpoint_phonon_modes(dw_qpts,
                                                           **calc_modes_args)
-            dw = dw_phonons.calculate_debye_waller(temperature,
-dw: DebyeWaller = dw_phonons.calculate_debye_waller(temperature)
+            dw: DebyeWaller = dw_phonons.calculate_debye_waller(temperature)
         elif not np.isclose(dw.temperature, temperature):
             msg = (
                 'Temperature argument is not consistent with '

--- a/euphonic/powder.py
+++ b/euphonic/powder.py
@@ -30,7 +30,7 @@ def sample_sphere_dos(fc: ForceConstants,
                       npts: int = 1000,
                       jitter: bool = False,
                       rng: RNG = rng,
-                      energy_bins: Quantity = None,
+                      energy_bins: Quantity | None = None,
                       **calc_modes_args,
                       ) -> Spectrum1D:
     """
@@ -123,7 +123,7 @@ def sample_sphere_pdos(
         npts: int = 1000,
         jitter: bool = False,
         rng: RNG = rng,
-        energy_bins: Quantity = None,
+        energy_bins: Quantity | None = None,
         weighting: str | None = None,
         cross_sections: str | dict[str, Quantity] = 'BlueBook',
         **calc_modes_args,
@@ -335,7 +335,7 @@ def sample_sphere_structure_factor(
             dw_phonons = fc.calculate_qpoint_phonon_modes(dw_qpts,
                                                           **calc_modes_args)
             dw = dw_phonons.calculate_debye_waller(temperature,
-                                                   )  # type: DebyeWaller
+dw: DebyeWaller = dw_phonons.calculate_debye_waller(temperature)
         elif not np.isclose(dw.temperature, temperature):
             msg = (
                 'Temperature argument is not consistent with '


### PR DESCRIPTION
Closes #440 

This makes the API more resilient against changes (e.g. because a new algorithm takes extra arguments). It is a breaking change so should be part of Euphonic 2.0 release.

I also take the opportunity to move the `rng` argument next to `jitter` as they are related.

Note that this PR targets `release-2.0.0`, not `master`. As there are a few things to do for 2.0 we may want to make another bugfix release from `master` before v2 is ready.