### PR TITLE
Another attempt to fix coverage CI

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -119,11 +119,19 @@ jobs:
           path: artifacts
           name: 'Coverage XML (ubuntu-latest)'
 
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: List downloaded artifacts (debug)
+        run: ls -R artifacts || true
+
       - name: Get Coverage
         uses: orgoro/coverage@v3.2
         continue-on-error: true
         with:
-          coverageFile: 'artifacts/coverage-combined.xml'
+          coverageFile: 'artifacts/**/coverage-combined.xml'
           token: ${{ secrets.GITHUB_TOKEN }}
 
   publish-coverage-badge:

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -113,25 +113,28 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event.pull_request.head.repo.full_name == github.repository
     steps:
-      - name: Download Artifacts
-        uses: actions/download-artifact@v4
-        with:
-          path: artifacts
-          name: 'Coverage XML (ubuntu-latest)'
-
       - name: Checkout repository
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
+      - name: Download Coverage XML to runner temp
+        uses: actions/download-artifact@v4
+        with:
+          name: coverage-xml-ubuntu-latest
+          path: ${{ runner.temp }}/artifacts
+
       - name: List downloaded artifacts (debug)
-        run: ls -R artifacts || true
+        run: ls -R "${{ runner.temp }}/artifacts" || true
+
+      - name: Print runner temp (debug)
+        run: echo "runner.temp=${{ runner.temp }}" && ls -la "${{ runner.temp }}" || true
 
       - name: Get Coverage
         uses: orgoro/coverage@v3.2
         continue-on-error: true
         with:
-          coverageFile: 'artifacts/**/coverage-combined.xml'
+          coverageFile: '${{ runner.temp }}/artifacts/**/coverage-combined.xml'
           token: ${{ secrets.GITHUB_TOKEN }}
 
   publish-coverage-badge:

--- a/.github/workflows/test_checkout_one_os.yml
+++ b/.github/workflows/test_checkout_one_os.yml
@@ -1,3 +1,4 @@
+# Full file content to replace .github/workflows/test_checkout_one_os.yml
 name: Run tests from source on one platform
 on:
   workflow_call:
@@ -100,11 +101,24 @@ jobs:
           reportgenerator -reports:tests_and_analysis/test/reports/coverage-combined.xml -targetdir:tests_and_analysis/test/reports/html -reporttypes:Html_Dark
           reportgenerator -reports:tests_and_analysis/test/reports/coverage-combined.xml -targetdir:tests_and_analysis/test/reports -reporttypes:Badges
 
+      - name: Produce text summary (debug)
+        if: inputs.coverage
+        shell: bash -l {0}
+        run: |
+          reportgenerator -reports:tests_and_analysis/test/reports/coverage-combined.xml -reporttypes:TextSummary -targetdir:tests_and_analysis/test/reports/summary || true
+          if [ -f tests_and_analysis/test/reports/summary/Summary.txt ]; then cat tests_and_analysis/test/reports/summary/Summary.txt; else echo 'No Summary.txt found'; fi
+
+      - name: Show coverage badge SVG (debug)
+        if: inputs.coverage
+        shell: bash -l {0}
+        run: |
+          if [ -f tests_and_analysis/test/reports/badge_shieldsio_linecoverage_lightgrey.svg ]; then sed -n '1,120p' tests_and_analysis/test/reports/badge_shieldsio_linecoverage_lightgrey.svg; else echo 'No badge SVG found'; fi
+
       - name: Upload coverage XML
         if: inputs.coverage
         uses: actions/upload-artifact@v4
         with:
-          name: Coverage XML (${{ inputs.os }})
+          name: coverage-xml-${{ inputs.os }}
           path: tests_and_analysis/test/reports/coverage-combined.xml
 
       - name: Upload coverage HTML


### PR DESCRIPTION
Github Copilot kindly offered to create a branch for me; it seemed worth a try!

The coverage reporter action has been failing to pick up changed/added files, which makes the report in PR chat pretty useless.

- The main insight is that a missing checkout means the Coverage action lacks context for the coverage information. That seems plausible.
- The secondary suggestion was to make sure we are _definitely_ finding the coverage .xml and not getting the artifact paths wrong. This seems less likely but doesn't hurt to check at the same time.