### PR TITLE
Deprecate --instrument-broadening flag

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,5 +1,11 @@
 `Unreleased <https://github.com/pace-neutrons/Euphonic/compare/v1.6.1...HEAD>`_
 -------------------------------------------------------------------------------
+- CLI changes
+
+  - The ``--instrument-broadening`` parameter of ``euphonic-dos`` is
+    deprecated and hidden.  The old ``--energy-broadening`` parameter
+    is now functionally the same; i.e. it can no longer set the
+    adaptive broadening width and ``--adaptive-scale`` must be used for that purpose.
 
 - API changes
 

--- a/euphonic/cli/dos.py
+++ b/euphonic/cli/dos.py
@@ -70,7 +70,7 @@ def main(params: list[str] | None = None) -> None:
             modes, mode_grads = data.calculate_qpoint_phonon_modes(
                 mp_grid(grid_spec), **cmkwargs)
             mode_widths = mode_gradients_to_widths(
-                mode_grads, modes.crystal.cell_vectors
+                mode_grads, modes.crystal.cell_vectors,
             ) * args.adaptive_scale
 
             if args.energy_broadening and args.shape == 'gauss':

--- a/euphonic/cli/dos.py
+++ b/euphonic/cli/dos.py
@@ -51,33 +51,8 @@ def main(params: list[str] | None = None) -> None:
         )
         raise TypeError(msg)
 
-    if (args.energy_broadening
-            and args.adaptive
-            and len(args.energy_broadening) == 1):
-        if args.adaptive_scale is not None:
-            msg = format_error(
-                'Adaptive scale factor was specified twice.',
-                fix="""
-                Use either --adaptive-scale or --energy-broadening.
-
-                To add a fixed width to adaptive broadening,
-                use --instrument-broadening.""",
-            )
-            raise ValueError(msg)
-        args.adaptive_scale = args.energy_broadening[0]
-
-    elif args.energy_broadening:
-        if args.inst_broadening is not None:
-            msg = format_error(
-                'Broadening width was specified twice.',
-                fix=('Use either --instrument-broadening '
-                     'or --energy-broadening.'),
-            )
-            raise ValueError(msg)
-        args.inst_broadening = args.energy_broadening
-
-    if args.inst_broadening:
-        energy_broadening_poly = Polynomial(args.inst_broadening)
+    if args.energy_broadening:
+        energy_broadening_poly = Polynomial(args.energy_broadening)
 
     mode_widths = None
     if isinstance(data, ForceConstants):
@@ -94,11 +69,11 @@ def main(params: list[str] | None = None) -> None:
             cmkwargs['return_mode_gradients'] = True
             modes, mode_grads = data.calculate_qpoint_phonon_modes(
                 mp_grid(grid_spec), **cmkwargs)
-            mode_widths = mode_gradients_to_widths(mode_grads,
-                                                   modes.crystal.cell_vectors)
-            if args.adaptive_scale:
-                mode_widths *= args.adaptive_scale
-            if args.inst_broadening and args.shape == 'gauss':
+            mode_widths = mode_gradients_to_widths(
+                mode_grads, modes.crystal.cell_vectors
+            ) * args.adaptive_scale
+
+            if args.energy_broadening and args.shape == 'gauss':
                 # Combine instrumental broadening and adaptive sample
                 # broadening: the convolution of a Gaussian with a Gaussian is
                 # a Gaussian with sigma = sqrt(sigma1^2 + sigma2^2)
@@ -113,6 +88,7 @@ def main(params: list[str] | None = None) -> None:
 
     else:
         modes = data
+
     modes.frequencies_unit = args.energy_unit
     ebins = _get_energy_bins(
         modes, args.ebins + 1, emin=args.e_min, emax=args.e_max)
@@ -128,10 +104,10 @@ def main(params: list[str] | None = None) -> None:
         pdos = modes.calculate_pdos(ebins, **kwargs)
         dos = _arrange_pdos_groups(pdos, args.pdos)
 
-    if args.inst_broadening and args.shape == 'gauss' and args.adaptive:
+    if args.energy_broadening and args.shape == 'gauss' and args.adaptive:
         pass  # Gaussian broadening included with adaptive sampling
 
-    elif (args.inst_broadening and len(energy_broadening_poly) > 1):
+    elif (args.energy_broadening and len(energy_broadening_poly) > 1):
         # Variable-width Gaussian broadening
         def energy_broadening_func(x):
             return energy_broadening_poly(x.to(args.energy_unit).magnitude,
@@ -142,7 +118,7 @@ def main(params: list[str] | None = None) -> None:
                           method='convolve',
                           width_interpolation_error=args.adaptive_error)
 
-    elif args.inst_broadening:
+    elif args.energy_broadening:
         # Fixed-width broadening
         dos = dos.broaden(energy_broadening_poly.coef[0] * ebins.units,
                           shape=args.shape)

