### PR TITLE
Support Linux on ARM, fix Windows builds, streamline tox setup.

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -73,23 +73,13 @@ jobs:
           echo LDFLAGS="-L${LLVM_DIR}/lib $LDFLAGS" >> $GITHUB_ENV
           echo CPPFLAGS="-I${LLVM_DIR}/include $CPPFLAGS" >> $GITHUB_ENV
 
-      - name: Windows - find MSVC and set environment variables
-        if: startsWith(matrix.os, 'windows')
-        shell: bash -l {0}
-        env:
-          MSVC_PREFIX: 'C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC'
+      - name: Remove Strawberry ccache binary (It confuses the meson build)
+        if: startsWith( inputs.os, 'windows')
+        shell: powershell
         run: |
-          echo "Available MSVC installations:"
-          ls "$MSVC_PREFIX"
-
-          MSVC_BIN=$(ls "$MSVC_PREFIX" | tail -n 1)\\bin\\HostX64\\x64
-          CC="$MSVC_PREFIX\\$MSVC_BIN\\cl.exe"
-          echo "CC: $CC"
-          echo "CC=$CC" >> $GITHUB_ENV
-
-          CC_LD="$MSVC_PREFIX\\$MSVC_BIN\\link.exe"
-          echo "CC_LD: $CC_LD"
-          echo "CC_LD=$CC_LD" >> $GITHUB_ENV
+          if (Test-Path "C:\Strawberry\c\bin\ccache.exe") {
+              Remove-Item "C:\Strawberry\c\bin\ccache.exe" -Force
+          }
 
       - name: Update Python pip, build, wheel, and twine
         shell: bash -l {0}

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -93,7 +93,6 @@ jobs:
           git show --name-only --pretty=format:%H -s HEAD
           git describe --tags --long --dirty || true
           cat euphonic/version.py
-          python -c "import euphonic; print('euphonic.version =', import('euphonic').version)"
 
       - name: Build wheels from git checkout
         uses: pypa/cibuildwheel@v3.4.1

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -18,7 +18,7 @@ jobs:
   build-wheels:
     strategy:
       matrix:
-        os: [windows-latest, macos-15-intel, macos-latest, ubuntu-latest]
+        os: [windows-latest, macos-15-intel, macos-latest, ubuntu-latest, ubuntu-24.04-arm]
         python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
         include:
           - os: windows-latest
@@ -33,6 +33,9 @@ jobs:
           - os: ubuntu-latest
             wheelname: manylinux
             cibw_archs: "x86_64"
+          - os: ubuntu-24.04-arm
+            wheelname: manylinux
+            cibw_archs: "aarch64"
           - python-version: '3.10'
             version-tag: cp310
           - python-version: '3.11'

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -86,6 +86,15 @@ jobs:
         run: |
           python -m pip install --upgrade pip build wheel twine
 
+      - name: Troubleshooting - gather info about Euphonic version
+        shell: bash -l {0}
+        run: |
+          git rev-parse --abbrev-ref HEAD
+          git show --name-only --pretty=format:%H -s HEAD
+          git describe --tags --long --dirty || true
+          cat euphonic/version.py
+          python -c "import euphonic; print('euphonic.version =', import('euphonic').version)"
+
       - name: Build wheels from git checkout
         uses: pypa/cibuildwheel@v3.4.1
         env:

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -86,14 +86,6 @@ jobs:
         run: |
           python -m pip install --upgrade pip build wheel twine
 
-      - name: Troubleshooting - gather info about Euphonic version
-        shell: bash -l {0}
-        run: |
-          git rev-parse --abbrev-ref HEAD
-          git show --name-only --pretty=format:%H -s HEAD
-          git describe --tags --long --dirty || true
-          cat euphonic/version.py
-
       - name: Build wheels from git checkout
         uses: pypa/cibuildwheel@v3.4.1
         env:

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -41,18 +41,18 @@ jobs:
           skip: false
           all-python-versions: ${{(github.event_name != 'pull_request')}}
           coverage: false
