### PR TITLE
Merge CHANGELOG check action into release branch

### DIFF
--- a/.github/workflows/check_changelog.yml
+++ b/.github/workflows/check_changelog.yml
@@ -1,0 +1,17 @@
+name: Changelog updated
+
+on:
+  pull_request:
+    types: [opened, reopened, labeled, synchronize]
+
+jobs:
+  check_log:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - name: Get changes
+        run: |
+          ! git diff --exit-code -- "${GITHUB_BASE_REF}" "${GITHUB_HEAD_REF}" CHANGELOG.rst


### PR DESCRIPTION
We wanted to use this action for bugfixes as well so it was initially merged to master. Now we should bring it to the release branch.