### PR TITLE
Bump pytest to 9.0.3 to address CVE-2025-71176

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,12 @@
 `Unreleased <https://github.com/pace-neutrons/Euphonic/compare/v1.6.0...HEAD>`_
 -------------------------------------------------------------------------------
 
+- Requirements
+
+  - Security
+
+    - Bumped *pytest* requirement for testing to 9.0.3. (`CVE-2025-71176 <https://www.cve.org/CVERecord?id=CVE-2025-71176>`_)
+
 `v1.6.0 <https://github.com/pace-neutrons/Euphonic/compare/v1.5.1...v1.6.0>`_
 -----------------------------------------------------------------------------
 

--- a/build_utils/conda_release_test_requirements.yml
+++ b/build_utils/conda_release_test_requirements.yml
@@ -1,7 +1,7 @@
 channels:
   - conda-forge
 dependencies:
-  - pytest=8.*
+  - pytest>=9.0.3,<10.0
   - coverage
   - pytest-mock
   - pytest-lazy-fixtures

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,5 +1,5 @@
-numpy>=1.21.3
-pytest==8.4.2
+numpy==2.4.2
+pytest==9.0.3
 setuptools==78.1.1
 sphinx==5.3.0
 sphinx-argparse==0.3.2

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,4 +1,4 @@
-numpy==2.4.2
+numpy==2.2.6
 pytest==9.0.3
 setuptools==78.1.1
 sphinx==5.3.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ matplotlib = ["matplotlib>=3.8.0"]
 phonopy_reader = ["h5py>=3.6.0", "PyYAML>=6.0"]  # Deprecated, will be removed in future versions.
 phonopy-reader = ["h5py>=3.6.0", "PyYAML>=6.0"]
 brille = ["brille>=0.7.0"]
-test = ["mock", "pytest>=8.0,<9.0", "pytest-cov", "pytest-mock", "pytest-lazy-fixtures", "pytest-xdist", "pytest-xvfb", "python-slugify"]
+test = ["mock", "pytest>=9.0.3,<10.0", "pytest-cov", "pytest-mock", "pytest-lazy-fixtures", "pytest-xdist", "pytest-xvfb", "python-slugify"]
 ci = ["tox==4.30.3"]
 
 [project.scripts]

--- a/tests_and_analysis/tox_requirements.txt
+++ b/tests_and_analysis/tox_requirements.txt
@@ -1,5 +1,5 @@
 mock
-pytest==7.*
+pytest>=9.0.3,<10.0
 coverage
 pytest-mock
 pytest-lazy-fixtures


### PR DESCRIPTION
Thanks dependabot for bringing to attention in #479 

While the test suite is _mostly_ run in CI VMs or on developer laptops, it's not unreasonable that an advanced user would like to run the test suite on a shared HPC system: in this situation the vulnerability is relevant.

Also noticed that readthedocs is building with a very old numpy, there isn't a good reason for that so bump to something more recent.