-        # - os: windows-latest
-        #   skip: false
-        #   all-python-versions: ${{(github.event_name != 'pull_request')}}
-        #   coverage: false
-        # - os: macos-latest
-        #   skip: false
-        #   all-python-versions: ${{(github.event_name != 'pull_request')}}
-        #   coverage: false
-        # - os: macos-15-intel
-        #   skip: ${{ github.event_name == 'pull_request' }}
-        #   all-python-versions: true
-        #   coverage: false
+        - os: windows-latest
+          skip: false
+          all-python-versions: ${{(github.event_name != 'pull_request')}}
+          coverage: false
+        - os: macos-latest
+          skip: false
+          all-python-versions: ${{(github.event_name != 'pull_request')}}
+          coverage: false
+        - os: macos-15-intel
+          skip: ${{ github.event_name == 'pull_request' }}
+          all-python-versions: true
+          coverage: false
 
       fail-fast: false
 

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -37,18 +37,22 @@ jobs:
           skip: false
           all-python-versions: ${{(github.event_name != 'pull_request')}}
           coverage: true
-        - os: windows-latest
+        - os: ubuntu-24.04-arm
           skip: false
           all-python-versions: ${{(github.event_name != 'pull_request')}}
           coverage: false
-        - os: macos-latest
-          skip: false
-          all-python-versions: ${{(github.event_name != 'pull_request')}}
-          coverage: false
-        - os: macos-15-intel
-          skip: ${{ github.event_name == 'pull_request' }}
-          all-python-versions: true
-          coverage: false
+        # - os: windows-latest
+        #   skip: false
+        #   all-python-versions: ${{(github.event_name != 'pull_request')}}
+        #   coverage: false
+        # - os: macos-latest
+        #   skip: false
+        #   all-python-versions: ${{(github.event_name != 'pull_request')}}
+        #   coverage: false
+        # - os: macos-15-intel
+        #   skip: ${{ github.event_name == 'pull_request' }}
+        #   all-python-versions: true
+        #   coverage: false
 
       fail-fast: false
 

--- a/.github/workflows/test_checkout_one_os.yml
+++ b/.github/workflows/test_checkout_one_os.yml
@@ -60,23 +60,13 @@ jobs:
           echo LDFLAGS="-L${LLVM_DIR}/lib $LDFLAGS" >> $GITHUB_ENV
           echo CPPFLAGS="-I${LLVM_DIR}/include $CPPFLAGS" >> $GITHUB_ENV
 
-      - name: Windows - find MSVC and set environment variables
-        if: startsWith( inputs.os , 'windows' )
-        shell: bash -l {0}
-        env:
-          MSVC_PREFIX: 'C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC'
+      - name: Remove Strawberry ccache binary (It confuses the meson build)
+        if: startsWith( inputs.os, 'windows')
+        shell: powershell
         run: |
-          echo "Available MSVC installations:"
-          ls "$MSVC_PREFIX"
-
-          MSVC_BIN=$(ls "$MSVC_PREFIX" | tail -n 1)\\bin\\HostX64\\x64
-          CC="$MSVC_PREFIX\\$MSVC_BIN\\cl.exe"
-          echo "CC: $CC"
-          echo "CC=$CC" >> $GITHUB_ENV
-
-          CC_LD="$MSVC_PREFIX\\$MSVC_BIN\\link.exe"
-          echo "CC_LD: $CC_LD"
-          echo "CC_LD=$CC_LD" >> $GITHUB_ENV
+          if (Test-Path "C:\Strawberry\c\bin\ccache.exe") {
+              Remove-Item "C:\Strawberry\c\bin\ccache.exe" -Force
+          }
 
       - name: Update pip and install dependencies
         shell: bash -l {0}

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,12 @@
 `Unreleased <https://github.com/pace-neutrons/Euphonic/compare/v2.0.0...HEAD>`_
 -------------------------------------------------------------------------------
 
