### PR TITLE
Remove Spectrum.copy() and implement shallower Spectrum.__copy__

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -48,6 +48,11 @@
   - ``validate._check_constructor_inputs`` reworked to use a sequence
     of ``validate.InputCheck``  ``NamedTuple`` classes as arguments.
 
+  - The ``.copy()`` method has been removed from Spectrum classes; use
+    ``copy.copy()`` or ``copy.deepcopy()`` from the standard library instead.
+    Note that ``copy.deepcopy()`` is closer to the legacy behaviour and carries
+    much less risk of unintended side-effects.
+
 - Features
 
   - Spectrum1DCollection and Spectrum2DCollection can be indexed with

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -55,6 +55,9 @@
 
 - Features
 
+  - Spectrum classes now implement ``__eq__`` and can be compared with
+    ``==``.
+
   - Spectrum1DCollection and Spectrum2DCollection can be indexed with
     slices where the stop value exceeds the collection
     length. (e.g. if a collection of 5 spectra is indexed with [3:10]

--- a/euphonic/spectra/base.py
+++ b/euphonic/spectra/base.py
@@ -636,8 +636,8 @@ class Spectrum1D(Spectrum):
 
     def __deepcopy__(self, memo: dict) -> Self:
         """Get a completely independent copy of spectrum"""
-        return type(self)(np.copy(self.x_data),
-                          np.copy(self.y_data),
+        return type(self)(self.x_data,
+                          self.y_data,
                           x_tick_labels=copy.deepcopy(
                               self.x_tick_labels, memo),
                           metadata=copy.deepcopy(self.metadata, memo))
@@ -1022,8 +1022,8 @@ class Spectrum2D(Spectrum):
                 width_convention=width_convention)
 
             spectrum = Spectrum2D(
-                np.copy(self.x_data),
-                np.copy(self.y_data),
+                self.x_data,
+                self.y_data,
                 ureg.Quantity(z_broadened, units=self.z_data_unit),
                 copy.copy(self.x_tick_labels),
                 copy.deepcopy(self.metadata),
@@ -1092,11 +1092,11 @@ class Spectrum2D(Spectrum):
         if axis == 'x':
             z_broadened = z_broadened.T
 
-        return Spectrum2D(np.copy(spectrum.x_data),
-                          np.copy(spectrum.y_data),
+        return Spectrum2D(spectrum.x_data,
+                          spectrum.y_data,
                           z_broadened,
-                          copy.copy(spectrum.x_tick_labels),
-                          copy.copy(spectrum.metadata))
+                          copy.deepcopy(spectrum.x_tick_labels),
+                          copy.deepcopy(spectrum.metadata))
 
     def __copy__(self) -> Self:
         """Get a shallow copy of spectrum
@@ -1116,9 +1116,9 @@ class Spectrum2D(Spectrum):
 
     def __deepcopy__(self, memo: dict) -> Self:
         """Get an fully-independent copy of spectrum"""
-        return type(self)(np.copy(self.x_data),
-                          np.copy(self.y_data),
-                          np.copy(self.z_data),
+        return type(self)(self.x_data,
+                          self.y_data,
+                          self.z_data,
                           copy.deepcopy(self.x_tick_labels, memo),
                           copy.deepcopy(self.metadata, memo))
 

--- a/euphonic/spectra/base.py
+++ b/euphonic/spectra/base.py
@@ -96,7 +96,7 @@ class Spectrum(ABC):
 
     def __mul__(self, other: Real) -> Self:
         """Get a new spectrum with scaled data"""
-        new_spec = self.copy()
+        new_spec = copy.deepcopy(self)
         new_spec *= other
         return new_spec
 
@@ -629,10 +629,14 @@ class Spectrum1D(Spectrum):
         Note that this is a a 'shallow' copy with the same underlying data:
         if you intend to mutate them, deepcopy is a better choice.
         """
-        return type(self)(self.x_data,
-                          self.y_data,
-                          x_tick_labels=copy.copy(self.x_tick_labels),
-                          metadata=copy.copy(self.metadata))
+        new = self.__new__(type(self))
+        for attr in ('_x_data', '_internal_x_data_unit', 'x_data_unit',
+                     '_y_data', '_internal_y_data_unit', 'y_data_unit',
+                     '_x_tick_labels', 'metadata',
+                     ):
+            setattr(new, attr, getattr(self, attr))
+
+        return new
 
     def __deepcopy__(self, memo: dict) -> Self:
         """Get a completely independent copy of spectrum"""
@@ -826,7 +830,7 @@ class Spectrum1D(Spectrum):
             msg = 'x_width must be a Quantity or Callable'
             raise TypeError(msg)
 
-        new_spectrum = self.copy()
+        new_spectrum = copy.deepcopy(self)
         new_spectrum.y_data = y_broadened
         return new_spectrum
 
@@ -1104,11 +1108,15 @@ class Spectrum2D(Spectrum):
         Note that this is a a 'shallow' copy with the same underlying data:
         if you intend to mutate them, deepcopy is a better choice.
         """
-        return type(self)(self.x_data,
-                          self.y_data,
-                          self.z_data,
-                          copy.copy(self.x_tick_labels),
-                          copy.copy(self.metadata))
+        new = self.__new__(type(self))
+        for attr in ('_x_data', '_internal_x_data_unit', 'x_data_unit',
+                     '_y_data', '_internal_y_data_unit', 'y_data_unit',
+                     '_z_data', '_internal_z_data_unit', 'z_data_unit',
+                     '_x_tick_labels', 'metadata',
+                     ):
+            setattr(new, attr, getattr(self, attr))
+
+        return new
 
     def __deepcopy__(self, memo: dict) -> Self:
         """Get an fully-independent copy of spectrum"""

--- a/euphonic/spectra/base.py
+++ b/euphonic/spectra/base.py
@@ -108,10 +108,6 @@ class Spectrum(ABC):
     def __deepcopy__(self, memo: dict) -> Self:
         """Get a completely independent copy of spectrum."""
 
-    def copy(self) -> Self:
-        """Get an independent copy of spectrum."""
-        return self.__copy__()
-
     @property
     def x_tick_labels(self) -> XTickLabels:
         """x-axis tick labels (e.g. high-symmetry point locations)"""
@@ -1393,7 +1389,7 @@ def apply_kinematic_constraints(spectrum: Spectrum2D,
                          (spectrum.get_bin_edges(bin_ax='x')[:-1, np.newaxis]
                           > q_bounds[-1][np.newaxis, :]))
 
-    new_spectrum = spectrum.copy()
+    new_spectrum = copy.deepcopy(spectrum)
     new_spectrum._z_data[mask] = float('nan')
 
     return new_spectrum

--- a/euphonic/spectra/base.py
+++ b/euphonic/spectra/base.py
@@ -624,11 +624,15 @@ class Spectrum1D(Spectrum):
                 for x0, x1 in ranges]
 
     def __copy__(self) -> Self:
-        """Get an independent copy of spectrum"""
-        return type(self)(np.copy(self.x_data),
-                          np.copy(self.y_data),
+        """Get a shallow copy of spectrum
+
+        Note that this is a a 'shallow' copy with the same underlying data:
+        if you intend to mutate them, deepcopy is a better choice.
+        """
+        return type(self)(self.x_data,
+                          self.y_data,
                           x_tick_labels=copy.copy(self.x_tick_labels),
-                          metadata=copy.deepcopy(self.metadata))
+                          metadata=copy.copy(self.metadata))
 
     def __deepcopy__(self, memo: dict) -> Self:
         """Get a completely independent copy of spectrum"""
@@ -1095,15 +1099,19 @@ class Spectrum2D(Spectrum):
                           copy.copy(spectrum.metadata))
 
     def __copy__(self) -> Self:
-        """Get an independent copy of spectrum"""
-        return type(self)(np.copy(self.x_data),
-                          np.copy(self.y_data),
-                          np.copy(self.z_data),
+        """Get a shallow copy of spectrum
+
+        Note that this is a a 'shallow' copy with the same underlying data:
+        if you intend to mutate them, deepcopy is a better choice.
+        """
+        return type(self)(self.x_data,
+                          self.y_data,
+                          self.z_data,
                           copy.copy(self.x_tick_labels),
-                          copy.deepcopy(self.metadata))
+                          copy.copy(self.metadata))
 
     def __deepcopy__(self, memo: dict) -> Self:
-        """Get an independent copy of spectrum"""
+        """Get an fully-independent copy of spectrum"""
         return type(self)(np.copy(self.x_data),
                           np.copy(self.y_data),
                           np.copy(self.z_data),

--- a/euphonic/spectra/base.py
+++ b/euphonic/spectra/base.py
@@ -1115,7 +1115,7 @@ class Spectrum2D(Spectrum):
         return new
 
     def __deepcopy__(self, memo: dict) -> Self:
-        """Get an fully-independent copy of spectrum"""
+        """Get a completely independent copy of spectrum"""
         return type(self)(self.x_data,
                           self.y_data,
                           self.z_data,

--- a/euphonic/spectra/base.py
+++ b/euphonic/spectra/base.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from types import NoneType
 from typing import (
     Any,
+    ClassVar,
     Literal,
     overload,
 )
@@ -100,13 +101,43 @@ class Spectrum(ABC):
         new_spec *= other
         return new_spec
 
+    @property
     @abstractmethod
+    def _core_attrs(self) -> set[str]:
+        """Attribute names of underlying data; used for __copy__ and __eq__"""
+
     def __copy__(self) -> Self:
-        """Get an independent copy of spectrum."""
+        """Get a shallow copy of spectrum
+
+        Note that this is a a 'shallow' copy with the same underlying data:
+        if you intend to mutate them, deepcopy is a better choice.
+        """
+        new = self.__new__(type(self))
+        for attr in self._core_attrs:
+            setattr(new, attr, getattr(self, attr))
+
+        return new
 
     @abstractmethod
     def __deepcopy__(self, memo: dict) -> Self:
         """Get a completely independent copy of spectrum."""
+
+    @staticmethod
+    def _eq(own_value: Any, other_value: Any) -> bool:
+        """Equality check for individual attribute"""
+        if isinstance(own_value, np.ndarray):
+            return np.array_equal(own_value, other_value)
+        return own_value == other_value
+
+    def __eq__(self, other: Any) -> bool:
+        if not isinstance(other, type(self)):
+            return False
+        if self._core_attrs != other._core_attrs:
+            return False
+        return all(
+            self._eq(getattr(self, attr), getattr(other, attr))
+            for attr in self._core_attrs
+        )
 
     @property
     def x_tick_labels(self) -> XTickLabels:
@@ -554,6 +585,11 @@ class Spectrum1D(Spectrum):
 
           - 'label' : str. This is used label lines on a 1D plot
     """
+    _core_attrs: ClassVar[set[str]] = {
+        '_x_data', '_internal_x_data_unit', 'x_data_unit',
+        '_y_data', '_internal_y_data_unit', 'y_data_unit',
+        '_x_tick_labels', 'metadata',
+    }
 
     def __init__(self, x_data: Quantity, y_data: Quantity,
                  x_tick_labels: XTickLabels | None = None,
@@ -618,21 +654,6 @@ class Spectrum1D(Spectrum):
                                                            x0, x1),
                            metadata=self.metadata)
                 for x0, x1 in ranges]
