### PR TITLE
Remove metadata class variable

### DIFF
--- a/euphonic/spectra/collections.py
+++ b/euphonic/spectra/collections.py
@@ -77,7 +77,6 @@ class SpectrumCollectionMixin(ABC, Generic[Spec]):
     _bin_axes = ('x',)
     _spectrum_axis = 'y'
     _item_type: type[Spec]
-    metadata: Metadata
 
     # Define some private methods which wrap this information into useful forms
     @property


### PR DESCRIPTION
Apologies for pushing this to release-2.0 by mistake, have reverted there.

I'm still a bit unsure about why this line is there and whether it is a problem.