+- Requirements
+
+  - Euphonic now provides PyPI wheels for Linux ARM (aarch64). Like
+    Mac, this platform has a slightly increased h5py version
+    requirement in order to access pre-built wheels.
+
 - Bug fixes
 
   - Fixed a stack-corruption bug in the C extension's ZHEEVD workspace

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,19 +9,15 @@
 
 - Bug fixes
 
-  - Fixed a stack-corruption bug in the C extension's ZHEEVD workspace
-    query. ``WORK`` is a ``COMPLEX*16`` array in the real LAPACK
-    signature, but the query result was written into a bare 8-byte
-    ``double``; the unused imaginary half of that write could spill
-    into adjacent stack memory. On aarch64/GCC this corrupted the
-    following variable (``LRWORK``), causing ``ZHEEVD`` to reject the
-    subsequent diagonalisation call with ``info=-10`` and phonon
-    calculations to fail.
+  - Fixed out-of-bounds write in ZHEEVD workspace-query code, which
+    could corrupt adjacent stack variables. A C ``double`` array was
+    used to receive fortran ``COMPLEX*16``; this requires 2 elements
+    to safely contain real and imaginary parts.
 
-  - ``LWORK``/``LRWORK`` in the same function are now properly
-    initialised to ``-1`` alongside ``LIWORK``. We are not aware of
-    this causing issues in production, but there is potential for
-    platform/compiler-dependent surprises.
+  - All the int "length" values passed-by-reference to the same
+    function are now properly initialised to ``-1``; as far as we are
+    aware this didn't cause problems *yet*, but could misbehave in
+    some environment.
 
 - Compatibility fixes
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,57 @@
 `Unreleased <https://github.com/pace-neutrons/Euphonic/compare/v2.0.0...HEAD>`_
 -------------------------------------------------------------------------------
 
+- Bug fixes
+
+  - Fixed a stack-corruption bug in the C extension's ZHEEVD workspace
+    query. ``WORK`` is a ``COMPLEX*16`` array in the real LAPACK
+    signature, but the query result was written into a bare 8-byte
+    ``double``; the unused imaginary half of that write could spill
+    into adjacent stack memory. On aarch64/GCC this corrupted the
+    following variable (``LRWORK``), causing ``ZHEEVD`` to reject the
+    subsequent diagonalisation call with ``info=-10`` and phonon
+    calculations to fail.
+
+  - ``LWORK``/``LRWORK`` in the same function are now properly
+    initialised to ``-1`` alongside ``LIWORK``. We are not aware of
+    this causing issues in production, but there is potential for
+    platform/compiler-dependent surprises.
+
+- Compatibility fixes
+
+  - The [brille] optional dependency group will no longer attempt to
+    install brille on Linux ARM; this platform has no pre-built wheels and 
+    currently brille doesn not build reliably from source there.
+    
+    Tests requiring brille will be skipped on Linux ARM via a new
+    ``brille_or_skip_if_unsupported`` fixture; on other platforms,
+    missing brille will still cause those tests to fail.
+
+- Maintenance
+
+  - Linux ARM (``ubuntu-24.04-arm``) has been added to the test matrix
+    in ``run_tests.yml``.
+
+  - brille and non-brille tests are now run by ``tox`` as separate
+    pytest invocations on all platforms; previously this was just done
+    for Mac. The purpose is to reduce the number of tests forced into
+    serial operation by OpenMP conflicts.
+
+  - Minimum requirements are now tested on all platforms using a
+    common ``tox`` environment specification.
+
+  - All ``tox`` environments can now pass options such as
+    ``--parallel`` as ``{posargs}`` using ``tox run --``;
+    previously this was limited to a subset.
+
+  - Simplified Windows CI workflows on Github: take advantage of
+    Meson's ``--vsenv`` handling (which is more robust than last time
+    we tried!) and avoid setting explicit environment variables.
+
+    This does require a new bit of Windows-runner wrangling in the
+    workflow: we delete the ``ccacche.exe`` from Strawberry Perl which
+    was polluting the path.
+
 `v2.0.0 <https://github.com/pace-neutrons/Euphonic/compare/v1.6.2...v2.0.0>`_
 -----------------------------------------------------------------------------
 