-
-    def __copy__(self) -> Self:
-        """Get a shallow copy of spectrum
-
-        Note that this is a a 'shallow' copy with the same underlying data:
-        if you intend to mutate them, deepcopy is a better choice.
-        """
-        new = self.__new__(type(self))
-        for attr in ('_x_data', '_internal_x_data_unit', 'x_data_unit',
-                     '_y_data', '_internal_y_data_unit', 'y_data_unit',
-                     '_x_tick_labels', 'metadata',
-                     ):
-            setattr(new, attr, getattr(self, attr))
-
-        return new
 
     def __deepcopy__(self, memo: dict) -> Self:
         """Get a completely independent copy of spectrum"""
@@ -856,6 +877,12 @@ class Spectrum2D(Spectrum):
         spectrum. Keys should be strings and values should be strings
         or integers
     """
+    _core_attrs: ClassVar[set[str]] = {
+        '_x_data', '_internal_x_data_unit', 'x_data_unit',
+        '_y_data', '_internal_y_data_unit', 'y_data_unit',
+        '_z_data', '_internal_z_data_unit', 'z_data_unit',
+        '_x_tick_labels', 'metadata',
+    }
 
     def __init__(self, x_data: Quantity, y_data: Quantity,
                  z_data: Quantity,
@@ -1097,22 +1124,6 @@ class Spectrum2D(Spectrum):
                           z_broadened,
                           copy.deepcopy(spectrum.x_tick_labels),
                           copy.deepcopy(spectrum.metadata))
-
-    def __copy__(self) -> Self:
-        """Get a shallow copy of spectrum
-
-        Note that this is a a 'shallow' copy with the same underlying data:
-        if you intend to mutate them, deepcopy is a better choice.
-        """
-        new = self.__new__(type(self))
-        for attr in ('_x_data', '_internal_x_data_unit', 'x_data_unit',
-                     '_y_data', '_internal_y_data_unit', 'y_data_unit',
-                     '_z_data', '_internal_z_data_unit', 'z_data_unit',
-                     '_x_tick_labels', 'metadata',
-                     ):
-            setattr(new, attr, getattr(self, attr))
-
-        return new
 
     def __deepcopy__(self, memo: dict) -> Self:
         """Get a completely independent copy of spectrum"""

--- a/euphonic/spectra/collections.py
+++ b/euphonic/spectra/collections.py
@@ -266,7 +266,7 @@ class SpectrumCollectionMixin(ABC, Generic[Spec]):
         return self._combine_metadata([metadata_lines[i] for i in item])
 
     def __copy__(self) -> Self:
-        # Borrow implementation from child tyoe: the data fields are the same
+        # Borrow implementation from child type: the data fields are the same
         return self._item_type.__copy__(self)
 
     def __deepcopy__(self, memo: dict) -> Self:

--- a/euphonic/spectra/collections.py
+++ b/euphonic/spectra/collections.py
@@ -266,15 +266,12 @@ class SpectrumCollectionMixin(ABC, Generic[Spec]):
         return self._combine_metadata([metadata_lines[i] for i in item])
 
     def __copy__(self) -> Self:
-        return type(self).from_spectra(list(self), unsafe=True)
+        # Borrow implementation from child tyoe: the data fields are the same
+        return self._item_type.__copy__(self)
 
     def __deepcopy__(self, memo: dict) -> Self:
         return type(self).from_spectra([copy.deepcopy(spectrum, memo)
                                         for spectrum in self], unsafe=True)
-
-    def copy(self) -> Self:
-        """Get an independent copy of spectrum"""
-        return self.__copy__()
 
     def __add__(self, other: Self) -> Self:
         """
