### PR TITLE
Add missing module documentation

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -53,6 +53,13 @@
     ``brille_or_skip_if_unsupported`` fixture; on other platforms,
     missing brille will still cause those tests to fail.
 
+- Documentation
+
+  - Added documentation for *readers*, *isotopes*, *broadening*
+    modules and updated related sections of existing docs.
+
+  - Recommend IsotopeData interface, not old *get_reference_data* function.
+
 - Maintenance
 
   - Unit-testing with ``tox``

--- a/doc/source/broadening.rst
+++ b/doc/source/broadening.rst
@@ -1,0 +1,30 @@
+.. _broadening:
+
+======================
+Broadening Utilities
+======================
+
+.. note::
+
+   If you are performing standard spectrum broadening (e.g. broadening a density of states or :class:`Spectrum1D <euphonic.spectra.base.Spectrum1D>` / :class:`Spectrum2D <euphonic.spectra.base.Spectrum2D>` object with a fixed or variable FWHM), you should use the high-level :py:meth:`Spectrum1D.broaden <euphonic.spectra.base.Spectrum1D.broaden>` or :py:meth:`Spectrum2D.broaden <euphonic.spectra.base.Spectrum2D.broaden>` methods (see :ref:`Spectra <spectra>`).
+
+.. contents:: :local:
+
+Overview
+========
+
+The ``euphonic.broadening`` module provides the low-level standalone convolution and interpolation algorithms used internally by Euphonic to apply Gaussian or Lorentzian broadening to 1-D and 2-D spectral data series.
+
+Key Capabilities
+================
+
+- **Variable-Width Broadening**: :py:func:`~euphonic.broadening.variable_width_broadening` handles x-dependent broadening functions (such as instrumental resolution functions varying with energy transfer).
+- **Kernel Interpolation**: :py:func:`~euphonic.broadening.width_interpolated_broadening` and :py:func:`~euphonic.broadening.find_coeffs` accelerate calculations by evaluating broadening kernels on regularly spaced intervals and interpolating across the spectrum.
+
+Module API Reference
+====================
+
+.. automodule:: euphonic.broadening
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/doc/source/broadening.rst
+++ b/doc/source/broadening.rst
@@ -14,12 +14,14 @@ Overview
 ========
 
 The ``euphonic.broadening`` module provides the low-level standalone convolution and interpolation algorithms used internally by Euphonic to apply Gaussian or Lorentzian broadening to 1-D and 2-D spectral data series.
+:py:func:`~euphonic.broadening.variable_width_broadening` evaluates broadening width functions (such as instrumental resolution functions varying with energy transfer)
+and passes them to :py:func:`~euphonic.broadening.width_interpolated_broadening`, which implements a fast approximate broadening scheme.
+The data is divided and convolved with multiple kernels to construct an interpolated spectrum without broadening every bin individually [Farmer2023]_.
 
-Key Capabilities
-================
+References
+==========
 
-- **Variable-Width Broadening**: :py:func:`~euphonic.broadening.variable_width_broadening` handles x-dependent broadening functions (such as instrumental resolution functions varying with energy transfer).
-- **Kernel Interpolation**: :py:func:`~euphonic.broadening.width_interpolated_broadening` and :py:func:`~euphonic.broadening.find_coeffs` accelerate calculations by evaluating broadening kernels on regularly spaced intervals and interpolating across the spectrum.
+.. [Farmer2023] J. Farmer and A. J. Jackson. *A fast approximate method for variable-width broadening of spectra*. `arXiv:2309.12135 <https://arxiv.org/abs/2309.12135>`_ (2023).
 
 Module API Reference
 ====================

--- a/doc/source/force-constants.rst
+++ b/doc/source/force-constants.rst
@@ -167,18 +167,7 @@ changed with the ``summary_name`` keyword argument:
   fc = ForceConstants.from_phonopy(path='NaCl',
                                    summary_name='phonopy_nacl.yaml')
 
-If you are using an older version of Phonopy, the force constants and born
-charges can also be read from Phonopy plaintext or hdf5 files by specifying the
-``fc_name`` and ``born_name`` keyword arguments:
-
-.. testcode:: nacl_yaml
-
-  from euphonic import ForceConstants
-
-  fc = ForceConstants.from_phonopy(path='NaCl',
-                                   summary_name='phonopy_nacl.yaml',
-                                   fc_name='force_constants.hdf5',
-                                   born_name='BORN_nacl')
+For older Phonopy versions or separate file layouts (such as explicit ``FORCE_CONSTANTS`` or ``BORN`` files), see :ref:`File Readers <readers>`.
 
 
 Reading From VASP