--- a/c/dyn_mat.c
+++ b/c/dyn_mat.c
@@ -344,24 +344,21 @@ int diagonalise_dyn_mat_zheevd(const int n_atoms, const double qpt[3],
     char uplo = 'L';
     int order = 3*n_atoms;
     int lda = order;
-    int lwork = -1, lrwork = -1, liwork = -1;
+    int lwork, lrwork, liwork;
     double *work, *rwork;
     int *iwork;
     int info;
 
-    // Query vars
-    // NOTE: WORK is a COMPLEX*16 array in the real ZHEEVD signature, so the
-    // workspace-query result written to WORK(1) is a full 16-byte complex
-    // value (real part = optimal size, imaginary part = 0 by LAPACK
-    // convention). A bare 8-byte double here would let that write spill into
-    // adjacent stack memory (observed in practice to corrupt lrworkopt on
-    // aarch64/GCC, causing spurious ZHEEVD info=-10 failures), so use a
-    // 2-double buffer standing in for one complex element.
+    // Stand-ins for data arrays, to receive optimal sizes from ZHEEVD query.
+    // WORK is COMPLEX*16 in the real ZHEEVD signature, so its query result
+    // (written to WORK(1)) is a 16-byte complex value. double[2] stands in
+    // for a complex double here as MSVC doesn't support C's _Complex type.
     double lworkopt[2];
     double lrworkopt;
     int liworkopt;
 
-    // Workspace query
+    // Workspace query enabled by setting length(s) to -1.
+    lwork = lrwork = liwork = -1;
     (*zheevdptr)(&jobz, &uplo, &order, dyn_mat, &lda, eigenvalues, lworkopt, &lwork,
         &lrworkopt, &lrwork, &liworkopt, &liwork, &info);
     if (info != 0) {
@@ -369,6 +366,8 @@ int diagonalise_dyn_mat_zheevd(const int n_atoms, const double qpt[3],
                "q-point %f %f %f\n", info, qpt[0], qpt[1], qpt[2]);
         return info;
     }
+    // In workspace query ZHEEVD passes back the (int) optimal sizes
+    // to complex, double and int arrays; cast them back to int.
     lwork = (int)lworkopt[0];
     lrwork = (int)lrworkopt;
     liwork = liworkopt;

--- a/c/dyn_mat.c
+++ b/c/dyn_mat.c
@@ -344,24 +344,32 @@ int diagonalise_dyn_mat_zheevd(const int n_atoms, const double qpt[3],
     char uplo = 'L';
     int order = 3*n_atoms;
     int lda = order;
-    int lwork, lrwork, liwork = -1;
+    int lwork = -1, lrwork = -1, liwork = -1;
     double *work, *rwork;
     int *iwork;
     int info;
 
     // Query vars
-    double lworkopt, lrworkopt;
+    // NOTE: WORK is a COMPLEX*16 array in the real ZHEEVD signature, so the
+    // workspace-query result written to WORK(1) is a full 16-byte complex
+    // value (real part = optimal size, imaginary part = 0 by LAPACK
+    // convention). A bare 8-byte double here would let that write spill into
+    // adjacent stack memory (observed in practice to corrupt lrworkopt on
+    // aarch64/GCC, causing spurious ZHEEVD info=-10 failures), so use a
+    // 2-double buffer standing in for one complex element.
+    double lworkopt[2];
+    double lrworkopt;
     int liworkopt;
 
     // Workspace query
-    (*zheevdptr)(&jobz, &uplo, &order, dyn_mat, &lda, eigenvalues, &lworkopt, &lwork,
+    (*zheevdptr)(&jobz, &uplo, &order, dyn_mat, &lda, eigenvalues, lworkopt, &lwork,
         &lrworkopt, &lrwork, &liworkopt, &liwork, &info);
     if (info != 0) {
         printf("INFO: Zheevd failed querying workspace with info %i at "
                "q-point %f %f %f\n", info, qpt[0], qpt[1], qpt[2]);
         return info;
     }
-    lwork = (int)lworkopt;
+    lwork = (int)lworkopt[0];
     lrwork = (int)lrworkopt;
     liwork = liworkopt;
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,7 +85,8 @@ dev = [
 matplotlib = ["matplotlib>=3.8.0"]
 phonopy_reader = ["h5py>=3.6.0", "PyYAML>=6.0"]  # Deprecated, will be removed in future versions.
 phonopy-reader = ["h5py>=3.6.0", "PyYAML>=6.0"]
-brille = ["brille>=0.7.0"]
+# brille build on ARM-Linux is currently a bad time; skip it so tests run properly
+brille = ["brille>=0.7.0; sys_platform != 'linux' or platform_machine not in 'aarch64 arm64'"]
 
 [project.scripts]
 euphonic-brille-convergence = "euphonic.cli.brille_convergence:main"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,8 +60,9 @@ min_reqs = [
     "seekpath==2.2.1",
     "pint==0.22",
     "matplotlib==3.8",
-    "h5py==3.6; sys_platform != 'darwin'",
-    "h5py==3.7; sys_platform == 'darwin'",
+    # h5py 3.6 has no wheels for Linux ARM or macOS; use 3.7 there instead.
+    "h5py==3.6; sys_platform != 'darwin' and (sys_platform != 'linux' or platform_machine not in 'aarch64 arm64')",
+    "h5py==3.7; sys_platform == 'darwin' or (sys_platform == 'linux' and platform_machine in 'aarch64 arm64')",
     "PyYAML==6.0",
     "threadpoolctl==3.0.0",
     "toolz==0.12.1"

--- a/tests_and_analysis/test/conftest.py
+++ b/tests_and_analysis/test/conftest.py
@@ -1,0 +1,30 @@
+"""Shared pytest fixtures for the Euphonic test suite."""
+
+import platform
+
+import pytest
+
+
+@pytest.fixture
+def brille_or_skip_if_unsupported():
+    """Import brille, or skip this test on a known-unsupported platform.
+
+    At the moment that platform is Linux ARM: wheels are not available and
+    we're having trouble building them in CI.
+
+    On other platforms, a missing brille import is treated as a real failure
+    rather than skipped silently. To avoid ModuleNotFoundError on those
+    platforms if brille was deliberately not installed, use "-m not brille" to
+    deselect these tests instead.
+
+    """
+    try:
+        import brille
+    except ModuleNotFoundError:
+        if platform.system() == 'Linux' and platform.machine() in (
+            'aarch64',
+            'arm64',
+        ):
+            pytest.skip('brille is not supported on Linux ARM')
+        raise
+    return brille

--- a/tests_and_analysis/test/euphonic_test/test_brille_interpolator.py
+++ b/tests_and_analysis/test/euphonic_test/test_brille_interpolator.py
@@ -26,9 +26,14 @@ from tests_and_analysis.test.utils import (
     ignore_openmp_warning,
 )
 
-# Allow tests with brille marker to be collected and
-# deselected if brille isn't installed
-pytestmark = pytest.mark.brille
+pytestmark = [
+    # Apply marker so these tests can be collected and deselected if brille
+    # isn't installed, using `-m "not brille"`.
+    pytest.mark.brille,
+    # Allow these tests to be skipped (rather than fail) if brille failed to
+    # import on an unsupported platform.
+    pytest.mark.usefixtures('brille_or_skip_if_unsupported')
+]
 
 
 def get_brille_grid(grid_file):

--- a/tests_and_analysis/test/script_tests/test_brille_convergence.py
+++ b/tests_and_analysis/test/script_tests/test_brille_convergence.py
@@ -19,11 +19,16 @@ from tests_and_analysis.test.utils import (
     ignore_openmp_warning,
 )
 
-pytestmark = [pytest.mark.multiple_extras, pytest.mark.brille,
-              pytest.mark.matplotlib]
-# These tests require both Brille and Matplotlib, allow tests with
-# these markers to be collected and deselected if
-# either is not installed
+pytestmark = [
+    # These tests require both Brille and Matplotlib, allow tests with these
+    # markers to be collected and deselected using if either is not installed.
+    pytest.mark.multiple_extras,
+    pytest.mark.brille,
+    pytest.mark.matplotlib,
+    # Allow these tests to be skipped (rather than fail) if brille failed to
+    # import on an unsupported platform.
+    pytest.mark.usefixtures('brille_or_skip_if_unsupported'),
+]
 
 # Required for mocking
 with suppress(ModuleNotFoundError):

--- a/tests_and_analysis/test/script_tests/test_powder_map.py
+++ b/tests_and_analysis/test/script_tests/test_powder_map.py
@@ -137,7 +137,7 @@ class TestRegression:
     @pytest.mark.parametrize(
         'powder_map_args', powder_map_params_brille)
     def test_powder_map_plot_image_with_brille(
-            self, inject_mocks, powder_map_args):
+            self, inject_mocks, brille_or_skip_if_unsupported, powder_map_args):
         # Different numerical results on different platforms
         # unless a very dense, computationally expensive grid
         # is used. Just check that the program runs and a plot
@@ -161,7 +161,8 @@ class TestRegression:
                                                          'n_threads': 2}}),
     ])
     def test_brille_interpolator_from_force_constants_kwargs_passed(
-            self, inject_mocks, mocker, powder_map_args, expected_kwargs):
+            self, inject_mocks, mocker, brille_or_skip_if_unsupported,
+            powder_map_args, expected_kwargs):
         from euphonic.brille import BrilleInterpolator
         # Stop execution once from_fc has been called - we're only
         # checking here that the correct arguments have been passed
