### PR TITLE
Documentation for VASP support

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -132,11 +132,14 @@ and syntax).
 
   - Many public functions and methods now use keyword-only arguments
     where previously these were permitted to be keyword *or* positional.
+
     - This will break code that depends on these arguments being in a
       specific order rather than calling them by name
+
     - The most "obvious" arguments can still be accessed by position
       for concise "standard" function calls; the goal is not to make
       downstream code drastically more verbose.
+
     - The purpose of this is to give more flexibility to add features
       or alias arguments while deprecating/changing their behaviour,
       without breaking the public API between major releases.

--- a/doc/source/force-constants.rst
+++ b/doc/source/force-constants.rst
@@ -184,7 +184,7 @@ charges can also be read from Phonopy plaintext or hdf5 files by specifying the
 Reading From VASP
 -------------------
 
-Euphonic supports direct import of VASP 6+ HDF5 calculation files (``vaspout.h5``) using
+Euphonic supports direct import of VASP 6 HDF5 calculation files (``vaspout.h5``) using
 :py:meth:`ForceConstants.from_vasp <euphonic.force_constants.ForceConstants.from_vasp>`.
 This extracts crystal structure, supercell force constants (Hessian), and any present Born effective charges and high-frequency dielectric tensors:
 

--- a/doc/source/force-constants.rst
+++ b/doc/source/force-constants.rst
@@ -181,6 +181,22 @@ charges can also be read from Phonopy plaintext or hdf5 files by specifying the
                                    born_name='BORN_nacl')
 
 
+Reading From VASP
+-------------------
+
+Euphonic supports direct import of VASP 6+ HDF5 calculation files (``vaspout.h5``) using
+:py:meth:`ForceConstants.from_vasp <euphonic.force_constants.ForceConstants.from_vasp>`.
+This extracts crystal structure, supercell force constants (Hessian), and any present Born effective charges and high-frequency dielectric tensors:
+
+.. code-block:: python
+
+  from euphonic import ForceConstants
+
+  fc = ForceConstants.from_vasp('vaspout.h5')
+
+For more details on how VASP HDF5 data groups are parsed and extracted, see :ref:`File Readers <readers>`.
+
+
 .. _fc_read_other_programs:
 
 Reading From Other Programs

--- a/doc/source/force-constants.rst
+++ b/doc/source/force-constants.rst
@@ -184,9 +184,9 @@ charges can also be read from Phonopy plaintext or hdf5 files by specifying the
 Reading From VASP
 -------------------
 
-Euphonic supports direct import of VASP 6 HDF5 calculation files (``vaspout.h5``) using
+Force constants may be constructed from VASP 6 HDF5 calculation files (``vaspout.h5``) using
 :py:meth:`ForceConstants.from_vasp <euphonic.force_constants.ForceConstants.from_vasp>`.
-This extracts crystal structure, supercell force constants (Hessian), and any present Born effective charges and high-frequency dielectric tensors:
+If present, Born effective charges and high-frequency dielectric tensors are included:
 
 .. code-block:: python
 

--- a/doc/source/howto.rst
+++ b/doc/source/howto.rst
@@ -2,7 +2,7 @@ Introduction
 ************
 
 Euphonic enables the quick simulation of phonons from a force constants matrix produced by many common simulation packages.
-By default it supports the output from CASTEP or Phonopy, but it is possible to load any other format with just a little more work.
+By default it supports the output from CASTEP, Phonopy or VASP, but it is possible to load any other format with just a little more work.
 This guide will describe how to perform many common Euphonic operations.
 It is not intended to describe every possible operation you could perform.
 We have tried to provide links to the API documentation for the most complex cases.

--- a/doc/source/python-api.rst
+++ b/doc/source/python-api.rst
@@ -10,6 +10,7 @@ Python API
   Phonon Frequencies and Eigenvectors <qpoint-phonon-modes>
   Phonon Frequencies Only <qpoint-frequencies>
   Crystal Structure <crystal>
+  File Readers <readers>
   Density of States <dos>
   Structure Factors <structure-factor>
   Scattering Intensities <scattering-intensities>

--- a/doc/source/qpoint-frequencies.rst
+++ b/doc/source/qpoint-frequencies.rst
@@ -55,6 +55,22 @@ argument. A path can also be specified.
 
   phonons = QpointFrequencies.from_phonopy(path='NaCl', phonon_name='mesh.hdf5')
 
+
+Reading From VASP
+-------------------
+
+Precalculated phonon frequencies can also be read directly from VASP HDF5 calculation files (``vaspout.h5``) containing phonon results using
+:py:meth:`QpointFrequencies.from_vasp <euphonic.qpoint_frequencies.QpointFrequencies.from_vasp>`:
+
+.. code-block:: python
+
+  from euphonic import QpointFrequencies
+
+  phonons = QpointFrequencies.from_vasp('vaspout.h5')
+
+For more details on VASP HDF5 data extraction, see :ref:`File Readers <readers>`.
+
+
 From Force Constants
 --------------------
 

