### PR TITLE
Update docs versions

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -77,7 +77,7 @@ jobs:
         shell: bash -l {0}
         run: |
           python -m pip install --upgrade pip
-          python -m pip install --group ci --group docs
+          python -m pip install --group ci --group docs --group test
           python -m pip install .[matplotlib,phonopy-reader,brille]
       - name: Run Sphinx doctests
         working-directory: ./doc

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,9 @@
     This decouples them from the actual package and changes their installation process
     from e.g. `pip install .[test]` to `pip install --group test`.
 
+  - Update docs dependencies and drop ``sphinx_autodoc_typehints`` in favour of
+    native ``sphinx>8`` type-hint processing.
+
   - Explicitly include typing-extensions dependency.
 
 - Maintenance

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -27,9 +27,9 @@ extensions = [
         'sphinx.ext.autodoc',
         'sphinx.ext.napoleon',
         'sphinxarg.ext',
-        'sphinx_autodoc_typehints',
         'sphinx.ext.doctest'
 ]
+
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
@@ -56,6 +56,7 @@ html_static_path = ['_static']
 
 # Autodoc settings
 autodoc_member_order = 'bysource'
+autodoc_typehints = 'description'
 add_module_names = False
 
 # Napoleon docstring style settings

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,8 @@ dependencies = [
     "toolz>=0.12.1",
     "typing_extensions~=4.0"
 ]
-dynamic = ["version"]
+#dynamic = ["version"]
+version = "2.20.0"
 
 [project.urls]
 Homepage = "https://github.com/pace-neutrons/Euphonic"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,8 +44,7 @@ dependencies = [
     "toolz>=0.12.1",
     "typing_extensions~=4.0"
 ]
-#dynamic = ["version"]
-version = "2.20.0"
+dynamic = ["version"]
 
 [project.urls]
 Homepage = "https://github.com/pace-neutrons/Euphonic"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,14 +69,12 @@ min_reqs = [
 test = ["mock", "pytest>=9.0.3,<10.0", "pytest-cov", "pytest-mock", "pytest-lazy-fixtures", "pytest-xdist", "pytest-xvfb", "python-slugify"]
 ci = ["tox==4.30.3"]
 docs = [
-    "numpy==2.2.6",
-    "pytest==9.0.3",
-    "setuptools==78.1.1",
-    "sphinx~=5.3.0",
-    "sphinx-autodoc-typehints==1.19.5",
-    "sphinx-argparse==0.3.2",
-    "sphinx-rtd-theme==1.1.1",
-    "wheel==0.46.2",
+ "numpy==2.2.6",
+ "setuptools==82.0.1",
+ "sphinx~=8.1.0",
+ "sphinx-argparse==0.5.2",
+ "sphinx-rtd-theme==3.1.0",
+ "wheel==0.47.0",
 ]
 dev = [
     {include-group = "test"},


### PR DESCRIPTION
- Update sphinx to last 3.10 compatible and docs deps respectively
- Drop `sphinx_autodoc_typehints` in favour of sphinx native type-hint processing

Fixes #496 

Blocked by #497 