@@ -237,7 +238,8 @@ class TestRegression:
     @pytest.mark.multiple_extras
     @pytest.mark.parametrize('powder_map_args', [
         [nacl_prim_fc_file, '--use-brille', '--brille-grid-type', 'grid']])
-    def test_invalid_brille_grid_raises_causes_exit(self, powder_map_args):
+    def test_invalid_brille_grid_raises_causes_exit(
+            self, brille_or_skip_if_unsupported, powder_map_args):
         # Argparse should call sys.exit on invalid choices
         with pytest.raises(SystemExit) as err:
             euphonic.cli.powder_map.main(powder_map_args)

--- a/tox.ini
+++ b/tox.ini
@@ -35,29 +35,29 @@ commands =
 
 # Py3.15 is pre-release, test without extras
 [testenv:py315]
-commands = {[testenv]test_command} -m "not (phonopy_reader or matplotlib or brille)"
+commands = {[testenv]test_command} {posargs} -m "not (phonopy_reader or matplotlib or brille)"
 
 # Test with no extras
 [testenv:py310-base]
-commands = {[testenv]test_command} -m "not (phonopy_reader or matplotlib or brille)"
+commands = {[testenv]test_command} {posargs} -m "not (phonopy_reader or matplotlib or brille)"
 
 # Test with matplotlib extra only
 [testenv:py310-matplotlib]
 extras =
     matplotlib
