### PR TITLE
Fix issue with version.py

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,11 @@
 `Unreleased <https://github.com/pace-neutrons/Euphonic/compare/v1.6.1...HEAD>`_
 -------------------------------------------------------------------------------
 
+- Maintenance
+
+  - Ensure ``build_utils/version.py`` works for uncommitted changes to tagged HEADs.
+
+
 `v1.6.1 <https://github.com/pace-neutrons/Euphonic/compare/v1.6.0...v1.6.1>`_
 -----------------------------------------------------------------------------
 

--- a/build_utils/version.py
+++ b/build_utils/version.py
@@ -41,7 +41,7 @@ version_file = Path(__file__).parent.parent / 'euphonic' / 'version.py'
 for gitcmd in gits:
     try:
         print(f'Trying {gitcmd} ...', file=sys.stderr)
-        proc = subprocess.run([gitcmd, 'describe', '--tags', '--dirty'],  # noqa: S603
+        proc = subprocess.run([gitcmd, 'describe', '--tags', '--dirty', '--long'],  # noqa: S603
                               capture_output=True, check=True, text=True,
                               )
     except FileNotFoundError:
@@ -55,8 +55,14 @@ for gitcmd in gits:
         continue
 
     version, *dirty = proc.stdout.strip().split('-')
-    if dirty:
-        version += f"+{dirty[0]}.{dirty[1]}{'.dirty' if len(dirty) > 2 and COMMAND != 'dump' else ''}"
+    match dirty:
+        case ('0', _):
+            pass
+        case (commits, hash):
+            version += f'+{commits}.{hash}'
+        case (commits, hash, 'dirty'):
+            version += f'+{commits}.{hash}.dirty'
+
     break
 
 else:  # Can't use git


### PR DESCRIPTION
Fix an issue whereby a dirty version from a tagged hash fails to run.

```
(/home/jacob/Twophonic/.venv) jacob@nyx [11:24:01] ~/Twophonic %  [master]
> git describe --tags --dirty
v1.6.1
(/home/jacob/Twophonic/.venv) jacob@nyx [11:24:07] ~/Twophonic %  [master]
> emacs pyproject.toml
(/home/jacob/Twophonic/.venv) jacob@nyx [11:24:15] ~/Twophonic %  [master*1]
> git describe --tags --dirty
v1.6.1-dirty
(/home/jacob/Twophonic/.venv) jacob@nyx [11:24:18] ~/Twophonic %  [master*1]
> python build_utils/version.py
Trying git ...
Traceback (most recent call last):
  File "/home/jacob/Twophonic/build_utils/version.py", line 59, in <module>
    version += f"+{dirty[0]}.{dirty[1]}{'.dirty' if len(dirty) > 2 and COMMAND != 'dump' else ''}"
                              ~~~~~^^^
IndexError: list index out of range
```
With the new version
```
(/home/jacob/Twophonic/.venv) jacob@nyx [11:26:08] ~/Twophonic %  [master*1]
> git reset --hard
(/home/jacob/Twophonic/.venv) jacob@nyx [11:28:34] ~/Twophonic %  [master]
> git checkout fix-version-py build_utils/version.py
Updated 1 path from 6007f05
(/home/jacob/Twophonic/.venv) jacob@nyx [11:28:44] ~/Twophonic %  [master*1]
> python build_utils/version.py
Trying git ...
v1.6.1+0.gd16dce7.dirty
```