### PR TITLE
Make Crystal Immutable

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -19,8 +19,11 @@
 
   - Some public functions in ``Crystal`` (``reciprocal_lattice``,
     ``cell_volume``) are now ``@cached_property`` and don't need ``()``.
-    The cache will be cleared on setting ``cell_vectors`` so direct changes
-    to the ``_cell_vectors`` attribute may cause desynchronisation.
+
+  - ``Crystal`` is now treated as immutable and this is enforced as
+    far as reasonably practical. Unit conversion should be performed
+    directly on the read-only properties, and new copies of the object
+    constructed as needed.
 
 - Features
 

--- a/euphonic/cli/intensity_map.py
+++ b/euphonic/cli/intensity_map.py
@@ -2,7 +2,6 @@ from argparse import ArgumentParser
 
 import matplotlib.style
 
-import euphonic
 from euphonic import ForceConstants, QpointPhononModes, ureg
 import euphonic.plot
 from euphonic.styles import base_style

--- a/euphonic/crystal.py
+++ b/euphonic/crystal.py
@@ -1,5 +1,5 @@
 from collections import OrderedDict
-from functools import cached_property
+from functools import cached_property, wraps
 from math import ceil
 from pathlib import Path
 from typing import Any, TypeVar
@@ -21,6 +21,18 @@ from euphonic.util import (
 )
 from euphonic.validate import _check_constructor_inputs
 
+
+def read_only_array(f):
+    """Call .setflags(write=False) on return value of decorated function
+
+    This ensures a numpy array isn't accidentally modified by accessing slices
+    """
+    @wraps(f)
+    def wrapper(*args, **kwds):
+        result = f(*args, **kwds)
+        result.setflags(write=False)
+        return result
+    return wrapper
 
 class read_only_cached_property(cached_property):
     def __set__(self, instance, value):
@@ -106,17 +118,13 @@ class Crystal:
         self._cell_vectors_unit = str(cell_vectors.units)
         self._atom_mass_unit = str(atom_mass.units)
 
-        # Set underlying arrays to read-only to defend during slice access
-        for array_attribute in (
-            self.atom_r, self.atom_type, self._cell_vectors, self._atom_mass,
-        ):
-            array_attribute.setflags(write=False)
-
     @property
+    @read_only_array
     def atom_r(self) -> np.ndarray:
         return self._atom_r
 
     @property
+    @read_only_array
     def atom_type(self) -> np.ndarray:
         return self._atom_type
 
@@ -133,18 +141,17 @@ class Crystal:
         return self._n_atoms
 
     @read_only_cached_property
+    @read_only_array
     def cell_vectors(self) -> Quantity:
-        result = Quantity(self._cell_vectors, 'bohr').to(self.cell_vectors_unit)
-        result.setflags(write=False)
-        return result
+        return Quantity(self._cell_vectors, 'bohr').to(self.cell_vectors_unit)
 
     @read_only_cached_property
+    @read_only_array
     def atom_mass(self) -> Quantity:
-        result = Quantity(self._atom_mass, 'm_e').to(self.atom_mass_unit)
-        result.setflags(write=False)
-        return result
+        return Quantity(self._atom_mass, 'm_e').to(self.atom_mass_unit)
 
     @read_only_cached_property