--- a/doc/source/isotopes.rst
+++ b/doc/source/isotopes.rst
@@ -35,8 +35,8 @@ For quick calculations or when testing custom scattering lengths for specific at
 
 This approach is lightweight and keeps problem-specific overrides self-contained within your script.
 
-Using General-Purpose Datasets (``sears_1992`` & ``CsvData``)
-=============================================================
+General-Purpose Datasets
+========================
 
 For robust, general-purpose isotopic tables supporting automatic mass and scattering length lookups across all elements and isotopes, Euphonic provides :py:class:`~euphonic.isotopes._csv.CsvData`.
 
@@ -51,8 +51,8 @@ By default, Euphonic preloads the Sears (1992) neutron scattering length dataset
 
 You can also load custom CSV data tables containing physical properties and unit definitions using :py:class:`~euphonic.isotopes._csv.CsvData`.
 
-Custom Providers & the ``IsotopeData`` Protocol
-===============================================
+Custom Providers & the IsotopeData Protocol
+===========================================
 
 For advanced workflows or integration into other materials simulation packages, you can create a custom data provider by implementing a class that adheres to the :py:class:`~euphonic.isotopes.IsotopeData` protocol. Implementing classes should define the :py:meth:`~euphonic.isotopes.IsotopeData.get_item` and :py:meth:`~euphonic.isotopes.IsotopeData.get_array` methods, and can optionally inherit from :py:class:`~euphonic.isotopes.ArrayFromValuesMixin` to automatically handle array extraction across crystal structures.
 

--- a/doc/source/isotopes.rst
+++ b/doc/source/isotopes.rst
@@ -14,7 +14,7 @@ Euphonic uses isotope and reference data when calculating neutron scattering qua
 Depending on your use case, isotope and scattering length properties can be provided in two main ways:
 
 1. **Problem-Specific Dictionaries**: A simple, convenient way to define scattering lengths or atomic weights tied directly to element or atom labels in a specific calculation, without needing external files.
-2. **General-Purpose Tabular Datasets (``CsvData``)**: A robust framework for loading comprehensive property tables across the periodic table (such as the built-in ``sears_1992`` dataset).
+2. **General-Purpose Tabular Datasets (CsvData)**: A robust framework for loading comprehensive property tables across the periodic table (such as the built-in ``sears_1992`` dataset).
 
 Using Custom Dictionaries for Problem-Specific Data
 ===================================================

--- a/doc/source/isotopes.rst
+++ b/doc/source/isotopes.rst
@@ -9,7 +9,7 @@ Isotope Data
 Overview
 ========
 
-Euphonic uses isotope and reference data when calculating neutron scattering quantities, such as structure factors (:py:meth:`QpointPhononModes.calculate_structure_factor <euphonic.qpoint_phonon_modes.QpointPhononModes.calculate_structure_factor>`) or neutron-weighted partial density of states (:py:meth:`QpointPhononModes.calculate_pdos <euphonic.qpoint_phonon_modes.QpointPhononModes.calculate_pdos>`). 
+Euphonic uses isotope and reference data when calculating neutron scattering quantities, such as structure factors (:py:meth:`QpointPhononModes.calculate_structure_factor <euphonic.qpoint_phonon_modes.QpointPhononModes.calculate_structure_factor>`) or neutron-weighted partial density of states (:py:meth:`QpointPhononModes.calculate_pdos <euphonic.qpoint_phonon_modes.QpointPhononModes.calculate_pdos>`).
 
 Depending on your use case, isotope and scattering length properties can be provided in two main ways:
 
@@ -38,7 +38,7 @@ This approach is lightweight and keeps problem-specific overrides self-contained
 Using General-Purpose Datasets (``sears_1992`` & ``CsvData``)
 =============================================================
 
-For robust, general-purpose isotopic tables supporting automatic mass and scattering length lookups across all elements and isotopes, Euphonic provides :py:class:`~euphonic.isotopes._csv.CsvData`. 
+For robust, general-purpose isotopic tables supporting automatic mass and scattering length lookups across all elements and isotopes, Euphonic provides :py:class:`~euphonic.isotopes._csv.CsvData`.
 
 By default, Euphonic preloads the Sears (1992) neutron scattering length dataset as ``sears_1992``:
 