-commands = {[testenv]test_command} -m "matplotlib and not multiple_extras"
+commands = {[testenv]test_command} {posargs} -m "matplotlib and not multiple_extras"
 
 # Test with phonopy-reader extra only
 [testenv:py310-phonopy-reader]
 extras =
     phonopy-reader
-commands = {[testenv]test_command} -m "phonopy_reader and not multiple_extras"
+commands = {[testenv]test_command} {posargs} -m "phonopy_reader and not multiple_extras"
 
 # Test with brille extra only
 [testenv:py310-brille]
 extras =
     brille
-commands = {[testenv]test_command} -m "brille and not multiple_extras"
+commands = {[testenv]test_command} {posargs} -m "brille and not multiple_extras"
 
 # Run remaining tests that require multiple extras
 [testenv:py310-all]
@@ -66,7 +66,7 @@ extras =
     phonopy-reader
     brille
 commands =
-    {[testenv]test_command} -m "multiple_extras"
+    {[testenv]test_command} {posargs} -m "multiple_extras"
 
 # Test without building C extension
 [testenv:py310-no-c]
@@ -76,7 +76,7 @@ extras =
     matplotlib
     phonopy-reader
     brille
-commands = {[testenv]test_command} -m "not c_extension"
+commands = {[testenv]test_command} {posargs} -m "not c_extension"
 
 # Test with minimum supported dependency versions
 [testenv:py310-minrequirements]
