### PR TITLE
Drop phonopy_reader optional group

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -37,7 +37,13 @@
 
 - Compatibility fixes
 
-  - Removed the deprecated duplicate ``phonopy_reader`` optional dependency entry from ``pyproject.toml``, retaining canonical ``phonopy-reader``. End-users require ``pip >= 22.2`` (or ``uv``) for PEP 685 extra name normalization (allowing legacy ``euphonic[phonopy_reader]`` syntax to resolve), while developers installing PEP 735 dependency groups via ``--group`` require ``pip >= 25.0`` (or ``uv``).
+  - Removed the deprecated ``phonopy_reader`` entry from
+    ``pyproject.toml``, retaining preferred ``phonopy-reader``. This
+    duplication was treated as an error by some modern package
+    installers. ``euphonic[phonopy_reader]`` will continue to resolve
+    for end-users with ``pip >= 22.2`` (or ``uv``; anything that
+    supports PEP 685). Developers installing PEP 735 dependency groups
+    via ``--group`` already required ``pip >= 25.0``.
 
   - The [brille] optional dependency group will no longer attempt to
     install brille on Linux ARM; this platform has no pre-built wheels and 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -37,6 +37,8 @@
 
 - Compatibility fixes
 
+  - Removed the deprecated duplicate ``phonopy_reader`` optional dependency entry from ``pyproject.toml``, retaining canonical ``phonopy-reader``. End-users require ``pip >= 22.2`` (or ``uv``) for PEP 685 extra name normalization (allowing legacy ``euphonic[phonopy_reader]`` syntax to resolve), while developers installing PEP 735 dependency groups via ``--group`` require ``pip >= 25.0`` (or ``uv``).
+
   - The [brille] optional dependency group will no longer attempt to
     install brille on Linux ARM; this platform has no pre-built wheels and 
     currently brille doesn not build reliably from source there.

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -21,6 +21,9 @@ overlooked please get in touch.
 Testing
 ~~~~~~~
 
+.. note::
+   Euphonic uses PEP 735 dependency groups for developer workflows (e.g. ``[dependency-groups]`` in ``pyproject.toml``). Installing dependency groups directly via ``pip install --group <group>`` requires ``pip >= 25.0`` or modern tools like ``uv``.
+
 Euphonic uses ``pytest`` with ``tox`` for unit testing in multiple
 isolated Python environments. Within the tox environments, the
 entrypoint to run unit tests is the

--- a/doc/source/installation.rst
+++ b/doc/source/installation.rst
@@ -35,6 +35,10 @@ If you don't require any of the extra depencencies, just use:
 
   pip install euphonic
 
+.. note::
+   Installing extra dependencies requires `pip >= 22.2` (or modern packaging tools like `uv`) to support PEP 685 extra name normalization (allowing legacy extra syntax such as `phonopy_reader` to automatically resolve to `phonopy-reader`).
+
+
 Conda
 =====
 

--- a/doc/source/installation.rst
+++ b/doc/source/installation.rst
@@ -5,7 +5,7 @@ Installation
 
 .. contents:: :local:
 
-Euphonic has been tested on Python 3.10 - 3.12.
+Euphonic has been tested on Python 3.10 - 3.14.
 
 Pip
 ===
@@ -36,7 +36,7 @@ If you don't require any of the extra depencencies, just use:
   pip install euphonic
 
 .. note::
-   Installing extra dependencies requires `pip >= 22.2` (or modern packaging tools like `uv`) to support PEP 685 extra name normalization (allowing legacy extra syntax such as `phonopy_reader` to automatically resolve to `phonopy-reader`).
+   Installing extra dependencies requires `pip >= 22.2` (or modern packaging tools like `uv`) for PEP 685 extra name normalization (i.e. allowing the legacy  `phonopy_reader` to automatically resolve to `phonopy-reader`).
 
 
 Conda

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,7 +84,6 @@ dev = [
 
 [project.optional-dependencies]
 matplotlib = ["matplotlib>=3.8.0"]
-phonopy_reader = ["h5py>=3.6.0", "PyYAML>=6.0"]  # Deprecated, will be removed in future versions.
 phonopy-reader = ["h5py>=3.6.0", "PyYAML>=6.0"]
 # brille build on ARM-Linux is currently a bad time; skip it so tests run properly
 brille = ["brille>=0.7.0; sys_platform != 'linux' or platform_machine not in 'aarch64 arm64'"]


### PR DESCRIPTION
This was causing trouble with modern systems like uv, which complain that it is an error to have duplicate groups after normalisation. It's a fair complaint, because how would conflicting values be handled?

The group was initially kept in order to maintain backward compatibility for users with install scripts etc. that might use the old version. But on closer inspection any reasonably modern Pip will normalise the old name correctly.

We also update the docs a bit to clarify the state of Pip requirements: using --group already required a newer version than this, but regular users don't need it.

---

Assisted-by: pi:gemini-3.7-flash
Assisted-by: pi:gemini-3.5-flash-lite