### PR TITLE
Enable FBT ruff rule

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,16 +17,16 @@
 
 - API changes
 
-  - Public functions in ``euphonic.broadening``, ``euphonic.powder``,
-    ``euphonic.plot``, ``euphonic.sampling`` now use some mandatory keyword arguments
+  - Many public functions and methods now use keyword-only arguments
+    where previously these were permitted to be keyword *or* positional.
     - This will break code that depends on these arguments being in a
       specific order rather than calling them by name
     - The most "obvious" arguments can still be accessed by position
-      for concise "standard" function calls.
-
-  - Methods of ``QpointFrequencies``, ``QpointPhononModes`` and
-    ``ForceConstants`` now use mandatory keyword arguments for many
-    parameters.
+      for concise "standard" function calls; the goal is not to make
+      downstream code drastically more verbose.
+    - The purpose of this is to give more flexibility to add features
+      or alias arguments while deprecating/changing their behaviour,
+      without breaking the public API between major releases.
 
   - The various Spectrum classes have an ``assert_regular_bins``
     method. It is now forbidden to use positional arguments and in the

--- a/build_utils/release.py
+++ b/build_utils/release.py
@@ -19,10 +19,10 @@ def main():
 
     test = not args.notest
     if args.github:
-        release_github(test)
+        release_github(test=test)
 
 
-def release_github(test=True):
+def release_github(*, test=True):
     with open('CHANGELOG.rst', encoding='utf8') as f:
         changelog = f.read()
     with open('CITATION.cff', encoding='utf8') as f:

