### PR TITLE
Skip publish-coverage from external forks

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -108,6 +108,7 @@ jobs:
   publish-coverage:
     needs: test
     runs-on: ubuntu-latest
+    if: github.event.pull_request.head.repo.full_name == github.repository
     steps:
       - name: Download Artifacts
         uses: actions/download-artifact@v4


### PR DESCRIPTION
This limitation is ultimately there for good security reasons. Let's accept it for now... We can still look in the test run outputs.