+    @read_only_array
     def reciprocal_cell(self) -> Quantity:
         """
         Calculates the reciprocal lattice vectors
@@ -163,9 +170,7 @@ class Crystal:
         vol = self.cell_volume
         norm = 2*np.pi/vol
 
-        result = np.vstack((norm * bxc, norm * cxa, norm * axb))
-        result.setflags(write=False)
-        return result
+        return np.vstack((norm * bxc, norm * cxa, norm * axb))
 
     @read_only_cached_property
     def cell_volume(self) -> Quantity:

--- a/euphonic/crystal.py
+++ b/euphonic/crystal.py
@@ -86,14 +86,22 @@ class Crystal:
         self.atom_type = atom_type
         self._atom_mass = atom_mass.to(ureg.m_e).magnitude
 
-        self.cell_vectors_unit = str(cell_vectors.units)
-        self.atom_mass_unit = str(atom_mass.units)
+        self._cell_vectors_unit = str(cell_vectors.units)
+        self._atom_mass_unit = str(atom_mass.units)
 
         # Set underlying arrays to read-only to defend during slice access
         for array_attribute in (
             self.atom_r, self.atom_type, self._cell_vectors, self._atom_mass,
         ):
             array_attribute.setflags(write=False)
+
+    @property
+    def cell_vectors_unit(self) -> str:
+        return self._cell_vectors_unit
+
+    @property
+    def atom_mass_unit(self) -> str:
+        return self._atom_mass_unit
 
     @property
     def n_atoms(self) -> int:

--- a/euphonic/crystal.py
+++ b/euphonic/crystal.py
@@ -19,7 +19,7 @@ from euphonic.util import (
     _get_unique_elems_and_idx,
     format_error,
 )
-from euphonic.validate import _check_constructor_inputs, _check_unit_conversion
+from euphonic.validate import _check_constructor_inputs
 
 
 class Crystal:
@@ -81,7 +81,7 @@ class Crystal:
             (atom_mass, Quantity, (n_atoms,), 'atom_mass'),
         )
         self._cell_vectors = cell_vectors.to(ureg.bohr).magnitude
-        self.n_atoms = n_atoms
+        self._n_atoms = n_atoms
         self.atom_r = atom_r
         self.atom_type = atom_type
         self._atom_mass = atom_mass.to(ureg.m_e).magnitude
@@ -89,34 +89,23 @@ class Crystal:
         self.cell_vectors_unit = str(cell_vectors.units)
         self.atom_mass_unit = str(atom_mass.units)
 
+        # Set underlying arrays to read-only to defend during slice access
+        for array_attribute in (
+            self.atom_r, self.atom_type, self._cell_vectors, self._atom_mass,
+        ):
+            array_attribute.setflags(write=False)
+
     @property
+    def n_atoms(self) -> int:
+        return self._n_atoms
+
+    @cached_property
     def cell_vectors(self) -> Quantity:
-        return self._cell_vectors*ureg('bohr').to(
-            self.cell_vectors_unit)
+        return Quantity(self._cell_vectors, 'bohr').to(self.cell_vectors_unit)
 
-    @cell_vectors.setter
-    def cell_vectors(self, value: Quantity) -> None:
-        self.cell_vectors_unit = str(value.units)
-        self._cell_vectors = value.to('bohr').magnitude
-        if hasattr(self, 'cell_volume'):
-            del self.cell_volume
-        if hasattr(self, 'reciprocal_cell'):
-            del self.reciprocal_cell
-
-    @property
+    @cached_property
     def atom_mass(self) -> Quantity:
-        return self._atom_mass*ureg('m_e').to(
-            self.atom_mass_unit)
-
-    @atom_mass.setter
-    def atom_mass(self, value: Quantity) -> None:
-        self.atom_mass_unit = str(value.units)
-        self._atom_mass = value.to('m_e').magnitude
-
-    def __setattr__(self, name: str, value: Any) -> None:
-        _check_unit_conversion(self, name, value,
-                               ['cell_vectors_unit', 'atom_mass_unit'])
-        super().__setattr__(name, value)
+        return Quantity(self._atom_mass, 'm_e').to(self.atom_mass_unit)
 
     @cached_property
     def reciprocal_cell(self) -> Quantity:

--- a/euphonic/crystal.py
+++ b/euphonic/crystal.py
@@ -22,6 +22,23 @@ from euphonic.util import (
 from euphonic.validate import _check_constructor_inputs
 
 
+class read_only_cached_property(cached_property):
+    def __set__(self, instance, value):
+        if hasattr(self, '__replace__'):
+            fix = ('You can make a modified copy of this '
+                   'object with copy.replace().')
+        else:
+            fix = (f'Make a new {instance.__class__.__name__} with '
+                   'the required values.')
+
+        msg = format_error(
+            f'{instance.__class__.__name__} property '
+            f'"{self.attrname}" is read-only.',
+            fix=fix
+        )
+        raise AttributeError(msg)
+
+
 class Crystal:
     """
     Stores lattice and atom information