@@ -822,7 +819,7 @@ class Spectrum1DCollection(SpectrumCollectionMixin[Spectrum1D],
                     yi, x_centres, x_width_calc, shape=shape,
                     method=method, width_convention=width_convention)
 
-            new_spectrum = self.copy()
+            new_spectrum = copy.deepcopy(self)
             new_spectrum.y_data = ureg.Quantity(
                 y_broadened, units=self.y_data_unit)
             return new_spectrum

--- a/euphonic/spectra/collections.py
+++ b/euphonic/spectra/collections.py
@@ -77,9 +77,17 @@ class SpectrumCollectionMixin(ABC, Generic[Spec]):
     _bin_axes = ('x',)
     _spectrum_axis = 'y'
     _item_type: type[Spec]
-    metadata: Metadata
 
     # Define some private methods which wrap this information into useful forms
+    @property
+    def _core_attrs(self):
+        """Additional items are implemented as an extra axis on spectrum array:
+
+        this means current implementations have the same _core_attrs as the
+        spectrum type they contain.
+        """
+        return self._item_type._core_attrs
+
     @classmethod
     def _spectrum_data_name(cls) -> str:
         return f'{cls._spectrum_axis}_data'
@@ -264,10 +272,6 @@ class SpectrumCollectionMixin(ABC, Generic[Spec]):
             return self._combine_metadata(metadata_lines[item])
         # Item must be some kind of integer sequence
         return self._combine_metadata([metadata_lines[i] for i in item])