--- a/euphonic/cli/utils/_cli_parser.py
+++ b/euphonic/cli/utils/_cli_parser.py
@@ -306,7 +306,7 @@ def _get_cli_parser(features: Collection[str] = {},  # noqa: C901
                     help=('Maximum absolute error for gaussian approximations '
                           'when using the fast adaptive broadening method'))
                 section.add_argument(
-                    '--adaptive-scale', type=float, default=None,
+                    '--adaptive-scale', type=float, default=1.0,
                     dest='adaptive_scale',
                     help='Scale factor applied to adaptive broadening width',
                     )

--- a/euphonic/cli/utils/_cli_parser.py
+++ b/euphonic/cli/utils/_cli_parser.py
@@ -1,4 +1,5 @@
 from argparse import (
+    Action,
     ArgumentDefaultsHelpFormatter,
     ArgumentParser,
     _ArgumentGroup,
@@ -9,6 +10,14 @@ from euphonic.util import (
     dedent_and_fill,
     format_error,
 )
+
+
+class InstrumentBroadening(Action):
+    """Custom action for --instrument-broadening alias"""
+
+    def __call__(self, parser, namespace, values, option_string=None):
+        print("Deprecated alias for --energy-broadening.")
+        setattr(namespace, self.dest, values)
 
 
 def _get_cli_parser(features: Collection[str] = {},  # noqa: C901
@@ -267,7 +276,7 @@ def _get_cli_parser(features: Collection[str] = {},  # noqa: C901
             section.add_argument('--ebins', type=int, default=200,
                                  help='Number of energy bins')
 
-            ib_help = (
+            eb_help = (
                 'The FWHM of broadening on energy axis in ENERGY_UNIT (no '
                 'broadening if unspecified). If multiple values are provided, '
                 'these will be interpreted as polynomial coefficients to be '
@@ -298,16 +307,15 @@ def _get_cli_parser(features: Collection[str] = {},  # noqa: C901
                     help='Scale factor applied to adaptive broadening width',
                     )
                 section.add_argument(
-                    '--instrument-broadening', type=float, nargs='+',
-                    default=None, dest='inst_broadening', help=ib_help)
+                    '--instrument-broadening',
+                    type=float,
+                    nargs='+',
+                    default=None,
+                    dest='energy_broadening',
+                    action=InstrumentBroadening,
+                    help=('Deprecated: use --energy-broadening.'),
+                )
 
-                eb_help = (
-                    'If using adaptive broadening and a single (i.e. scalar) '
-                    'value is provided, this is an alias for --adaptive-scale.'
-                    ' Otherwise, this is an alias for --instrument-broadening.'
-                    )
-            else:
-                eb_help = ib_help
             section.add_argument(
                 '--energy-broadening', '--eb', type=float, default=None,
                 nargs='+', dest='energy_broadening', help=eb_help)

--- a/euphonic/cli/utils/_cli_parser.py
+++ b/euphonic/cli/utils/_cli_parser.py
@@ -2,6 +2,7 @@ from argparse import (
     Action,
     ArgumentDefaultsHelpFormatter,
     ArgumentParser,
+    SUPPRESS,
     _ArgumentGroup,
 )
 from collections.abc import Collection
@@ -16,7 +17,9 @@ class InstrumentBroadening(Action):
     """Custom action for --instrument-broadening alias"""
 
     def __call__(self, parser, namespace, values, option_string=None):
-        print("Deprecated alias for --energy-broadening.")
+        print('Using --instrument-broadening: this is a deprecated alias '
+              'for --energy-broadening.')
+
         setattr(namespace, self.dest, values)
 
 
@@ -275,6 +278,7 @@ def _get_cli_parser(features: Collection[str] = {},  # noqa: C901
                              type=str, default='meV', help='Energy units')
 
     if {'ebins', 'adaptive-broadening'}.intersection(features):
+
         if 'ebins' in features:
             section = sections['energy']
             section.add_argument('--ebins', type=int, default=200,
@@ -287,6 +291,16 @@ def _get_cli_parser(features: Collection[str] = {},  # noqa: C901
                 'evaluated in ENERGY_UNIT base, e.g. --energy-broadening'
                 ' 1. 0.01 1e-6 --energy-unit meV will apply FWHM of '
                 '(1. + 0.01 (energy / meV) + 1e-6 (energy / meV)^2) meV.')
+
+            eb_group = section.add_mutually_exclusive_group()
+            eb_group.add_argument(
+                '--energy-broadening', '--eb', type=float, default=None,
+                nargs='+', dest='energy_broadening', help=eb_help)
+
+            section.add_argument(
+                '--shape', type=str, nargs='?', default='gauss',
+                choices=('gauss', 'lorentz'),
+                help='The broadening shape')
 
             if 'adaptive-broadening' in features:
                 section.add_argument(
@@ -310,24 +324,16 @@ def _get_cli_parser(features: Collection[str] = {},  # noqa: C901
                     dest='adaptive_scale',
                     help='Scale factor applied to adaptive broadening width',
                     )
-                section.add_argument(
+                eb_group.add_argument(
                     '--instrument-broadening',
                     type=float,
                     nargs='+',
                     default=None,
                     dest='energy_broadening',
                     action=InstrumentBroadening,
-                    help=('Deprecated: use --energy-broadening.'),
+                    help=SUPPRESS,
                 )
 
-            section.add_argument(
-                '--energy-broadening', '--eb', type=float, default=None,
-                nargs='+', dest='energy_broadening', help=eb_help)
-
-            section.add_argument(
-                '--shape', type=str, nargs='?', default='gauss',
-                choices=('gauss', 'lorentz'),
-                help='The broadening shape')
         else:
             msg = format_error(
                 'Missing "ebins" argument.',

--- a/euphonic/cli/utils/_cli_parser.py
+++ b/euphonic/cli/utils/_cli_parser.py
@@ -55,6 +55,10 @@ def _get_cli_parser(features: Collection[str] = {},  # noqa: C901
         formatter_class=ArgumentDefaultsHelpFormatter,
         conflict_handler=conflict_handler)
 
+    # From 3.14 this improves feedback for mistyped commands.
+    # When lower versions are dropped, this can be included as __init__ param.
+    parser.suggest_on_error = True
+
     # Set up groups; these are only displayed if used, so simplest to
     # instantiate them all now and guarantee consistent order/presence
     # regardless of control logic

--- a/euphonic/cli/utils/_cli_parser.py
+++ b/euphonic/cli/utils/_cli_parser.py
@@ -15,6 +15,7 @@ from euphonic.util import (
 
 class InstrumentBroadening(Action):
     """Custom action for --instrument-broadening alias"""
+    # From Python 3.13 consider replacing with "deprecated" feature in argparse
 
     def __call__(
         self, parser, namespace, values, option_string=None,  # noqa: ARG002

--- a/euphonic/cli/utils/_cli_parser.py
+++ b/euphonic/cli/utils/_cli_parser.py
@@ -1,8 +1,8 @@
 from argparse import (
+    SUPPRESS,
     Action,
     ArgumentDefaultsHelpFormatter,
     ArgumentParser,
-    SUPPRESS,
     _ArgumentGroup,
 )
 from collections.abc import Collection
@@ -16,7 +16,9 @@ from euphonic.util import (
 class InstrumentBroadening(Action):
     """Custom action for --instrument-broadening alias"""
 
-    def __call__(self, parser, namespace, values, option_string=None):
+    def __call__(
+        self, parser, namespace, values, option_string=None,  # noqa: ARG002
+    ):
         print('Using --instrument-broadening: this is a deprecated alias '
               'for --energy-broadening.')
 

--- a/tests_and_analysis/test/data/script_data/dos.json
+++ b/tests_and_analysis/test/data/script_data/dos.json
@@ -3772,7 +3772,7 @@
         ],
         "y_label": []
     },
-    "quartz quartz.castep_bin --grid 5 5 4 --adaptive --eb 2": {
+    "quartz quartz.castep_bin --grid 5 5 4 --adaptive --adaptive-scale 2": {
         "x_ticklabels": [
             [
                 "0",

--- a/tests_and_analysis/test/script_tests/test_dos.py
+++ b/tests_and_analysis/test/script_tests/test_dos.py
@@ -146,25 +146,15 @@ class TestRegression:
         with pytest.raises(ValueError):
             _get_pdos_weighting('coherentdos')
 
-    def test_adaptive_scale_twice_raises_valueerror(self, inject_mocks):
-        with pytest.raises(ValueError,
-                           match='Adaptive scale factor was specified twice'):
-            euphonic.cli.dos.main([
-                quartz_fc_file,
-                '--energy-broadening=1',
-                '--adaptive',
-                '--adaptive-scale=2.',
-            ])
-
-    def test_broadening_twice_raises_valueerror(self, inject_mocks):
-        with pytest.raises(ValueError,
-                           match='Broadening width was specified twice'):
+    def test_broadening_twice_exit_error(self, inject_mocks, capsys):
+        with pytest.raises(SystemExit):
             euphonic.cli.dos.main([
                 quartz_fc_file,
                 '--energy-broadening=1',
                 '--instrument-broadening=2',
             ])
-
+        out, err = capsys.readouterr()
+        assert 'not allowed with argument' in err
 
 @patch('matplotlib.pyplot.show')
 @pytest.mark.skip(reason='Only run if you want to regenerate the test data')

--- a/tests_and_analysis/test/script_tests/test_dos.py
+++ b/tests_and_analysis/test/script_tests/test_dos.py
@@ -53,7 +53,7 @@ dos_params = [
     [quartz_fc_file, '--grid', '5', '5', '4'],
     [quartz_fc_file, '--grid', '5', '5', '4', '--adaptive', '--pdos'],
     [quartz_fc_file, '--grid', '5', '5', '4', '--adaptive'],
-    [quartz_fc_file, '--grid', '5', '5', '4', '--adaptive', '--eb', '2'],
+    [quartz_fc_file, '--grid', '5', '5', '4', '--adaptive', '--adaptive-scale', '2'],
     [quartz_fc_file, '--grid', '5', '5', '4', '--adaptive',
      '--adaptive-method=fast'],
     [quartz_fc_file, '--grid', '5', '5', '4', '--adaptive',


### PR DESCRIPTION
Closes #249 

We can actually hide this from argparse --help, while still avoiding immediate script breakage. The parameter will be removed entirely in v3 (#250)