@@ -82,8 +99,8 @@ class Crystal:
         )
         self._cell_vectors = cell_vectors.to(ureg.bohr).magnitude
         self._n_atoms = n_atoms
-        self.atom_r = atom_r
-        self.atom_type = atom_type
+        self._atom_r = atom_r
+        self._atom_type = atom_type
         self._atom_mass = atom_mass.to(ureg.m_e).magnitude
 
         self._cell_vectors_unit = str(cell_vectors.units)
@@ -94,6 +111,14 @@ class Crystal:
             self.atom_r, self.atom_type, self._cell_vectors, self._atom_mass,
         ):
             array_attribute.setflags(write=False)
+
+    @property
+    def atom_r(self) -> np.ndarray:
+        return self._atom_r
+
+    @property
+    def atom_type(self) -> np.ndarray:
+        return self._atom_type
 
     @property
     def cell_vectors_unit(self) -> str:
@@ -107,15 +132,19 @@ class Crystal:
     def n_atoms(self) -> int:
         return self._n_atoms
 
-    @cached_property
+    @read_only_cached_property
     def cell_vectors(self) -> Quantity:
-        return Quantity(self._cell_vectors, 'bohr').to(self.cell_vectors_unit)
+        result = Quantity(self._cell_vectors, 'bohr').to(self.cell_vectors_unit)
+        result.setflags(write=False)
+        return result
 
-    @cached_property
+    @read_only_cached_property
     def atom_mass(self) -> Quantity:
-        return Quantity(self._atom_mass, 'm_e').to(self.atom_mass_unit)
+        result = Quantity(self._atom_mass, 'm_e').to(self.atom_mass_unit)
+        result.setflags(write=False)
+        return result
 
-    @cached_property
+    @read_only_cached_property
     def reciprocal_cell(self) -> Quantity:
         """
         Calculates the reciprocal lattice vectors
@@ -134,9 +163,11 @@ class Crystal:
         vol = self.cell_volume
         norm = 2*np.pi/vol
 
-        return np.vstack((norm * bxc, norm * cxa, norm * axb))
+        result = np.vstack((norm * bxc, norm * cxa, norm * axb))
+        result.setflags(write=False)
+        return result
 
-    @cached_property
+    @read_only_cached_property
     def cell_volume(self) -> Quantity:
         """
         Calculates the cell volume

--- a/euphonic/crystal.py
+++ b/euphonic/crystal.py
@@ -34,7 +34,9 @@ def read_only_array(f):
         return result
     return wrapper
 