-
-    def __copy__(self) -> Self:
-        # Borrow implementation from child type: the data fields are the same
-        return self._item_type.__copy__(self)
 
     def __deepcopy__(self, memo: dict) -> Self:
         return type(self).from_spectra([copy.deepcopy(spectrum, memo)

--- a/tests_and_analysis/test/euphonic_test/test_spectrum1d.py
+++ b/tests_and_analysis/test/euphonic_test/test_spectrum1d.py
@@ -1,3 +1,4 @@
+import copy
 import json
 
 import numpy as np
@@ -574,31 +575,56 @@ class TestSpectrum1DMethods:
             check_spectrum1d(spec, spec * 2.)
 
     def test_copy(self):
+        """Check copy.copy() (i.e. spectrum.__copy__()) """
         spec = get_spectrum1d('xsq_spectrum1d.json')
 
-        spec_copy = spec.copy()
+        spec_copy = copy.copy(spec)
         # Copy should be same
         check_spectrum1d(spec, spec_copy)
 
-        # Until data is edited
+        # Even after data is edited
         spec_copy._y_data *= 2
-        with pytest.raises(AssertionError):
-            check_spectrum1d(spec, spec_copy)
+        check_spectrum1d(spec, spec_copy)
 
-        spec_copy = spec.copy()
+        spec_copy = copy.copy(spec)
         spec_copy._x_data *= 2
-        with pytest.raises(AssertionError):
-            check_spectrum1d(spec, spec_copy)
+        check_spectrum1d(spec, spec_copy)
 
-        spec_copy = spec.copy()
-        spec_copy.x_tick_labels = [(1, 'different')]
-        with pytest.raises(AssertionError):
-            check_spectrum1d(spec, spec_copy)
+        spec_copy = copy.copy(spec)
+        spec_copy.x_tick_labels[0] = (1, 'different')
+        check_spectrum1d(spec, spec_copy)
 
-        spec_copy = spec.copy()
+        spec_copy = copy.copy(spec)
         spec_copy.metadata['Test'] = spec_copy.metadata['Test'].upper()
+        check_spectrum1d(spec, spec_copy)
+
+    def test_deepcopy(self):
+        """Check copy.deepcopy() (i.e. spectrum.__deepcopy__())"""
+        spec = get_spectrum1d('xsq_spectrum1d.json')
+
+        spec_deepcopy = copy.deepcopy(spec)
+        # Deepcopy should be same
+        check_spectrum1d(spec, spec_deepcopy)
+
+        # Until data is edited
+        spec_deepcopy._y_data *= 2
         with pytest.raises(AssertionError):
-            check_spectrum1d(spec, spec_copy)
+            check_spectrum1d(spec, spec_deepcopy)
+
+        spec_deepcopy = copy.deepcopy(spec)
+        spec_deepcopy._x_data *= 2
+        with pytest.raises(AssertionError):
+            check_spectrum1d(spec, spec_deepcopy)
+
+        spec_deepcopy = copy.deepcopy(spec)
+        spec_deepcopy.x_tick_labels[0] = (1, 'different')
+        with pytest.raises(AssertionError):
+            check_spectrum1d(spec, spec_deepcopy)
+
+        spec_deepcopy = copy.deepcopy(spec)
+        spec_deepcopy.metadata['Test'] = spec_deepcopy.metadata['Test'].upper()
+        with pytest.raises(AssertionError):
+            check_spectrum1d(spec, spec_deepcopy)
 
 class TestBasePrivateFunctions:
     def test_distribution_1d_error(self):

--- a/tests_and_analysis/test/euphonic_test/test_spectrum1d.py
+++ b/tests_and_analysis/test/euphonic_test/test_spectrum1d.py
@@ -574,6 +574,19 @@ class TestSpectrum1DMethods:
         with pytest.raises(AssertionError):
             check_spectrum1d(spec, spec * 2.)
 
+    def test_compare_equal(self):
+        spec1 = get_spectrum1d('xsq_spectrum1d.json')
+        spec2 = get_spectrum1d('xsq_spectrum1d.json')
+
+        assert spec1 == spec2
+
+        spec1.x_data *= 2
+        assert spec1 != spec2
+
+        spec1 = get_spectrum1d('xsq_spectrum1d.json')
+        spec2.metadata = {'different': 'metadata'}
+        assert spec1 != spec2
+
     def test_copy(self):
         """Check copy.copy() (i.e. spectrum.__copy__()) """
         spec = get_spectrum1d('xsq_spectrum1d.json')

--- a/tests_and_analysis/test/euphonic_test/test_spectrum1dcollection.py
+++ b/tests_and_analysis/test/euphonic_test/test_spectrum1dcollection.py
@@ -798,3 +798,16 @@ class TestSpectrum1DCollectionMethods:
         spec_deepcopy.metadata['Test'] = spec_deepcopy.metadata['Test'].upper()
         with pytest.raises(AssertionError):
             check_spectrum1dcollection(spec, spec_deepcopy)
+
+    def test_compare_equal(self):
+        spec1 = get_spectrum1dcollection('gan_bands.json')
+        spec2 = get_spectrum1dcollection('gan_bands.json')
+
+        assert spec1 == spec2
+
+        spec1.y_data *= 2
+        assert spec1 != spec2
+
+        spec1 = get_spectrum1dcollection('gan_bands.json')
+        spec2.metadata = {'different': 'metadata'}
+        assert spec1 != spec2

--- a/tests_and_analysis/test/euphonic_test/test_spectrum1dcollection.py
+++ b/tests_and_analysis/test/euphonic_test/test_spectrum1dcollection.py
@@ -1,3 +1,4 @@
+import copy
 import json
 
 import numpy as np
@@ -750,26 +751,50 @@ class TestSpectrum1DCollectionMethods:
         spec = get_spectrum1dcollection('gan_bands.json')
         spec.metadata = {'Test': 'item', 'int': 1}
 
-        spec_copy = spec.copy()
+        spec_copy = copy.copy(spec)
         # Copy should be same
         check_spectrum1dcollection(spec, spec_copy)
 
-        # Until data is edited
-        spec_copy._y_data *= 2
-        with pytest.raises(AssertionError):
-            check_spectrum1dcollection(spec, spec_copy)
+        # Even after data is mutated in-place
+        spec_copy._y_data[:] *= 2
+        check_spectrum1dcollection(spec, spec_copy)
 
-        spec_copy = spec.copy()
-        spec_copy._x_data *= 2
-        with pytest.raises(AssertionError):
-            check_spectrum1dcollection(spec, spec_copy)
+        spec_copy = copy.copy(spec)
+        spec_copy._x_data[:] *= 2
+        check_spectrum1dcollection(spec, spec_copy)
 
-        spec_copy = spec.copy()
-        spec_copy.x_tick_labels = [(1, 'different')]
-        with pytest.raises(AssertionError):
-            check_spectrum1dcollection(spec, spec_copy)
+        spec_copy = copy.copy(spec)
+        spec_copy.x_tick_labels[0] = (1, 'different')
+        check_spectrum1dcollection(spec, spec_copy)
 
-        spec_copy = spec.copy()
+        spec_copy = copy.copy(spec)
         spec_copy.metadata['Test'] = spec_copy.metadata['Test'].upper()
+        check_spectrum1dcollection(spec, spec_copy)
+
+    def test_deepcopy(self):
+        spec = get_spectrum1dcollection('gan_bands.json')
+        spec.metadata = {'Test': 'item', 'int': 1}
+
+        spec_deepcopy = copy.deepcopy(spec)
+        # Copy should be same
+        check_spectrum1dcollection(spec, spec_deepcopy)
+
+        # Until data is edited
+        spec_deepcopy._y_data[:] *= 2
         with pytest.raises(AssertionError):
-            check_spectrum1dcollection(spec, spec_copy)
+            check_spectrum1dcollection(spec, spec_deepcopy)
+
+        spec_deepcopy = copy.deepcopy(spec)
+        spec_deepcopy._x_data[:] *= 2
+        with pytest.raises(AssertionError):
+            check_spectrum1dcollection(spec, spec_deepcopy)
+
+        spec_deepcopy = copy.deepcopy(spec)
+        spec_deepcopy.x_tick_labels = [(1, 'different')]
+        with pytest.raises(AssertionError):
+            check_spectrum1dcollection(spec, spec_deepcopy)
+
+        spec_deepcopy = copy.deepcopy(spec)
+        spec_deepcopy.metadata['Test'] = spec_deepcopy.metadata['Test'].upper()
+        with pytest.raises(AssertionError):
+            check_spectrum1dcollection(spec, spec_deepcopy)

--- a/tests_and_analysis/test/euphonic_test/test_spectrum2d.py
+++ b/tests_and_analysis/test/euphonic_test/test_spectrum2d.py
@@ -19,6 +19,8 @@ from tests_and_analysis.test.utils import (
     get_data_path,
 )
 
+from .test_spectrum1d import get_spectrum1d
+
 FLOAT64_EPS =  np.finfo(np.float64).eps
 
 class ExpectedSpectrum2D:
@@ -540,6 +542,10 @@ class TestSpectrum2DMethods:
         spec1 = get_spectrum2d('example_spectrum2d.json')
         spec2.metadata = {'different': 'metadata'}
         assert spec1 != spec2
+
+        spec_1d = get_spectrum1d('xsq_spectrum1d.json')
+        assert spec1 != spec_1d
+        assert spec_1d != spec1
 
     def test_copy(self):
         spec = get_spectrum2d('quartz_fuzzy_map_1.json')

--- a/tests_and_analysis/test/euphonic_test/test_spectrum2d.py
+++ b/tests_and_analysis/test/euphonic_test/test_spectrum2d.py
@@ -1,3 +1,4 @@
+import copy
 import json
 
 import numpy as np
@@ -530,7 +531,43 @@ class TestSpectrum2DMethods:
     def test_copy(self):
         spec = get_spectrum2d('example_spectrum2d.json')
 
-        spec_copy = spec.copy()
+        spec_copy = copy.copy(spec)
+        # Copy should be same
+        check_spectrum2d(spec, spec_copy)
+
+        # Even after data is edited in-place
+        for attr in 'x_data', 'y_data', 'z_data':
+            getattr(spec_copy, attr)[:] *= 2
+
+            check_spectrum2d(spec, spec_copy)
+
+            spec_copy = copy.copy(spec)
+
+        # But not if attr is replaced entirely
+        for attr in '_x_data', '_y_data', '_z_data':
+            setattr(spec_copy, attr, getattr(spec, attr) * 2)
+
+            with pytest.raises(AssertionError):
+                check_spectrum2d(spec, spec_copy)
+
+            spec_copy = copy.copy(spec)
+
+
+        # spec_copy = copy.deepcopy(spec)
+        # spec_copy.x_tick_labels = [(1, 'different')]
+        # with pytest.raises(AssertionError):
+        #     check_spectrum2d(spec, spec_copy)
+
+        # spec_copy = copy.deepcopy(spec)
+        # spec_copy.metadata['description'] = \
+        #     spec_copy.metadata['description'].upper()
+        # with pytest.raises(AssertionError):
+        #     check_spectrum2d(spec, spec_copy)
+
+    def test_deepcopy(self):
+        spec = get_spectrum2d('example_spectrum2d.json')
+
+        spec_copy = copy.deepcopy(spec)
         # Copy should be same
         check_spectrum2d(spec, spec_copy)
 
@@ -541,14 +578,14 @@ class TestSpectrum2DMethods:
             with pytest.raises(AssertionError):
                 check_spectrum2d(spec, spec_copy)
 
-            spec_copy = spec.copy()
+            spec_copy = copy.deepcopy(spec)
 
-        spec_copy = spec.copy()
+        spec_copy = copy.deepcopy(spec)
         spec_copy.x_tick_labels = [(1, 'different')]
         with pytest.raises(AssertionError):
             check_spectrum2d(spec, spec_copy)
 
-        spec_copy = spec.copy()
+        spec_copy = copy.deepcopy(spec)
         spec_copy.metadata['description'] = \
             spec_copy.metadata['description'].upper()
         with pytest.raises(AssertionError):

--- a/tests_and_analysis/test/euphonic_test/test_spectrum2d.py
+++ b/tests_and_analysis/test/euphonic_test/test_spectrum2d.py
@@ -528,6 +528,19 @@ class TestSpectrum2DMethods:
         with pytest.raises(AssertionError):
             check_spectrum2d(spec, spec * 2.)
 
+    def test_compare_equal(self):
+        spec1 = get_spectrum2d('example_spectrum2d.json')
+        spec2 = get_spectrum2d('example_spectrum2d.json')
+
+        assert spec1 == spec2
+
+        spec1.z_data *= 2
+        assert spec1 != spec2
+
+        spec1 = get_spectrum2d('example_spectrum2d.json')
+        spec2.metadata = {'different': 'metadata'}
+        assert spec1 != spec2
+
     def test_copy(self):
         spec = get_spectrum2d('quartz_fuzzy_map_1.json')
         spec_copy = copy.copy(spec)

--- a/tests_and_analysis/test/euphonic_test/test_spectrum2d.py
+++ b/tests_and_analysis/test/euphonic_test/test_spectrum2d.py
@@ -529,9 +529,9 @@ class TestSpectrum2DMethods:
             check_spectrum2d(spec, spec * 2.)
 
     def test_copy(self):
-        spec = get_spectrum2d('example_spectrum2d.json')
-
+        spec = get_spectrum2d('quartz_fuzzy_map_1.json')
         spec_copy = copy.copy(spec)
+
         # Copy should be same
         check_spectrum2d(spec, spec_copy)
 
@@ -543,6 +543,15 @@ class TestSpectrum2DMethods:
 
             spec_copy = copy.copy(spec)
 
+        spec_copy = copy.copy(spec)
+        spec_copy.x_tick_labels[1] = (1, 'different')
+        check_spectrum2d(spec, spec_copy)
+
+        spec_copy = copy.copy(spec)
+        spec_copy.metadata['common'] = \
+            spec_copy.metadata['common'].upper()
+        check_spectrum2d(spec, spec_copy)
+
         # But not if attr is replaced entirely
         for attr in '_x_data', '_y_data', '_z_data':
             setattr(spec_copy, attr, getattr(spec, attr) * 2)
@@ -552,20 +561,17 @@ class TestSpectrum2DMethods:
 
             spec_copy = copy.copy(spec)
 
+        spec_copy.x_tick_labels = [(1, 'different')]
+        with pytest.raises(AssertionError):
+            check_spectrum2d(spec, spec_copy)
 
-        # spec_copy = copy.deepcopy(spec)
-        # spec_copy.x_tick_labels = [(1, 'different')]
-        # with pytest.raises(AssertionError):
-        #     check_spectrum2d(spec, spec_copy)
-
-        # spec_copy = copy.deepcopy(spec)
-        # spec_copy.metadata['description'] = \
-        #     spec_copy.metadata['description'].upper()
-        # with pytest.raises(AssertionError):
-        #     check_spectrum2d(spec, spec_copy)
+        spec_copy = copy.copy(spec)
+        spec_copy.metadata = {'new': 'metadata'}
+        with pytest.raises(AssertionError):
+            check_spectrum2d(spec, spec_copy)
 
     def test_deepcopy(self):
-        spec = get_spectrum2d('example_spectrum2d.json')
+        spec = get_spectrum2d('quartz_fuzzy_map_1.json')
 
         spec_copy = copy.deepcopy(spec)
         # Copy should be same
@@ -581,13 +587,13 @@ class TestSpectrum2DMethods:
             spec_copy = copy.deepcopy(spec)
 
         spec_copy = copy.deepcopy(spec)
-        spec_copy.x_tick_labels = [(1, 'different')]
+        spec_copy.x_tick_labels[1] = (1, 'different')
         with pytest.raises(AssertionError):
             check_spectrum2d(spec, spec_copy)
 
         spec_copy = copy.deepcopy(spec)
-        spec_copy.metadata['description'] = \
-            spec_copy.metadata['description'].upper()
+        spec_copy.metadata['common'] = \
+            spec_copy.metadata['common'].upper()
         with pytest.raises(AssertionError):
             check_spectrum2d(spec, spec_copy)
 

--- a/tests_and_analysis/test/euphonic_test/test_spectrum2dcollection.py
+++ b/tests_and_analysis/test/euphonic_test/test_spectrum2dcollection.py
@@ -2,6 +2,7 @@
 
 # Stop the linter from complaining when pytest fixtures are used idiomatically
 # pylint: disable=redefined-outer-name
+from copy import deepcopy
 
 import numpy as np
 import pytest
@@ -296,3 +297,16 @@ class TestSpectrum2DCollectionFunctionality:
         selection = quartz_fuzzy_collection.select(direction=2, common='yes')
         ref_item_2 = get_spectrum2d('quartz_fuzzy_map_2.json')
         check_spectrum2d(selection.sum(), ref_item_2)
+
+    def test_compare_equal(self, quartz_fuzzy_collection):
+        spec1 = deepcopy(quartz_fuzzy_collection)
+        spec2 = deepcopy(quartz_fuzzy_collection)
+
+        assert spec1 == spec2
+
+        spec1.z_data *= 2
+        assert spec1 != spec2
+
+        spec1 = deepcopy(quartz_fuzzy_collection)
+        spec2.metadata = {'different': 'metadata'}
+        assert spec1 != spec2


### PR DESCRIPTION
Closes #453 

Dropping copy() is a tidy-up but pretty marginal. The main benefit is to reduce confusion... but does it, when users may find shallow copies confusing in their own right?

It's not entirely clear how _useful_ the shallow copies are, but they should be cheap to build!
We hope to have immutable objects in v3, for which `copy()` and `deepcopy()` will be redundant and the general workflow will be to work with the original object or spawn a modified copy with `__replace__`.