--- a/doc/source/qpoint-phonon-modes.rst
+++ b/doc/source/qpoint-phonon-modes.rst
@@ -56,6 +56,22 @@ argument. A path can also be specified.
 
   phonons = QpointPhononModes.from_phonopy(path='NaCl', phonon_name='mesh.hdf5')
 
+
+Reading From VASP
+-------------------
+
+Precalculated phonon frequencies and eigenvectors can also be read directly from VASP HDF5 calculation files (``vaspout.h5``) containing phonon results using
+:py:meth:`QpointPhononModes.from_vasp <euphonic.qpoint_phonon_modes.QpointPhononModes.from_vasp>`:
+
+.. code-block:: python
+
+  from euphonic import QpointPhononModes
+
+  phonons = QpointPhononModes.from_vasp('vaspout.h5')
+
+For more details on VASP HDF5 data extraction, see :ref:`File Readers <readers>`.
+
+
 From Force Constants
 --------------------
 

--- a/doc/source/readers.rst
+++ b/doc/source/readers.rst
@@ -8,7 +8,7 @@ File Readers
 
    The ``euphonic.readers`` subpackage is part of Euphonic's public API and provides low-level functions that extract raw Python dictionaries from calculation files.
 
-   In most standard workflows, end-users are not expected to call these functions directly. Instead, you should construct high-level Euphonic objects (:py:class:`~euphonic.force_constants.ForceConstants`, :py:class:`~euphonic.qpoint_phonon_modes.QpointPhononModes`, :py:class:`~euphonic.qpoint_frequencies.QpointFrequencies`, or :py:class:`~euphonic.crystal.Crystal`) via their respective ``.from_vasp()``, ``.from_castep()``, or ``.from_phonopy()`` classmethod constructors.
+   In most standard workflows, end-users are not expected to call these functions directly. Instead, you should construct high-level Euphonic objects (:py:class:`~euphonic.force_constants.ForceConstants`, :py:class:`~euphonic.qpoint_phonon_modes.QpointPhononModes`, or :py:class:`~euphonic.qpoint_frequencies.QpointFrequencies`) via their respective ``.from_vasp()``, ``.from_castep()``, or ``.from_phonopy()`` classmethod constructors.
 
 .. contents:: :local:
 

--- a/doc/source/readers.rst
+++ b/doc/source/readers.rst
@@ -1,0 +1,40 @@
+.. _readers:
+
+============
+File Readers
+============
+
+.. note::
+
+   The ``euphonic.readers`` subpackage is part of Euphonic's public API and provides low-level functions that extract raw Python dictionaries from calculation files.
+
+   In most standard workflows, end-users are not expected to call these functions directly. Instead, you should construct high-level Euphonic objects (``ForceConstants``, ``QpointPhononModes``, ``QpointFrequencies``, or ``Crystal``) via their respective ``.from_vasp()``, ``.from_castep()``, or ``.from_phonopy()`` classmethod constructors.
+
+.. contents:: :local:
+
+VASP HDF5 Reader
+----------------
+
+Euphonic supports direct import of VASP 6+ HDF5 calculation files (e.g. ``vaspout.h5``) containing supercell force constants, Born effective charges, dielectric tensors, and precalculated phonon data.
+
+### HDF5 Group Structure Mapping
+
+The `euphonic.readers.vasp` module extracts data from standard VASP 6+ HDF5 hierarchies:
+
+* **Crystal Structure & Masses**:
+  - Equilibrium lattice and ion positions: `input/poscar` (or fallback `results/positions`)
+  - Primitive cell structure (when available): `results/phonons/primitive`
+  - Atomic masses (POMASS): Extracted from `input/incar/POMASS`, `original/incar/content`, or `input/potcar/content`.
+* **Force Constants & Dielectric Properties**:
+  - Force constants / Hessian matrix: `results/linear_response/force_constants` or `results/linear_response/hessian`
+  - Born effective charges: `results/linear_response/born_charges`
+  - High-frequency electronic dielectric tensor ($\epsilon^\infty$): `results/linear_response/electron_dielectric_tensor`
+* **Precalculated Phonons**:
+  - Dispersion / mesh q-points, frequencies, and eigenvectors: `results/phonons`
+
+### Module API Reference
+
+.. automodule:: euphonic.readers.vasp
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/doc/source/readers.rst
+++ b/doc/source/readers.rst
@@ -17,22 +17,30 @@ VASP HDF5 Reader
 
 Euphonic supports direct import of VASP 6+ HDF5 calculation files (e.g. ``vaspout.h5``) containing supercell force constants, Born effective charges, dielectric tensors, and precalculated phonon data.
 
-### HDF5 Group Structure Mapping
+HDF5 Group Structure Mapping
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The `euphonic.readers.vasp` module extracts data from standard VASP 6+ HDF5 hierarchies:
+The ``euphonic.readers.vasp`` module extracts data from standard VASP 6+ HDF5 hierarchies:
 
 * **Crystal Structure & Masses**:
-  - Equilibrium lattice and ion positions: `input/poscar` (or fallback `results/positions`)
-  - Primitive cell structure (when available): `results/phonons/primitive`
-  - Atomic masses (POMASS): Extracted from `input/incar/POMASS`, `original/incar/content`, or `input/potcar/content`.
-* **Force Constants & Dielectric Properties**:
-  - Force constants / Hessian matrix: `results/linear_response/force_constants` or `results/linear_response/hessian`
-  - Born effective charges: `results/linear_response/born_charges`
-  - High-frequency electronic dielectric tensor ($\epsilon^\infty$): `results/linear_response/electron_dielectric_tensor`
-* **Precalculated Phonons**:
-  - Dispersion / mesh q-points, frequencies, and eigenvectors: `results/phonons`
 
-### Module API Reference
+  * Equilibrium lattice and ion positions: ``input/poscar`` (or fallback ``results/positions``)
+  * Primitive cell structure (when available): ``results/phonons/primitive``
+  * Atomic masses (POMASS): Extracted from ``input/incar/POMASS``, ``original/incar/content``, or ``input/potcar/content``.
+
+* **Force Constants & Dielectric Properties**:
+
+  * Force constants / Hessian matrix: ``results/linear_response/force_constants`` or ``results/linear_response/hessian``
+  * Born effective charges: ``results/linear_response/born_charges``
+  * High-frequency electronic dielectric tensor (:math:`\epsilon^\infty`): ``results/linear_response/electron_dielectric_tensor``
+
+* **Precalculated Phonons**:
+
+  * Dispersion / mesh q-points, frequencies, and eigenvectors: ``results/phonons``
+
+
+Module API Reference
+^^^^^^^^^^^^^^^^^^^^
 
 .. automodule:: euphonic.readers.vasp
    :members:

--- a/doc/source/readers.rst
+++ b/doc/source/readers.rst
@@ -8,33 +8,33 @@ File Readers
 
    The ``euphonic.readers`` subpackage is part of Euphonic's public API and provides low-level functions that extract raw Python dictionaries from calculation files.
 
-   In most standard workflows, end-users are not expected to call these functions directly. Instead, you should construct high-level Euphonic objects (``ForceConstants``, ``QpointPhononModes``, ``QpointFrequencies``, or ``Crystal``) via their respective ``.from_vasp()``, ``.from_castep()``, or ``.from_phonopy()`` classmethod constructors.
+   In most standard workflows, end-users are not expected to call these functions directly. Instead, you should construct high-level Euphonic objects (:py:class:`~euphonic.force_constants.ForceConstants`, :py:class:`~euphonic.qpoint_phonon_modes.QpointPhononModes`, :py:class:`~euphonic.qpoint_frequencies.QpointFrequencies`, or :py:class:`~euphonic.crystal.Crystal`) via their respective ``.from_vasp()``, ``.from_castep()``, or ``.from_phonopy()`` classmethod constructors.
 
 .. contents:: :local:
 
 VASP HDF5 Reader
 ----------------
 
-Euphonic supports direct import of VASP 6+ HDF5 calculation files (e.g. ``vaspout.h5``) containing supercell force constants, Born effective charges, dielectric tensors, and precalculated phonon data.
+Euphonic supports direct import of VASP 6 HDF5 calculation files (e.g. ``vaspout.h5``) containing supercell force constants, Born effective charges, dielectric tensors, and precalculated phonon data.
 
 HDF5 Group Structure Mapping
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The ``euphonic.readers.vasp`` module extracts data from standard VASP 6+ HDF5 hierarchies:
+The ``euphonic.readers.vasp`` module extracts data from standard VASP 6 HDF5 hierarchies to construct native Euphonic objects:
 
-* **Crystal Structure & Masses**:
+* **Crystal Structure & Masses** (used by :py:class:`~euphonic.crystal.Crystal`):
 
   * Equilibrium lattice and ion positions: ``input/poscar`` (or fallback ``results/positions``)
   * Primitive cell structure (when available): ``results/phonons/primitive``
   * Atomic masses (POMASS): Extracted from ``input/incar/POMASS``, ``original/incar/content``, or ``input/potcar/content``.
 
-* **Force Constants & Dielectric Properties**:
+* **Force Constants & Dielectric Properties** (used by :py:meth:`ForceConstants.from_vasp <euphonic.force_constants.ForceConstants.from_vasp>`):
 
   * Force constants / Hessian matrix: ``results/linear_response/force_constants`` or ``results/linear_response/hessian``
   * Born effective charges: ``results/linear_response/born_charges``
   * High-frequency electronic dielectric tensor (:math:`\epsilon^\infty`): ``results/linear_response/electron_dielectric_tensor``
 
-* **Precalculated Phonons**:
+* **Precalculated Phonons** (used by :py:meth:`QpointPhononModes.from_vasp <euphonic.qpoint_phonon_modes.QpointPhononModes.from_vasp>` and :py:meth:`QpointFrequencies.from_vasp <euphonic.qpoint_frequencies.QpointFrequencies.from_vasp>`):
 
   * Dispersion / mesh q-points, frequencies, and eigenvectors: ``results/phonons``
 


### PR DESCRIPTION
The `readers` module is currently undocumented, so we also create some space for the castep and phonopy functions.

---
Assisted-by: pi:gemini-3.7-flash
Assisted-by: pi:gemini-3.5-flash-lite