-class read_only_cached_property(cached_property):
+
+class read_only_cached_property(cached_property):  # noqa: N801
+    """Modified functools.cached_property to disallow __set__"""
     def __set__(self, instance, value):
         if hasattr(self, '__replace__'):
             fix = ('You can make a modified copy of this '
@@ -46,7 +48,7 @@ class read_only_cached_property(cached_property):
         msg = format_error(
             f'{instance.__class__.__name__} property '
             f'"{self.attrname}" is read-only.',
-            fix=fix
+            fix=fix,
         )
         raise AttributeError(msg)
 

--- a/tests_and_analysis/test/euphonic_test/test_crystal.py
+++ b/tests_and_analysis/test/euphonic_test/test_crystal.py
@@ -10,8 +10,6 @@ import spglib
 from euphonic import Crystal, Quantity, ureg
 from tests_and_analysis.test.utils import (
     check_json_metadata,
-    check_property_setters,
-    check_unit_conversion,
     get_data_path,
 )
 
@@ -259,12 +257,12 @@ class TestCrystalSetters:
     def test_setters_cached_array_properties(self, material, attr):
         crystal = get_crystal(material)
         current_value = getattr(crystal, attr)
-        with pytest.raises(AttributeError, match="Make a new Crystal"):
+        with pytest.raises(AttributeError, match='Make a new Crystal'):
             setattr(crystal, attr, current_value * 2.)
 
         # Writing to slice/element: numpy error
         if hasattr(current_value, '__item__'):
-            with pytest.raises(ValueError, match="read-only"):
+            with pytest.raises(ValueError, match='read-only'):
                 current_value[1] = current_value[0]
 
     @pytest.mark.parametrize('material, attr', [
@@ -276,11 +274,11 @@ class TestCrystalSetters:
         current_value = getattr(crystal, attr)
 
         # Writing to slice/element: numpy error
-        with pytest.raises(ValueError, match="read-only"):
+        with pytest.raises(ValueError, match='read-only'):
             current_value[1] = current_value[0]
 
         # Writing to attribute: no setter available
-        with pytest.raises(AttributeError, match="has no setter"):
+        with pytest.raises(AttributeError, match='has no setter'):
             setattr(crystal, attr, current_value[::-1])
 
     @pytest.mark.parametrize('material, attr', [
@@ -293,7 +291,7 @@ class TestCrystalSetters:
         current_value = getattr(crystal, attr)
 
         # Writing to attribute: no setter available
-        with pytest.raises(AttributeError, match="has no setter"):
+        with pytest.raises(AttributeError, match='has no setter'):
             setattr(crystal, attr, current_value)
 
 

--- a/tests_and_analysis/test/euphonic_test/test_crystal.py
+++ b/tests_and_analysis/test/euphonic_test/test_crystal.py
@@ -247,26 +247,6 @@ class TestCrystalSerialisation:
         check_crystal(crystal, expected_crystal)
 
 
-class TestCrystalUnitConversion:
-
-    @pytest.mark.parametrize('material, attr, unit_val', [
-        ('quartz', 'cell_vectors', 'bohr'),
-        ('quartz', 'atom_mass', 'kg')])
-    def test_correct_unit_conversion(self, material, attr,
-                                     unit_val):
-        crystal = get_crystal(material)
-        check_unit_conversion(crystal, attr, unit_val)
-
-    @pytest.mark.parametrize('material, unit_attr, unit_val, err', [
-        ('quartz', 'cell_vectors_unit', 'kg', ValueError),
-        ('quartz', 'atom_mass_unit', 'bohr', ValueError)])
-    def test_incorrect_unit_conversion(self, material, unit_attr,
-                                       unit_val, err):
-        crystal = get_crystal(material)
-        with pytest.raises(err):
-            setattr(crystal, unit_attr, unit_val)
-
-
 class TestCrystalSetters:
 
     @pytest.mark.parametrize('material, attr, unit, scale', [
@@ -287,8 +267,8 @@ class TestCrystalSetters:
                                        unit, err):
         crystal = get_crystal(material)
         new_attr = getattr(crystal, attr).magnitude*ureg(unit)
-        with pytest.raises(err):
-            setattr(crystal, attr, new_attr)
+        #with pytest.raises(err):
+        setattr(crystal, attr, new_attr)
 
 
 class TestCrystalMethods:

--- a/tests_and_analysis/test/euphonic_test/test_crystal.py
+++ b/tests_and_analysis/test/euphonic_test/test_crystal.py
@@ -278,7 +278,8 @@ class TestCrystalSetters:
             current_value[1] = current_value[0]
 
         # Writing to attribute: no setter available
-        with pytest.raises(AttributeError, match='has no setter'):
+        with pytest.raises(AttributeError,
+                           match="(can't set attribute)|(no setter)"):
             setattr(crystal, attr, current_value[::-1])
 
     @pytest.mark.parametrize('material, attr', [
@@ -291,7 +292,8 @@ class TestCrystalSetters:
         current_value = getattr(crystal, attr)
 
         # Writing to attribute: no setter available
-        with pytest.raises(AttributeError, match='has no setter'):
+        with pytest.raises(AttributeError,
+                           match="(can't set attribute)|(no setter)"):
             setattr(crystal, attr, current_value)
 
 

--- a/tests_and_analysis/test/euphonic_test/test_crystal.py
+++ b/tests_and_analysis/test/euphonic_test/test_crystal.py
@@ -248,27 +248,53 @@ class TestCrystalSerialisation:
 
 
 class TestCrystalSetters:
+    """Crystal is immutable, there should not be any working setters"""
 
-    @pytest.mark.parametrize('material, attr, unit, scale', [
-        ('quartz', 'cell_vectors', 'bohr', 2.),
-        ('quartz', 'cell_vectors', 'angstrom', 3.),
-        ('quartz', 'atom_mass', 'kg', 2.),
-        ('quartz', 'atom_mass', 'm_e', 0.5),
+    @pytest.mark.parametrize('material, attr', [
+        ('quartz', 'cell_vectors'),
+        ('quartz', 'atom_mass'),
+        ('quartz', 'reciprocal_cell'),
+        ('quartz', 'cell_volume'),
         ])
-    def test_setter_correct_units(self, material, attr,
-                                  unit, scale):
+    def test_setters_cached_array_properties(self, material, attr):
         crystal = get_crystal(material)
-        check_property_setters(crystal, attr, unit, scale)
+        current_value = getattr(crystal, attr)
+        with pytest.raises(AttributeError, match="Make a new Crystal"):
+            setattr(crystal, attr, current_value * 2.)
 
-    @pytest.mark.parametrize('material, attr, unit, err', [
-        ('quartz', 'cell_vectors', 'kg', ValueError),
-        ('quartz', 'atom_mass', 'bohr', ValueError)])
-    def test_incorrect_unit_conversion(self, material, attr,
-                                       unit, err):
+        # Writing to slice/element: numpy error
+        if hasattr(current_value, '__item__'):
+            with pytest.raises(ValueError, match="read-only"):
+                current_value[1] = current_value[0]
+
+    @pytest.mark.parametrize('material, attr', [
+        ('quartz', 'atom_r'),
+        ('quartz', 'atom_type'),
+        ])
+    def test_setter_array_properties(self, material, attr):
         crystal = get_crystal(material)
-        new_attr = getattr(crystal, attr).magnitude*ureg(unit)
-        #with pytest.raises(err):
-        setattr(crystal, attr, new_attr)
+        current_value = getattr(crystal, attr)
+
+        # Writing to slice/element: numpy error
+        with pytest.raises(ValueError, match="read-only"):
+            current_value[1] = current_value[0]
+
+        # Writing to attribute: no setter available
+        with pytest.raises(AttributeError, match="has no setter"):
+            setattr(crystal, attr, current_value[::-1])
+
+    @pytest.mark.parametrize('material, attr', [
+        ('quartz', 'cell_vectors_unit'),
+        ('quartz', 'atom_mass_unit'),
+        ('quartz', 'n_atoms'),
+        ])
+    def test_setter_other_properties(self, material, attr):
+        crystal = get_crystal(material)
+        current_value = getattr(crystal, attr)
+
+        # Writing to attribute: no setter available
+        with pytest.raises(AttributeError, match="has no setter"):
+            setattr(crystal, attr, current_value)
 
 
 class TestCrystalMethods:

--- a/tests_and_analysis/test/euphonic_test/test_crystal.py
+++ b/tests_and_analysis/test/euphonic_test/test_crystal.py
@@ -207,7 +207,7 @@ class TestCrystalCreation:
 
     def test_faulty_creation(self, inject_faulty_elements):
         faulty_args, expected_exception = inject_faulty_elements
-        with pytest.raises(expected_exception):
+        with pytest.raises(expected_exception, match=None):
             Crystal(*faulty_args)
 
 


### PR DESCRIPTION
Closes #483 

Currently the doctests are failing on the page that describes the unit system. This currently
- declares that _all_ euphonic classes with Quantity attributes allow the unit to be changed by poking the `thing_unit` attribute.
- walks though dealing with the odd behaviour where you can replace a whole array but not always mutate elements of it

Will it confuse matters more to have only _some_ classes following this system? Maybe overhauling all the classes to have simpler property handling (and a `dataclass` base?) is a project for Euphonic v3. I don't see a lot of benefit to the complex mutability of the current system, especially if we provide a `__replace__` hook. The main benefits of current system are:
- direct access to private attributes in atomic units for the C code.
- array size validation

But these could also be handled with dataclass `__post_init__` hooks. And I wonder if the always-convert-to-au-on-init overhead is really worthwhile to simplify the C setup anyway; those things could be wrapped to call a cached conversion method.