### PR TITLE
Write coverage info from master to special branch

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -111,9 +111,11 @@ jobs:
   publish-coverage:
     needs: test
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request'
+    if: |
+      github.event_name == 'pull_request' ||
+      (github.ref == 'refs/heads/master' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch'))
     permissions:
-      contents: read
+      contents: write
       pull-requests: read
       checks: read
     steps:
@@ -126,11 +128,13 @@ jobs:
           name: 'Coverage Data (ubuntu-latest)'
 
       - name: Generate coverage comment file
+        id: coverage_comment
         uses: py-cov-action/python-coverage-comment-action@v3
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Upload comment artifact
+        if: steps.coverage_comment.outputs.COMMENT_FILE_WRITTEN == 'true'
         uses: actions/upload-artifact@v4
         with:
           name: python-coverage-comment-action


### PR DESCRIPTION
We can use a feature of the new coverage action (py-cov-action/python-coverage-comment-action@v3) to streamline things a bit. But to try it out we first need to get this action to run on `master` and actually create the relevant branch/badge.

(External fork PRs will still only create the text payload.)