@@ -50,6 +50,12 @@ By default, Euphonic preloads the Sears (1992) neutron scattering length dataset
   si_b = sears_1992.get_array('Si', 'bound_coherent_scattering_length')
 
 You can also load custom CSV data tables containing physical properties and unit definitions using :py:class:`~euphonic.isotopes._csv.CsvData`.
+
+Custom Providers & the ``IsotopeData`` Protocol
+===============================================
+
+For advanced workflows or integration into other materials simulation packages, you can create a custom data provider by implementing a class that adheres to the :py:class:`~euphonic.isotopes.IsotopeData` protocol. Implementing classes should define the :py:meth:`~euphonic.isotopes.IsotopeData.get_item` and :py:meth:`~euphonic.isotopes.IsotopeData.get_array` methods, and can optionally inherit from :py:class:`~euphonic.isotopes.ArrayFromValuesMixin` to automatically handle array extraction across crystal structures.
+
 
 
 Module API Reference

--- a/doc/source/isotopes.rst
+++ b/doc/source/isotopes.rst
@@ -1,0 +1,61 @@
+.. _isotopes:
+
+============
+Isotope Data
+============
+
+.. contents:: :local:
+
+Overview
+========
+
+Euphonic uses isotope and reference data when calculating neutron scattering quantities, such as structure factors (:py:meth:`QpointPhononModes.calculate_structure_factor <euphonic.qpoint_phonon_modes.QpointPhononModes.calculate_structure_factor>`) or neutron-weighted partial density of states (:py:meth:`QpointPhononModes.calculate_pdos <euphonic.qpoint_phonon_modes.QpointPhononModes.calculate_pdos>`). 
+
+Depending on your use case, isotope and scattering length properties can be provided in two main ways:
+
+1. **Problem-Specific Dictionaries**: A simple, convenient way to define scattering lengths or atomic weights tied directly to element or atom labels in a specific calculation, without needing external files.
+2. **General-Purpose Tabular Datasets (``CsvData``)**: A robust framework for loading comprehensive property tables across the periodic table (such as the built-in ``sears_1992`` dataset).
+
+Using Custom Dictionaries for Problem-Specific Data
+===================================================
+
+For quick calculations or when testing custom scattering lengths for specific atomic labels in your crystal structure, you can pass a plain Python dictionary (or ``AtomTypeDictData``) directly to calculation methods. The dictionary maps element or atom symbols to `pint.Quantity` objects:
+
+.. code-block:: python
+
+  from euphonic import ureg, ForceConstants
+
+  fc = ForceConstants.from_castep('quartz.castep_bin')
+  phonons = fc.calculate_qpoint_phonon_modes(qpts, asr='reciprocal')
+
+  fm = ureg('fm')
+  # Simple dictionary mapping element symbols to scattering lengths
+  scattering_lengths = {'Si': 4.1491 * fm, 'O': 5.803 * fm}
+  sf = phonons.calculate_structure_factor(scattering_lengths=scattering_lengths)
+
+This approach is lightweight and keeps problem-specific overrides self-contained within your script.
+
+Using General-Purpose Datasets (``sears_1992`` & ``CsvData``)
+=============================================================
+
+For robust, general-purpose isotopic tables supporting automatic mass and scattering length lookups across all elements and isotopes, Euphonic provides :py:class:`~euphonic.isotopes._csv.CsvData`. 
+
+By default, Euphonic preloads the Sears (1992) neutron scattering length dataset as ``sears_1992``:
+
+.. code-block:: python
+
+  from euphonic.isotopes import sears_1992
+
+  # Access scattering length for a specific isotope or element
+  si_b = sears_1992.get_array('Si', 'bound_coherent_scattering_length')
+
+You can also load custom CSV data tables containing physical properties and unit definitions using :py:class:`~euphonic.isotopes._csv.CsvData`.
+
+
+Module API Reference
+====================
+
+.. automodule:: euphonic.isotopes
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/doc/source/python-api.rst
+++ b/doc/source/python-api.rst
@@ -11,6 +11,8 @@ Python API
   Phonon Frequencies Only <qpoint-frequencies>
   Crystal Structure <crystal>
   File Readers <readers>
+  Isotope Data <isotopes>
+  Broadening Utilities <broadening>
   Density of States <dos>
   Structure Factors <structure-factor>
   Scattering Intensities <scattering-intensities>

