### PR TITLE
Minor improvements to documentation

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -60,6 +60,8 @@
 
   - Recommend IsotopeData interface, not old *get_reference_data* function.
 
+  - Other minor improvements.
+
 - Maintenance
 
   - Unit-testing with ``tox``

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -73,7 +73,7 @@ def skip(app, what, name, obj, would_skip, options):
 def setup(app):
     app.connect("autodoc-skip-member", skip)
 
-rst_prolog = """
+rst_prolog = r"""
 .. |q| replace:: \|\ q\ \|
 """
 

--- a/doc/source/plotting.rst
+++ b/doc/source/plotting.rst
@@ -228,5 +228,6 @@ e.g.:
   fig.show()
 
 This approach is used in the Euphonic command-line tools; for more
-information see :ref:`styling`. The CLI defaults can be imitated by
-using the same style sheet ``euphonic.style.base_style``.
+information on customizing plot aesthetics and available style presets, see
+:ref:`styling`. The CLI defaults can be imitated by using the bundled
+style sheet ``euphonic.styles.base_style``.

--- a/doc/source/python-api.rst
+++ b/doc/source/python-api.rst
@@ -18,9 +18,9 @@ Python API
   Scattering Intensities <scattering-intensities>
   Debye-Waller <debye-waller>
   Spectra <spectra>
-  powder
-  plotting
-  sampling
-  utils
+  Powder Averaging <powder>
+  Plotting <plotting>
+  Sampling Tools <sampling>
+  Utilities <utils>
   Interpolation with Brille <brille-interpolator>
-  writers
+  Writing to External Formats <writers>


### PR DESCRIPTION
The last couple of PRs were more focused, this picks up some remaining minor snags

- Clear a build warning related to automatic substitution of "|q|" strings.
- Make section titles in menu explicit, current mixture of explicit and inferred is a bit unsettling.
- Improved wording of plot styling section.

---
Assisted-by: pi:gemini-3.7-flash