@@ -91,5 +91,5 @@ extras =
     phonopy-reader
     brille
 commands =
-    {[testenv]test_command} -m "brille"
-    {[testenv]test_command} -m "not brille"
+    {[testenv]test_command} {posargs} -m "brille"
+    {[testenv]test_command} {posargs} -m "not brille"

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 min_version = 4.0
 # The python environments to run the tests in
-envlist = py{311,312,313,314,315},py{311,312,313,314}-mac,py310-{base,brille,matplotlib,phonopy-reader,all,minrequirements-linux,minrequirements-mac,no-c}
+envlist = py{311,312,313,314,315},py310-{base,brille,matplotlib,phonopy-reader,all,minrequirements,no-c}
 allowlist_externals = git
 
 [testenv]
@@ -19,21 +19,16 @@ install_command =
 dependency_groups =
     test
 
-# Test with all extras
+# Test with all extras.
+# brille and non-brille tests are run as separate pytest invocations:
+# importing brille often creates OpenMP conflicts, and Euphonic avoid deadlocks
+# in this case by falling back to OMP_NUM_THREADS=1. By isolating most tests
+# from this scenario they can still benefit from parallelism.
 [testenv:py{311,312,313,314}]
-platform = (linux)|(win32)
 extras =
     matplotlib
     phonopy-reader
     brille
-commands =
-    {[testenv]test_command} {posargs}
-
-# Test brille and non-brille separately
-[testenv:py{311,312,313,314}-mac]
-platform = darwin
-extras = {[testenv:py311]extras}
-
 commands =
     {[testenv]test_command} {posargs} -m "brille"
     {[testenv]test_command} {posargs} -m "not brille"
@@ -58,16 +53,14 @@ extras =
     phonopy-reader
 commands = {[testenv]test_command} -m "phonopy_reader and not multiple_extras"
 
+# Test with brille extra only
 [testenv:py310-brille]
-platform = (linux)|(win32)
-
 extras =
     brille
 commands = {[testenv]test_command} -m "brille and not multiple_extras"
 
 # Run remaining tests that require multiple extras
 [testenv:py310-all]
-platform = (linux)|(win32)
 extras =
     matplotlib
     phonopy-reader
@@ -75,6 +68,7 @@ extras =
 commands =
     {[testenv]test_command} -m "multiple_extras"
 
+# Test without building C extension
 [testenv:py310-no-c]
 platform = linux
 install_command = {[testenv]install_command} -Csetup-args="-Dpython_only=true"
@@ -84,22 +78,8 @@ extras =
     brille
 commands = {[testenv]test_command} -m "not c_extension"
 
-[testenv:py310-minrequirements-linux]
-platform = linux
-dependency_groups =
-    {[testenv]dependency_groups}
-    min_reqs
-deps =
-    numpy==1.24
-    setuptools==60.*
-extras =
-    matplotlib
-    phonopy-reader
-    brille
-commands = {[testenv]test_command} -m "multiple_extras"
-
-[testenv:py310-minrequirements-mac]
-platform = darwin
+# Test with minimum supported dependency versions
+[testenv:py310-minrequirements]
 dependency_groups =
     {[testenv]dependency_groups}
     min_reqs


### PR DESCRIPTION
I'm increasingly working in Linux containers on my ARM Mac laptop, so lack of Euphonic wheels is annoying.

It turns out there are issues with the C extension on this platform, and with brille building/interface.

- Tweak typing in C code, it looks some complex numbers were only allocated correct space by good fortune and this fails on ARM Linux
- Streamline tox.ini in general; we don't actually need these Mac special-cases