--- a/euphonic/cli/optimise_dipole_parameter.py
+++ b/euphonic/cli/optimise_dipole_parameter.py
@@ -33,6 +33,7 @@ def main(params: list[str] | None = None) -> None:
 
 def calculate_optimum_dipole_parameter(
         filename: Path | str,
+        *,
         dipole_parameter_min: float = 0.25,
         dipole_parameter_max: float = 1.5,
         dipole_parameter_step: float = 0.25,

--- a/euphonic/cli/utils/_band_structure.py
+++ b/euphonic/cli/utils/_band_structure.py
@@ -130,6 +130,7 @@ def _convert_labels_to_fractions(
 
 def _bands_from_force_constants(data: ForceConstants,
                                 q_distance: Quantity,
+                                *,
                                 insert_gamma: bool = True,
                                 frequencies_only: bool = False,
                                 **calc_modes_kwargs,

--- a/euphonic/cli/utils/_loaders.py
+++ b/euphonic/cli/utils/_loaders.py
@@ -17,6 +17,7 @@ from euphonic.util import (
 
 
 def _load_euphonic_json(filename: str | os.PathLike,
+                        *,
                         frequencies_only: bool = False,
 ) -> QpointPhononModes | QpointFrequencies | ForceConstants:
     with open(filename) as f:
@@ -40,6 +41,7 @@ def _load_euphonic_json(filename: str | os.PathLike,
 
 
 def _load_phonopy_file(filename: str | os.PathLike,
+                       *,
                        frequencies_only: bool = False,
 ) -> QpointPhononModes | QpointFrequencies | ForceConstants:
     path = Path(filename)
@@ -130,6 +132,7 @@ def _janus_fc_filename(phonopy_file: Path) -> Path:
 
 
 def load_data_from_file(filename: str | os.PathLike,
+                        *,
                         frequencies_only: bool = False,
                         verbose: bool = False,
 ) -> QpointPhononModes | QpointFrequencies | ForceConstants:
@@ -163,9 +166,9 @@ def load_data_from_file(filename: str | os.PathLike,
         case '.castep_bin' | '.check':
             data = ForceConstants.from_castep(path)
         case '.json':
-            data = _load_euphonic_json(path, frequencies_only)
+            data = _load_euphonic_json(path, frequencies_only=frequencies_only)
         case '.hdf5' | '.yaml' | '.yml':
-            data = _load_phonopy_file(path, frequencies_only)
+            data = _load_phonopy_file(path, frequencies_only=frequencies_only)
         case _:
             msg = format_error(
                  f'File format ({path.suffix}) not recognised.',

--- a/euphonic/force_constants.py
+++ b/euphonic/force_constants.py
@@ -447,20 +447,21 @@ class ForceConstants:
             return qpt_freqs, grads
         return qpt_freqs
 
+
     def _calculate_phonons_at_qpts(  # noqa: C901
             self,
             qpts: np.ndarray,
             weights: np.ndarray | None,
             asr: Literal['realspace', 'reciprocal'] | None,
-            dipole: bool,
+            dipole: bool,                # noqa: FBT001
             dipole_parameter: float,
-            splitting: bool,
-            insert_gamma: bool,
-            reduce_qpts: bool,
-            use_c: bool | None,
+            splitting: bool,             # noqa: FBT001
+            insert_gamma: bool,          # noqa: FBT001
+            reduce_qpts: bool,           # noqa: FBT001
+            use_c: bool | None,          # noqa: FBT001
             n_threads: int | None,
-            return_mode_gradients: bool,
-            return_eigenvectors: bool) -> tuple[
+            return_mode_gradients: bool, # noqa: FBT001
+            return_eigenvectors: bool) -> tuple[  # noqa: FBT001
                 np.ndarray, Quantity, np.ndarray | None,
                 np.ndarray | None, Quantity] | None:
         """
@@ -781,7 +782,7 @@ casting to real mode gradients.
             all_origins_cart: np.ndarray,
             dyn_mat_weighting: np.ndarray,
             recip_asr_correction: np.ndarray,
-            dipole: bool,
+            dipole: bool,  # noqa: FBT001
             q_dir: np.ndarray | None = None,
             ) -> tuple[np.ndarray, np.ndarray, np.ndarray | None]:
         """

--- a/euphonic/plot.py
+++ b/euphonic/plot.py
@@ -223,7 +223,7 @@ def plot_1d(spectra: OneDSpectrumOrSpectra,
 
     # Add an invisible large axis for common labels
     ax = fig.add_subplot(111, frameon=False)
-    ax.grid(False)
+    ax.grid(visible=False)
     ax.tick_params(labelcolor='none', bottom=False, left=False)
     ax.set_xlabel(xlabel)
     ax.set_ylabel(ylabel)
@@ -354,7 +354,7 @@ def plot_2d(spectra: Spectrum2D | Sequence[Spectrum2D],
 
     # Add an invisible large axis for common labels
     ax = fig.add_subplot(111, frameon=False)
-    ax.grid(False)
+    ax.grid(visible=False)
     ax.tick_params(labelcolor='none', bottom=False, left=False)
     ax.set_xlabel(xlabel)
     ax.set_ylabel(ylabel)

--- a/euphonic/powder.py
+++ b/euphonic/powder.py
@@ -408,6 +408,7 @@ def _qpts_cart_to_frac(qpts: Quantity,
 
 
 def _get_qpts_sphere(npts: int,
+                     *,
                      sampling: SphericalSamplingOptions = 'golden',
                      jitter: bool = False,
                      rng: RNG = rng) -> np.ndarray:

--- a/euphonic/readers/castep.py
+++ b/euphonic/readers/castep.py
@@ -127,6 +127,7 @@ def read_phonon_dos_data(
 
 def read_phonon_data(
         filename: Path | str,
+        *,
         cell_vectors_unit: str = 'angstrom',
         atom_mass_unit: str = 'amu',
         frequencies_unit: str = 'meV',

--- a/euphonic/readers/phonopy.py
+++ b/euphonic/readers/phonopy.py
@@ -46,6 +46,7 @@ def _convert_weights(weights: np.ndarray) -> np.ndarray:
 
 
 def _extract_phonon_data_yaml(filename: Path,
+                              *,
                               read_eigenvectors: bool = True,
                               ) -> dict[str, np.ndarray]:
     """
@@ -117,6 +118,7 @@ def _extract_phonon_data_yaml(filename: Path,
 
 
 def _extract_phonon_data_hdf5(filename: Path,
+                              *,
                               read_eigenvectors: bool = True,
                               ) -> dict[str, np.ndarray]:
     """
@@ -180,6 +182,7 @@ def _extract_phonon_data_hdf5(filename: Path,
     return data_dict
 
 def read_phonon_data(
+        *,
         path: Path | str = '.',
         phonon_name: Path | str = 'band.yaml',
         phonon_format: str | None = None,
@@ -456,7 +459,9 @@ def _extract_born(born_file_obj: TextIO) -> dict[str, float | np.ndarray]:
     return born_dict
 
 
-def _extract_summary(filename: Path, fc_extract: bool = False,
+def _extract_summary(filename: Path,
+                     *,
+                     fc_extract: bool = False,
                      ) -> dict[str, str | int | np.ndarray]:
     """
     Read phonopy.yaml for summary data produced during the Phonopy

--- a/euphonic/spectra/base.py
+++ b/euphonic/spectra/base.py
@@ -429,6 +429,7 @@ class Spectrum(ABC):
     @staticmethod
     def _bin_centres_to_edges(
             bin_centres: Quantity,
+            *,
             restrict_range: bool = True,
     ) -> Quantity:
         if restrict_range:

--- a/euphonic/structure_factor.py
+++ b/euphonic/structure_factor.py
@@ -131,6 +131,7 @@ class StructureFactor(QpointFrequencies):
 
     def calculate_1d_average(self,
                              e_bins: Quantity,
+                             *,
                              calc_bose: bool = True,
                              temperature: Quantity | None = None,
                              weights: np.ndarray | None = None,
@@ -173,6 +174,7 @@ class StructureFactor(QpointFrequencies):
 
     def calculate_sqw_map(self,
                           e_bins: Quantity,
+                          *,
                           calc_bose: bool = True,
                           temperature: Quantity | None = None,
                           ) -> Spectrum2D:
@@ -234,6 +236,7 @@ class StructureFactor(QpointFrequencies):
     def _bose_corrected_structure_factor(
             self,
             e_bins: Quantity,
+            *,
             calc_bose: bool = True,
             temperature: Quantity | None = None,
     ) -> Quantity:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -121,7 +121,7 @@ select = [
        "ASYNC",
        "S",       # Security (flake8-bandit)
        "BLE",     # flake8-blind-except
-       "FBT",   # flake8-boolean-trap: don't use positional boolean arguments. Fixable, but API-breaking.
+       "FBT",     # flake8-boolean-trap: don't use positional boolean arguments. Fixable, but API-breaking.
        "B",       # flake8-bugbear
        "A",       # flake8-builtins
        "COM",     # flake8-commas
@@ -154,7 +154,7 @@ select = [
        "FLY",     # flynt
        "I",       # isort
        "C90",     # mccabe : code complexity metric
-       "NPY",   # NumPy-specific rules
+       "NPY",     # NumPy-specific rules
        "N",       # pep8-naming
        "PERF",    # Perflint
        "F401",    # unused-import

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -121,7 +121,7 @@ select = [
        "ASYNC",
        "S",       # Security (flake8-bandit)
        "BLE",     # flake8-blind-except
-       # "FBT",   # flake8-boolean-trap: don't use positional boolean arguments. Fixable, but API-breaking.
+       "FBT",   # flake8-boolean-trap: don't use positional boolean arguments. Fixable, but API-breaking.
        "B",       # flake8-bugbear
        "A",       # flake8-builtins
        "COM",     # flake8-commas
@@ -209,6 +209,7 @@ extend-ignore-names = ["k_B", "H_ab", "Q"]
     "RUF012", # declaring sample data inside test classes is tidy
     "E501",   # long lines seem more common with verbose test names
     ]
+"tests_and_analysis/test/run_tests.py" = ["FBT"]  # Boolean positional arg; not public API, low risk
 "euphonic/isotopes/_legacy.py" = ["PLC0415"]  # Imports inside functions to avoid loop
 "euphonic/version.py" = ["Q000"]  # Source build prefers double quotes here
 

--- a/tests_and_analysis/test/euphonic_test/test_qpoint_phonon_modes.py
+++ b/tests_and_analysis/test/euphonic_test/test_qpoint_phonon_modes.py
@@ -134,7 +134,9 @@ def get_qpt_ph_modes(material):
 
 
 def check_qpt_ph_modes(
-        qpoint_phonon_modes, expected_qpoint_phonon_modes,
+        qpoint_phonon_modes,
+        expected_qpoint_phonon_modes,
+        *,
         frequencies_atol=FLOAT64_EPS,
         frequencies_rtol=1e-7,
         acoustic_gamma_atol=None,

--- a/tests_and_analysis/test/euphonic_test/test_spectrum2d.py
+++ b/tests_and_analysis/test/euphonic_test/test_spectrum2d.py
@@ -101,6 +101,7 @@ def get_expected_spectrum2d(json_filename):
 
 def check_spectrum2d(actual_spectrum2d,
                      expected_spectrum2d,
+                     *,
                      equal_nan=False,
                      z_atol=FLOAT64_EPS):
 

--- a/tests_and_analysis/test/euphonic_test/test_structure_factor.py
+++ b/tests_and_analysis/test/euphonic_test/test_structure_factor.py
@@ -135,6 +135,7 @@ def get_expected_sf(material, json_file):
 
 def check_structure_factor(
         sf, expected_sf,
+        *,
         freq_atol=FLOAT64_EPS,
         freq_rtol=1e-7,
         freq_gamma_atol=None,

--- a/tests_and_analysis/test/run_tests.py
+++ b/tests_and_analysis/test/run_tests.py
@@ -118,8 +118,11 @@ def _build_pytest_options(
     return options
 
 
-def run_tests(pytest_options: list[str], do_report_coverage: bool,
-              reports_dir: Path, test_dir: Path) -> int:
+def run_tests(
+    pytest_options: list[str],
+    do_report_coverage: bool,
+    reports_dir:Path,
+    test_dir: Path) -> int:
     """
     Run the tests and record coverage if selected.
 

--- a/tests_and_analysis/test/utils.py
+++ b/tests_and_analysis/test/utils.py
@@ -278,7 +278,9 @@ def sum_at_degenerate_modes(values_to_sum, frequencies, tol=0.05):
     return value_sum.squeeze()
 
 
-def get_spectrum_from_text(text_filename: Path | str, is_collection: bool = True):
+def get_spectrum_from_text(
+    text_filename: Path | str, *, is_collection: bool = True
+):
     """
     Reads a Spectrum1DCollection or Spectrum1D from a text file,
     for testing to_text_file method. The text file


### PR DESCRIPTION
Most of these are straightforward.

I made exceptions for a couple of cases where the functions is clearly internal/private and has a large number of arguments, such that calling them as kwargs would actively harm readability while risk of API desync is low.

Note that I have made *all* the parameters keyword-only to many "import phonopy" functions. I'm not loving the current path + filename arrangement and would prefer to do something more Pathlib-native - but don't have a precise proposal for replacement, yet. It seems reasonably likely then that this will involve additional keyword(s) while current one(s) are deprecated; mandatory kwarg should make that transitions safer.