### PR TITLE
Drop redundant get_args function from cli.utils

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,9 @@
   - Unused argument ``use_brille`` is removed from
     ``euphonic.cli.brille_convergence.check_brille_settings``.
 
+  - ``get_args()`` function removed from ``euphonic.cli.utils``; this
+    was previously simplified to a one-liner so brings no DRY benefit.
+
 - Features
 
   - Spectrum1DCollection and Spectrum2DCollection can be indexed with

--- a/euphonic/cli/brille_convergence.py
+++ b/euphonic/cli/brille_convergence.py
@@ -14,7 +14,6 @@ from euphonic.cli.utils import (
     _brille_calc_modes_kwargs,
     _get_cli_parser,
     _get_energy_bins,
-    get_args,
     load_data_from_file,
 )
 from euphonic.sampling import recurrence_sequence
@@ -22,7 +21,7 @@ from euphonic.util import format_error
 
 
 def main(params: list[str] | None = None) -> None:
-    args = get_args(get_parser(), params)
+    args = get_parser().parse_args(args=params)
     params = vars(args)
 
     del params['use_brille']  # This tool _always_ uses brille

--- a/euphonic/cli/dispersion.py
+++ b/euphonic/cli/dispersion.py
@@ -16,14 +16,13 @@ from .utils import (
     _get_q_distance,
     _get_title,
     _plot_label_kwargs,
-    get_args,
     load_data_from_file,
     matplotlib_save_or_show,
 )
 
 
 def main(params: list[str] | None = None) -> None:
-    args = get_args(get_parser(), params)
+    args = get_parser().parse_args(args=params)
 
     # Need eigenvectors to reorder bands or write website JSON
     frequencies_only = args.save_web_json is None and not args.reorder

--- a/euphonic/cli/dos.py
+++ b/euphonic/cli/dos.py
@@ -18,15 +18,13 @@ from .utils import (
     _get_pdos_weighting,
     _grid_spec_from_args,
     _plot_label_kwargs,
-    get_args,
     load_data_from_file,
     matplotlib_save_or_show,
 )
 
 
 def main(params: list[str] | None = None) -> None:
-    parser = get_parser()
-    args = get_args(parser, params)
+    args = get_parser().parse_args(args=params)
 
     frequencies_only = (args.weighting == 'dos' and args.pdos is None)
     data = load_data_from_file(args.filename, verbose=True,

--- a/euphonic/cli/intensity_map.py
+++ b/euphonic/cli/intensity_map.py
@@ -17,14 +17,13 @@ from .utils import (
     _get_energy_bins,
     _get_q_distance,
     _plot_label_kwargs,
-    get_args,
     load_data_from_file,
     matplotlib_save_or_show,
 )
 
 
 def main(params: list[str] | None = None) -> None:
-    args = get_args(get_parser(), params)
+    args = get_parser().parse_args(args=params)
     calc_modes_kwargs = _calc_modes_kwargs(args)
 
     frequencies_only = (args.weighting != 'coherent')

--- a/euphonic/cli/optimise_dipole_parameter.py
+++ b/euphonic/cli/optimise_dipole_parameter.py
@@ -14,7 +14,7 @@ import warnings
 import numpy as np
 
 from euphonic import ForceConstants
-from euphonic.cli.utils import _get_cli_parser, get_args, load_data_from_file
+from euphonic.cli.utils import _get_cli_parser, load_data_from_file
 from euphonic.util import format_error
 
 # Formatting string for timing output TEXT: VALUE UNITS
@@ -25,7 +25,7 @@ DPARAM_TEMPLATE = '{:s} {:2.2f}'
 
 
 def main(params: list[str] | None = None) -> None:
-    args = get_args(get_parser(), params)
+    args = get_parser().parse_args(args=params)
     params = vars(args)
     params.update({'print_to_terminal': True})
     calculate_optimum_dipole_parameter(**params)

--- a/euphonic/cli/powder_map.py
+++ b/euphonic/cli/powder_map.py
@@ -19,7 +19,6 @@ from euphonic.cli.utils import (
     _get_pdos_weighting,
     _get_q_distance,
     _plot_label_kwargs,
-    get_args,
     load_data_from_file,
     matplotlib_save_or_show,
 )
@@ -124,7 +123,7 @@ def _get_broaden_kwargs(q_broadening: Sequence[float] | None = None,
 
 
 def main(params: list[str] | None = None) -> None:
-    args = get_args(get_parser(), params)
+    args = get_parser().parse_args(args=params)
     calc_modes_kwargs = _calc_modes_kwargs(args)
 
     # Make sure we get an error if accessing NPTS inappropriately

--- a/euphonic/cli/show_sampling.py
+++ b/euphonic/cli/show_sampling.py
@@ -7,7 +7,7 @@ import numpy as np
 import euphonic.sampling
 from euphonic.util import zips
 
-from .utils import get_args, matplotlib_save_or_show
+from .utils import matplotlib_save_or_show
 
 choices_2d = {'golden-square', 'regular-square', 'recurrence-square'}
 choices_3d = {'golden-sphere', 'sphere-from-square-grid',
@@ -34,8 +34,7 @@ def get_parser() -> ArgumentParser:
 
 
 def main(params: list[str] | None = None) -> None:
-    parser = get_parser()
-    args = get_args(parser, params)
+    args = get_parser().parse_args(args=params)
 
     if args.sampling in choices_2d:
         fig, ax = plt.subplots()

--- a/euphonic/cli/utils.py
+++ b/euphonic/cli/utils.py
@@ -183,28 +183,6 @@ def load_data_from_file(filename: str | os.PathLike,
     return data
 
 
-def get_args(parser: ArgumentParser, params: list[str] | None = None,
-             ) -> Namespace:
-    """
-    Get the arguments from the parser. `params` should only be `None` when
-    running from command line.
-
-    Parameters
-    ----------
-    parser
-        The parser to get the arguments from
-    params
-        The parameters to get arguments from, if None,
-         then parse_args gets them from command line args
-
-    Returns
-    -------
-    args
-        Arguments object for use e.g. args.unit
-    """
-    return parser.parse_args(args=params)
-
-
 def matplotlib_save_or_show(save_filename: Path | str | None = None) -> None:
     """
     Save or show the current matplotlib plot.


### PR DESCRIPTION
Closes #399 

This function was previously simplified to a one-liner, but kept in API to avoid compatibility break. For v2 release we can drop it.