--- a/doc/source/qpoint-phonon-modes.rst
+++ b/doc/source/qpoint-phonon-modes.rst
@@ -119,7 +119,7 @@ be set as a dictionary mapping each atom identity to a ``pint.Quantity``
 (see :ref:`Units` for details).
 
 Alternatively, this argument may be a string referring to a data file
-with the *coherent_scattering_length* property. (See :ref:`Reference Data <ref_data>` for details.)
+with the *coherent_scattering_length* property. (See :ref:`Isotope Data <isotopes>` for details.)
 By default, :py:meth:`QpointPhononModes.calculate_structure_factor <euphonic.qpoint_phonon_modes.QpointPhononModes.calculate_structure_factor>` will use the ``"Sears1992"`` data set included in Euphonic.
 If you have a custom data file, this can be used instead.
 

--- a/doc/source/readers.rst
+++ b/doc/source/readers.rst
@@ -20,9 +20,9 @@ Euphonic supports reading CASTEP calculation files (``.castep_bin``, ``.check``,
 File Structure & Records
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
-* **Binary Files (``.castep_bin``, ``.check``)**: Binary records containing unit cell vectors, ionic positions, species, force constants matrix, Born effective charges, and high-frequency dielectric tensors.
-* **Phonon Dispersion Files (``.phonon``)**: Text blocks containing q-points, phonon frequencies, and eigenvectors.
-* **Density of States Files (``.phonon_dos``)**: Text tables containing total density of states and per-element partial DOS.
+* **Binary Files (.castep_bin, .check)**: Binary records containing structure, force constants, Born effective charges, and dielectric tensors.
+* **Phonon Dispersion Files (.phonon)**: Text blocks containing q-points, phonon frequencies, and eigenvectors.
+* **Density of States Files (.phonon_dos)**: Text tables containing total density of states and per-element partial DOS.
 
 Module API Reference
 ^^^^^^^^^^^^^^^^^^^^
@@ -41,15 +41,17 @@ Euphonic supports reading Phonopy calculation files in YAML and HDF5 formats.
 File Structure & Records
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
-* **Summary Files (``phonopy.yaml``)**: Unified metadata file containing crystal structure, supercell transformation matrix, Born effective charges, and calculation parameters.
-* **Force Constant Files (``FORCE_CONSTANTS`` / ``force_constants.hdf5``)**: Standalone supercell force constant matrices.
-* **Dielectric Files (``BORN``)**: Standalone Born effective charges and dielectric tensors.
-* **Phonon Dispersion / Mesh Files (``mesh.*``, ``qpoints.*``, ``bands.*``)**: Precalculated q-points, frequencies, and eigenvectors.
+* **Summary Files (phonopy.yaml)**: Unified metadata file containing crystal structure, supercell transformation matrix, Born effective charges, and calculation parameters.
+* **Force Constant Files (FORCE_CONSTANTS / force_constants.hdf5)**: Standalone supercell force constant matrices.
+* **Dielectric Files (BORN)**: Standalone Born effective charges and dielectric tensors.
+* **Phonon Dispersion / Mesh Files (mesh.*, qpoints.*, bands.*)**: Precalculated q-points, frequencies, and eigenvectors.
 
 Separate Files & Fallback Behavior
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-When using modern Phonopy versions with ``--include-all``, a single ``phonopy.yaml`` contains all necessary data. However, for older Phonopy versions or split calculations where force constants and Born charges are stored in separate files (e.g. ``FORCE_CONSTANTS``, ``force_constants.hdf5``, or ``BORN``), Euphonic will look inside ``phonopy.yaml`` first and fall back to external files if needed:
+Using Phonopy with the ``--include-all`` parameter, all necessary data can be written to a single ``phonopy.yaml`` .
+Otherwise, force constants and Born charges might be stored in separate files (e.g. ``FORCE_CONSTANTS``, ``force_constants.hdf5``, or ``BORN``).
+Euphonic will look inside ``phonopy.yaml`` first and fall back to external files if needed:
 
 * **Python API**: Specify explicit filenames using keyword arguments such as ``fc_name='force_constants.hdf5'`` or ``born_name='BORN'`` in :py:meth:`ForceConstants.from_phonopy <euphonic.force_constants.ForceConstants.from_phonopy>`.
 * **CLI Tools**: Euphonic's command-line tools automatically detect and load accompanying ``FORCE_CONSTANTS`` or ``force_constants.hdf5`` files if they reside in the same directory as ``phonopy.yaml``.

--- a/doc/source/readers.rst
+++ b/doc/source/readers.rst
@@ -12,6 +12,61 @@ File Readers
 
 .. contents:: :local:
 
+CASTEP Reader
+-------------
+
+Euphonic supports reading CASTEP calculation files (``.castep_bin``, ``.check``, ``.phonon``, ``.phonon_dos``).
+
+File Structure & Records
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+* **Binary Files (``.castep_bin``, ``.check``)**: Binary records containing unit cell vectors, ionic positions, species, force constants matrix, Born effective charges, and high-frequency dielectric tensors.
+* **Phonon Dispersion Files (``.phonon``)**: Text blocks containing q-points, phonon frequencies, and eigenvectors.
+* **Density of States Files (``.phonon_dos``)**: Text tables containing total density of states and per-element partial DOS.
+
+Module API Reference
+^^^^^^^^^^^^^^^^^^^^
+
+.. automodule:: euphonic.readers.castep
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+
+Phonopy Reader
+--------------
+
+Euphonic supports reading Phonopy calculation files in YAML and HDF5 formats.
+
+File Structure & Records
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+* **Summary Files (``phonopy.yaml``)**: Unified metadata file containing crystal structure, supercell transformation matrix, Born effective charges, and calculation parameters.
+* **Force Constant Files (``FORCE_CONSTANTS`` / ``force_constants.hdf5``)**: Standalone supercell force constant matrices.
+* **Dielectric Files (``BORN``)**: Standalone Born effective charges and dielectric tensors.
+* **Phonon Dispersion / Mesh Files (``mesh.*``, ``qpoints.*``, ``bands.*``)**: Precalculated q-points, frequencies, and eigenvectors.
+
+Separate Files & Fallback Behavior
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+When using modern Phonopy versions with ``--include-all``, a single ``phonopy.yaml`` contains all necessary data. However, for older Phonopy versions or split calculations where force constants and Born charges are stored in separate files (e.g. ``FORCE_CONSTANTS``, ``force_constants.hdf5``, or ``BORN``), Euphonic will look inside ``phonopy.yaml`` first and fall back to external files if needed:
+
+* **Python API**: Specify explicit filenames using keyword arguments such as ``fc_name='force_constants.hdf5'`` or ``born_name='BORN'`` in :py:meth:`ForceConstants.from_phonopy <euphonic.force_constants.ForceConstants.from_phonopy>`.
+* **CLI Tools**: Euphonic's command-line tools automatically detect and load accompanying ``FORCE_CONSTANTS`` or ``force_constants.hdf5`` files if they reside in the same directory as ``phonopy.yaml``.
+
+.. note::
+
+   Force constants from Phonopy use the atomic-coordinate phase convention (:math:`\mathbf{q}\cdot\mathbf{r}_\kappa`). Euphonic automatically converts these into cell-origin convention (:math:`\mathbf{q}\cdot\mathbf{R}_l`) during ingestion using :py:func:`euphonic.util.convert_fc_phases`. For more details, see :ref:`Phase Convention <fc_format>`.
+
+Module API Reference
+^^^^^^^^^^^^^^^^^^^^
+
+.. automodule:: euphonic.readers.phonopy
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+
 VASP HDF5 Reader
 ----------------
 

--- a/doc/source/utils.rst
+++ b/doc/source/utils.rst
@@ -8,14 +8,8 @@ Utilities
 Reference data
 --------------
 
-Reference data is stored as JSON files and accessed using :py:func:`euphonic.util.get_reference_data`.
-As well as inbuilt data sets (e.g. ``"Sears1992"``), user files may be specified.
-For examples of the data format, see the documentation of that function or
-`take a look <https://github.com/pace-neutrons/Euphonic/blob/master/euphonic/isotopes/data/sears-1992.json>`_
-in the Euphonic source repository. The key point is that each "collection" file should contain a dictionary
-with a ``"physical_properties"`` key corresponding to another dictionary of reference data.
-The units should be specified with the special key ``__units__``; this will automatically
-be used to wrap the data to ``pint.Quantity`` when accessed.
+For isotope data, bound coherent scattering lengths, and atomic masses, see the :ref:`Isotope Data <isotopes>` documentation.
+
 
 euphonic.util module
 --------------------


### PR DESCRIPTION
A few modules have been overlooked, as they have to be added by hand since the initial generation of auto-docs.

---

Assisted-by: pi:gemini-3.7-flash
Assisted-by: pi:gemini-3.5-flash-lite