### PR TITLE
Fix Changelog check

### DIFF
--- a/.github/workflows/check_changelog.yml
+++ b/.github/workflows/check_changelog.yml
@@ -17,7 +17,7 @@ jobs:
           set +e  # Don't immediately fail when bash sees exit 1
           git diff --exit-code "origin/${GITHUB_BASE_REF}" -- CHANGELOG.rst
           if [ $? -eq 1 ]; then
-              return 0
+              exit 0
           fi
           # git-diff did not return 1; either no changes or another error encountered
-          return 1
+          exit 1

--- a/.github/workflows/check_changelog.yml
+++ b/.github/workflows/check_changelog.yml
@@ -14,4 +14,4 @@ jobs:
           fetch-depth: 0
       - name: Get changes
         run: |
-          ! git diff --exit-code "${GITHUB_BASE_REF}" -- CHANGELOG.rst
+          ! git diff --exit-code "origin/${GITHUB_BASE_REF}" -- CHANGELOG.rst

--- a/.github/workflows/check_changelog.yml
+++ b/.github/workflows/check_changelog.yml
@@ -14,4 +14,10 @@ jobs:
           fetch-depth: 0
       - name: Get changes
         run: |
-          ! git diff --exit-code "origin/${GITHUB_BASE_REF}" -- CHANGELOG.rst
+          set +e  # Don't immediately fail when bash sees exit 1
+          git diff --exit-code "origin/${GITHUB_BASE_REF}" -- CHANGELOG.rst
+          if [ $? -eq 1 ]; then
+              return 0
+          fi
+          # git-diff did not return 1; either no changes or another error encountered
+          return 1

--- a/.github/workflows/check_changelog.yml
+++ b/.github/workflows/check_changelog.yml
@@ -14,4 +14,4 @@ jobs:
           fetch-depth: 0
       - name: Get changes
         run: |
-          ! git diff --exit-code -- "${GITHUB_BASE_REF}" "${GITHUB_HEAD_REF}" CHANGELOG.rst
+          ! git diff --exit-code "${GITHUB_BASE_REF}" -- CHANGELOG.rst

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,7 +14,7 @@
   - Security
 
     - Bumped *wheel* requirement for docs and testing to 0.46.2. (`CVE-2026-24049 <https://www.cve.org/CVERecord?id=CVE-2026-24049>`_)
-  
+
 
 - Bug fixes
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,7 +14,7 @@
   - Security
 
     - Bumped *wheel* requirement for docs and testing to 0.46.2. (`CVE-2026-24049 <https://www.cve.org/CVERecord?id=CVE-2026-24049>`_)
-
+  
 
 - Bug fixes
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,5 +1,3 @@
-This is definitely a change the changelog needs.
-
 `Unreleased <https://github.com/pace-neutrons/Euphonic/compare/v1.6.0...HEAD>`_
 -------------------------------------------------------------------------------
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,5 @@
+This is definitely a change the changelog needs.
+
 `Unreleased <https://github.com/pace-neutrons/Euphonic/compare/v1.6.0...HEAD>`_
 -------------------------------------------------------------------------------
 
@@ -14,7 +16,7 @@
   - Security
 
     - Bumped *wheel* requirement for docs and testing to 0.46.2. (`CVE-2026-24049 <https://www.cve.org/CVERecord?id=CVE-2026-24049>`_)
-  
+
 
 - Bug fixes
 


### PR DESCRIPTION
Attempts to fix the issue with the changelog check. Should not be merged without reverting the changelog changes. 

Issues were due to misplaced `--` and naming of branch due to not checked out. 